### PR TITLE
Relax YAML front matter boundaries by allowing trailing whitespace

### DIFF
--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -81,7 +81,7 @@ class FileSource extends AbstractSource
 
                 $content = file_get_contents($this->file);
 
-                if (preg_match('/^\s*(?:---[\r\n]+)(.*?)(?:---[\r\n]+)(.*?)$/s', $content, $matches)) {
+                if (preg_match('/^\s*(?:---[\s]*[\r\n]+)(.*?)(?:---[\s]*[\r\n]+)(.*?)$/s', $content, $matches)) {
                     $this->content = $matches[2];
                     if (preg_match('/^(\s*[-]+\s*|\s*)$/', $matches[1])) {
                         // There is nothing useful in the YAML front matter.


### PR DESCRIPTION
I'm sure most people are more careful with their content, but this might help adoption for those who are like me and coming from jekyll. Took me a good hour and a half to work out what was going wrong.
