### PR TITLE
Force 'use' YAML value to be an array

### DIFF
--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -94,6 +94,11 @@ class FormatterManager
         ));
 
         foreach ($this->dataProviderManager->dataProviders() as $name) {
+
+            if (!is_array($context['use'])) {
+                $context['use'] = array($context['use']);
+            }
+
             if (isset($context['use']) and in_array($name, $context['use'])) {
                 $baseContext->set('data.'.$name, $this->dataProviderManager->dataProvider($name)->provideData());
             }


### PR DESCRIPTION
Manipulated the parsed YAML front matter to force the 'use' value to always be an array even if it's passed as a single string. 

I feel like this really needs a test but I couldn't find a good place for it because Tests/FormatContextTest.php doesn't pass the data through the FormatManager. Feel free to suggest a better place to write a test if you want to include that before accepting the PR.
