### PR TITLE
Bring in PHPUnit via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "twig/twig": "1.6.*"
     },
     "require-dev": {
-        "mikey179/vfsStream": "1.*"
+        "mikey179/vfsStream": "1.*",
+        "Eher/PHPUnit": "*"
     },
     "autoload": {
         "psr-0": { "sculpin": "src" }

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "69c39ed1f4bb0169c1fee90298a1b2af",
+    "hash": "eebe245ea68c736eece747cc86f385f5",
     "packages": [
         {
             "package": "composer/composer",
@@ -99,6 +99,10 @@
         }
     ],
     "packages-dev": [
+        {
+            "package": "EHER/PHPUnit",
+            "version": "1.6"
+        },
         {
             "package": "mikey179/vfsStream",
             "version": "v1.0.0"


### PR DESCRIPTION
PHPUnit has always been a pain for me to install. http://packagist.org/packages/EHER/PHPUnit is pretty nice. Allows use of `vendor/bin/phpunit` to run tests. Do we want to add it to "require-dev"?
