### PR TITLE
Fixing incompatible comparison

### DIFF
--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -179,7 +179,7 @@ class FilesystemDataSource implements DataSourceInterface
                 }
                 if ($this->matcher->match(
                         $pattern,
-                        $this->directorySeparatorNormalizer->normalize($file->getRelativePathname())
+                        $this->directorySeparatorNormalizer->normalize($file->getPathname())
                     )
                 ) {
                     $excludedFilesHaveChanged = true;


### PR DESCRIPTION
After observing an unwanted "_views" folder in my output_prod, I did some digging and found that the exclude patterns are being added with a Full pathname, but only compared against a Relative pathname - as a result, the comparisons are incompatible and do not work properly.

This commit is mostly to highlight the problem area, it does not represent a comprehensive solution.

It would make more sense to find out why the relative exclude path is not being used. This behaviour likely came into play with a commit from 24 days ago (c6072dbd8282a46938e16d6162e109c43bf18797)
