### PR TITLE
Replaced preg_replace with preg_replace_callback

### DIFF
--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -44,10 +44,11 @@ class RegisterKernelListenersPass implements CompilerPassInterface
                 }
 
                 if (!isset($event['method'])) {
-                    $event['method'] = 'on'.preg_replace(array(
-                        '/(?<=\b)[a-z]/ie',
-                        '/[^a-z0-9]/i'
-                    ), array('strtoupper("\\0")', ''), $event['event']);
+                    $event['method'] = 'on'.preg_replace_callback(array(
+                        '/(?<=\b)[a-z]/i',
+                        '/[^a-z0-9]/i',
+                    ), function ($matches) { return strtoupper($matches[0]); }, $event['event']);
+                    $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);
                 }
 
                 $definition->addMethodCall('addListenerService', array($event['event'], array($id, $event['method']), $priority));


### PR DESCRIPTION
In PHP5.5 using the /e modifier causes an DEPRECATED warning to be emitted.
This PR solves it, although I'm not to happy that we need to add the extra preg_replace.
To be fair: I just copied this from the Symfony HttpKernel.
