### PR TITLE
Changes to configuration files will regenerate site

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Data Source pass
+ *
+ * @author Beau Simensen <beau@dflydev.com>
+ */
+class DataSourcePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasDefinition('sculpin.data_source')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('sculpin.data_source');
+
+        foreach ($container->findTaggedServiceIds('sculpin.data_source') as $id => $tagAttributes) {
+            $definition->addMethodCall('addDataSource', array(new Reference($id)));
+        }
+    }
+}

--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -15,6 +15,7 @@
         <parameter key="sculpin.class">Sculpin\Core\Sculpin</parameter>
         <parameter key="sculpin.data_source.class">Sculpin\Core\Source\CompositeDataSource</parameter>
         <parameter key="sculpin.default_filesystem_data_source.class">Sculpin\Core\Source\FilesystemDataSource</parameter>
+        <parameter key="sculpin.default_config_filesystem_data_source.class">Sculpin\Core\Source\ConfigFilesystemDataSource</parameter>
         <parameter key="sculpin.source_permalink_factory.class">Sculpin\Core\Permalink\SourcePermalinkFactory</parameter>
         <parameter key="sculpin.finder_factory.class">Dflydev\Symfony\FinderFactory\FinderFactory</parameter>
         <parameter key="sculpin.configuration.path_configurator.class">Sculpin\Bundle\SculpinBundle\Sculpin\Configuration\PathConfigurator</parameter>
@@ -100,13 +101,19 @@
             <argument type="service" id="sculpin.finder_factory" />
             <argument type="service" id="sculpin.matcher" />
             <argument type="service" id="sculpin.canal.analyzer" />
+            <tag name="sculpin.data_source" />
         </service>
 
-        <service id="sculpin.data_source" class="%sculpin.data_source.class%">
-            <argument type="collection">
-                <argument type="service" id="sculpin.default_filesystem_data_source" />
-            </argument>
+        <service id="sculpin.default_config_filesystem_data_source" class="%sculpin.default_config_filesystem_data_source.class%">
+            <argument>%kernel.root_dir%/config</argument>
+            <argument type="service" id="sculpin.site_configuration" />
+            <argument type="service" id="sculpin.site_configuration_factory" />
+            <argument type="service" id="sculpin.finder_factory" />
+            <argument type="service" id="sculpin.matcher" />
+            <tag name="sculpin.data_source" />
         </service>
+
+        <service id="sculpin.data_source" class="%sculpin.data_source.class%" />
 
         <service id="sculpin.custom_mime_types_repository" class="Dflydev\ApacheMimeTypes\ArrayRepository" />
 

--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Bundle\SculpinBundle;
 
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\ConverterManagerPass;
+use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\DataSourcePass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\DataProviderManagerPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\FormatterManagerPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\GeneratorManagerPass;
@@ -40,5 +41,6 @@ class SculpinBundle extends Bundle
         $container->addCompilerPass(new GeneratorManagerPass);
         $container->addCompilerPass(new PathConfiguratorPass);
         $container->addCompilerPass(new CustomMimeTypesRepositoryPass);
+        $container->addCompilerPass(new DataSourcePass);
     }
 }

