### PR TITLE
Update HttpServer to detect mimetype of blog posts

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -68,6 +68,10 @@ class HttpServer
                 if ($guessedType = $repository->findType($extension)) {
                     $type = $guessedType;
                 }
+            } else {
+                $finfo = finfo_open(FILEINFO_MIME_TYPE);
+                $type  = finfo_file($finfo, $path);
+                finfo_close($finfo);
             }
 
             HttpServer::logRequest($output, 200, $request);


### PR DESCRIPTION
While updating one of my projects to the latest Sculpin, I noticed that the built-in server was dishing out blog posts with a mimetype of "application/octet-stream". This made it difficult to preview my progress.

After tracing through the code I was able to narrow it down to the fact that my blog posts don't have an extension - nor to they exist as a folder with an index.html endpoint. They are just named files without extensions.

I used the Fileinfo extension (which appears to be included in >=5.3.0) to try and guess the mimetype of files without extensions. I didn't do much in the way of error checking, so hopefully this doesn't cause weird issues. :)
