### PR TITLE
Added basename and pretty_basename options for permalinks

### DIFF
--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -116,6 +116,10 @@ class SourcePermalinkFactory
                 }
                 $permalink = preg_replace('/:filename/', $filename, $permalink);
                 $permalink = preg_replace('/:slug_filename/', $this->normalize($slug ?: $filename), $permalink);
+                $basename = substr($filename, strrpos($filename, '/')+1);
+                $prettyBasename = substr($basename, 0, strrpos($basename, '.'));
+                $permalink = preg_replace('/:basename/', $basename, $permalink);
+                $permalink = preg_replace('/:pretty_basename/', $prettyBasename, $permalink);
                 if (substr($permalink, -1, 1) == '/') {
                     $permalink .= 'index.html';
                 }


### PR DESCRIPTION
This PR adds two new options to use in permalinks; `:basename` and `:pretty_basename`.

Currently, when using custom content types the `:filename` permalink option would result in a ugly link like `_mytype/filename.html`. The `:basename` option strips the directory from the filename and the `:pretty_basename` option also removes the file extension.

Example:
Source: `source/_projects/pop.html`
File name: `_projects/pop.html`
Base name: `pop.html`
Pretty base name: `pop`

If this PR gets merged I would also update/add this to the documentation.
