### PR TITLE
Add Sculpin to the vendor bins definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "autoload": {
         "psr-0": { "Sculpin": "src" }
     },
+    "bin": ["bin/sculpin"],
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"


### PR DESCRIPTION
Don't forget to have Sculpin in the vendor bin definitions so that consuming applications can use the sculpin binary.
