### PR TITLE
exclude twig verbatim blocks from twig formater tests

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -112,7 +112,10 @@ class TwigFormatter implements FormatterInterface
     {
         $template = $formatContext->template();
         if ($layout = $formatContext->data()->get('layout')) {
-            if (!preg_match_all('/{%\s+block\s+(\w+)\s+%}(.*?){%\s+endblock\s+%}/si', $template, $matches)) {
+            // exclude verbatim blocks before block test
+            $templateWithoutVerbatimsBlocks = preg_replace('/{%\s+verbatim\s+%}(.*?){%\s+endverbatim\s+%}/si', '', $template);
+
+            if (!preg_match_all('/{%\s+block\s+(\w+)\s+%}(.*?){%\s+endblock\s+%}/si', $templateWithoutVerbatimsBlocks, $matches)) {
                 $template = '{% block content %}'.$template.'{% endblock %}';
             }
             $template = '{% extends "' . $layout . '" %}' . $template;


### PR DESCRIPTION
this patch exclude twig verbatims block from block test, it's allow you now to add code blocks in your markdown posts with `{% block blockname %}{% endblock %}` inside without errors.

For example if you need to add this code block in a markdown post, it's now possible.

```
{% verbatim %}
<!DOCTYPE html>
<html lang="fr">
<head>
    <meta charset="UTF-8">
    <title>{{ site.title }}</title>
    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
</head>
<body class="container">
    <header>
        <h1>{{ site.title }}</h1>
        <h2>{{ site.subtitle }}</h2>
    </header>
    <div id="content">
        {% block content %}{% endblock %}
    </div>
</body>
</html>
{% endverbatim %}
```
