### PR TITLE
Introduce a composer.json for each Sculpin component

### DIFF
--- a/src/Sculpin/Bundle/ComposerBundle/composer.json
+++ b/src/Sculpin/Bundle/ComposerBundle/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "sculpin/composer-bundle",
+    "type": "library",
+    "description": "Sculpin Composer Bundle",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "composer/composer": "1.*@alpha",
+        "symfony/console": "2.1.*"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin/Bundle/ComposerBundle": "" }
+    },
+    "target-dir": "Sculpin/Bundle/ComposerBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}

--- a/src/Sculpin/Bundle/MarkdownBundle/composer.json
+++ b/src/Sculpin/Bundle/MarkdownBundle/composer.json
@@ -1,0 +1,35 @@
+{
+    "name": "sculpin/markdown-bundle",
+    "type": "library",
+    "description": "Sculpin Markdown Bundle",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "dflydev/markdown": "1.*",
+        "symfony/config": "2.1.*"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin\\Bundle\\MarkdownBundle": "" }
+    },
+    "target-dir": "Sculpin/Bundle/MarkdownBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/composer.json
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "sculpin/markdown-twig-bundle",
+    "type": "library",
+    "description": "Sculpin Markdown Twig Bundle",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "sculpin/markdown": "1.*",
+        "symfony/config": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/http-kernel": "2.1.*"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin\\Bundle\\MarkdownTwigCompatBundle": "" }
+    },
+    "target-dir": "Sculpin/Bundle/MarkdownTwigCompatBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}

--- a/src/Sculpin/Bundle/SculpinBundle/composer.json
+++ b/src/Sculpin/Bundle/SculpinBundle/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "sculpin/sculpin-bundle",
+    "type": "library",
+    "description": "Sculpin Bundle",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "dflydev/ant-path-matcher": "1.*",
+        "symfony/console": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/http-kernel": "2.1.*"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin\\Bundle\\SculpinBundle": "" }
+    },
+    "target-dir": "Sculpin/Bundle/SculpinBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}

--- a/src/Sculpin/Bundle/StandaloneBundle/composer.json
+++ b/src/Sculpin/Bundle/StandaloneBundle/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "sculpin/standalone-bundle",
+    "type": "library",
+    "description": "Sculpin Bundle",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "symfony/config": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/http-kernel": "2.1.*"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin\\Bundle\\StandaloneBundle": "" }
+    },
+    "target-dir": "Sculpin/Bundle/StandaloneBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}

--- a/src/Sculpin/Bundle/TwigBundle/composer.json
+++ b/src/Sculpin/Bundle/TwigBundle/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "sculpin/standalone-bundle",
+    "type": "library",
+    "description": "Sculpin Bundle",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "symfony/config": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/http-kernel": "2.1.*",
+        "twig/twig": "1.6.*",
+        "sculpin/core": "self.version"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin\\Bundle\\TwigBundle": "" }
+    },
+    "target-dir": "Sculpin/Bundle/TwigBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}

--- a/src/Sculpin/Core/composer.json
+++ b/src/Sculpin/Core/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "sculpin/core",
+    "type": "application",
+    "description": "Static Site Generator",
+    "homepage": "http://getsculpin.com",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Dragonfly Development Inc.",
+            "email": "info@dflydev.com",
+            "homepage": "http://dflydev.com"
+        },
+        {
+            "name": "Beau Simensen",
+            "email": "beau@dflydev.com",
+            "homepage": "http://beausimensen.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "dflydev/ant-path-matcher": "1.*",
+        "dflydev/dot-access-configuration": "1.*",
+        "symfony/console": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/event-dispatcher": "2.1.*",
+        "symfony/finder": "2.1.*"
+    },
+    "autoload": {
+        "psr-0": { "Sculpin\\Core": "" }
+    },
+    "target-dir": "Sculpin/Core",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    },
+    "minimum-stability": "alpha"
+}


### PR DESCRIPTION
I'm probably missing some dependencies, but this will allow us to split the components into separate repositories. This mimics the effect that Symfony has with all the components split out.