--- a/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Core\Source;
+
+use Dflydev\DotAccessConfiguration\ConfigurationInterface;
+use Dflydev\Symfony\FinderFactory\FinderFactory;
+use Dflydev\Symfony\FinderFactory\FinderFactoryInterface;
+use dflydev\util\antPathMatcher\AntPathMatcher;
+use Sculpin\Core\SiteConfiguration\SiteConfigurationFactory;
+
+/**
+ * Config Filesystem Data Source.
+ *
+ * @author Beau Simensen <beau@dflydev.com>
+ */
+class ConfigFilesystemDataSource implements DataSourceInterface
+{
+    /**
+     * Source directory
+     *
+     * @var string
+     */
+    protected $sourceDir;
+
+    /**
+     * Site configuration
+     *
+     * @var ConfigurationInterface
+     */
+    protected $siteConfiguration;
+
+    /**
+     * Site configuration factory
+     *
+     * @var string
+     */
+    protected $siteConfigurationFactory;
+
+    /**
+     * Finder Factory
+     *
+     * @var FinderFactoryInterface
+     */
+    protected $finderFactory;
+
+    /**
+     * Path Matcher
+     *
+     * @var AntPathMatcher
+     */
+    protected $matcher;
+
+    /**
+     * Since time
+     *
+     * @var string
+     */
+    protected $sinceTime;
+
+    /**
+     * Constructor.
+     *
+     * @param string                       $sourceDir                    Source directory
+     * @param ConfigurationInterface       $siteConfiguration            Site Configuration
+     * @param SiteConfigurationFactory     $siteConfigurationFactory     Site Configuration Factory
+     * @param FinderFactoryInterface       $finderFactory                Finder Factory
+     * @param AntPathMatcher               $matcher                      Matcher
+     */
+    public function __construct(
+        $sourceDir,
+        ConfigurationInterface $siteConfiguration,
+        SiteConfigurationFactory $siteConfigurationFactory,
+        FinderFactoryInterface $finderFactory = null,
+        AntPathMatcher $matcher = null
+    ) {
+        $this->sourceDir = $sourceDir;
+        $this->siteConfiguration = $siteConfiguration;
+        $this->siteConfigurationFactory = $siteConfigurationFactory;
+        $this->finderFactory = $finderFactory ?: new FinderFactory;
+        $this->matcher = $matcher ?: new AntPathMatcher;
+        $this->sinceTime = '1970-01-01T00:00:00Z';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dataSourceId()
+    {
+        // This is not really needed since we are not going to
+        // ever create actual sources.
+        return 'ConfigFilesystemDataSource:'.$this->sourceDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refresh(SourceSet $sourceSet)
+    {
+        $sinceTimeLast = $this->sinceTime;
+
+        $this->sinceTime = date('c');
+
+        // We regenerate the whole site if any config file changes.
+        $configFilesHaveChanged = false;
+
+        $files = $this
+            ->finderFactory->createFinder()
+            ->files()
+            ->name('sculpin_site*.yml')
+            ->date('>='.$sinceTimeLast)
+            ->in($this->sourceDir);
+
+        $sinceTimeLastSeconds = strtotime($sinceTimeLast);
+
+        foreach ($files as $file) {
+            if ($sinceTimeLastSeconds > $file->getMTime()) {
+                // This is a hack because Finder is actually incapable
+                // of resolution down to seconds.
+                //
+                // Sometimes this may result in the file looking like it
+                // has been modified twice in a row when it has not.
+                continue;
+            }
+
+            $configFilesHaveChanged = true;
+
+            break;
+        }
+
+        if ($configFilesHaveChanged) {
+            $newConfig = $this->siteConfigurationFactory->create();
+            $this->siteConfiguration->import($newConfig);
+
+            // If any of the config files have changed we should
+            // mark all of the sources as having changed.
+            foreach ($sourceSet->allSources() as $source) {
+                $source->setHasChanged();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to fix a long standing issue where changes to config data
(specifically config/sculpin_site*.yml configuration) does not get reflected
until sculpin regenerates itself.

This solution is somewhat simple in that it makes a few assumptions about how
dot-access-configuration works, particularly with placeholder resolver's cache.
It is possible that this may result in unexpected behaviour.

This was tested out by changing `assets_version` key in sculpin_site.yml and it
would cause the entire site to be regenerated and all pages had the new
`assets_version` value as expected.

This was also tested by creating a new file in the config directory and adding a
new file was picked up.

Removing a file is not currently handled so that behaviour is currently unknown.

This might not work well with imports. :( This definitely needs some work but it
should help a bit for now.

closes #87

---

@AdrianSchneider would love some feedback before I merge. :)
