### PR TITLE
Copy files from Bundle Resources/public directories

### DIFF
--- a/src/sculpin/Sculpin.php
+++ b/src/sculpin/Sculpin.php
@@ -238,6 +238,24 @@ class Sculpin extends ContainerAware
         foreach ($this->bundles as $bundle) {
             $bundle->boot();
         }
+
+        // Process each Bundle's Resources/public directory.
+        $sourceset = $this->container->get('sculpin.sourceset');
+        foreach ($this->bundles as $bundle) {
+            if (is_dir($bundle->getPath().'/Resources/public')) {
+                // Copy all the files from Resources/public directory.
+                $files = $this
+                    ->finder()
+                    ->files()
+                    ->ignoreVCS(true)
+                    ->in($bundle->getPath().'/Resources/public');
+                foreach ($files as $file) {
+                    $source = new FileSource($file, true, true);
+                    $sourceset->mergeSource($source);
+                }
+            }
+        }
+
         $eventdispatcher->dispatch(self::EVENT_AFTER_START, new Event($this));
     }
 
@@ -272,14 +290,6 @@ class Sculpin extends ContainerAware
                 ->ignoreVCS(true)
                 ->date('>= '.$sinceTimeLast)
                 ->in($this->configuration->getPath('source_dir'));
-
-            // Add all public files from all Bundle public directories.
-            foreach ($this->bundles as $bundle) {
-                $dir = $bundle->getPath().'/Resources/public';
-                if (is_dir($dir)) {
-                    $files->in($dir);
-                }
-            }
 
             // We regenerate the whole site if an excluded file changes.
             $excludedFilesHaveChanged = false;


### PR DESCRIPTION
To more closely mimic the ways Symfony Bundles work, we should copy files from Bundle Resources/public directories into the compiled web folder. An example of a bundle having a public folder is at https://github.com/robloach/jquery . Adding the following to your sculpin.yml.dist will add the Bundle to your site:

``` yaml
bundles:
    - Assetize\jQuery\jQueryBundle
```

This will result in the following during the compilation process:

``` bash
 + FileSource:jquery.js
 + FileSource:jquery.min.js
```

Both jquery.js and jquery.min are now available in the compiled public web folder.
