### PR TITLE
Fixes bug with :basename tag in permalinks

### DIFF
--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -122,8 +122,8 @@ class SourcePermalinkFactory
                     $basename = $filename;
                 }
                 $prettyBasename = substr($basename, 0, strrpos($basename, '.'));
-                $permalink = preg_replace('/:basename/', $basename, $permalink);
-                $permalink = preg_replace('/:pretty_basename/', $prettyBasename, $permalink);
+                $permalink = preg_replace('/:basename_real/', $basename, $permalink);
+                $permalink = preg_replace('/:basename/', $prettyBasename, $permalink);
                 if (substr($permalink, -1, 1) == '/') {
                     $permalink .= 'index.html';
                 }


### PR DESCRIPTION
When :basename was used for files in the root source directory, one character was removed from the beginning because there is no slash. Sorry for that.
