### PR TITLE
Append Twig paths for Bundles at the end of the loader.

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -47,6 +47,16 @@ class TwigLoaderPass implements CompilerPassInterface
             $appendedLoaders[] = new Reference($id);
         }
 
+        $sourceViewPaths = $container->getParameter('sculpin_twig.source_view_paths');
+        foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
+            $reflection = new \ReflectionClass($class);
+            foreach ($sourceViewPaths as $sourceViewPath) {
+                if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/'.$sourceViewPath)) {
+                    $appendedLoaders[] = $dir;
+                }
+            }
+        }
+
         $arguments[0] = array_merge($prependedLoaders, $loaders, $appendedLoaders);
         $definition->setArguments($arguments);
     }


### PR DESCRIPTION
This will allow bundles to ship views. They will be at the end of the loader so themes and sites will be able to override them. This means bundles get to ship the _default_ template that can be overridden by anyone.
