### PR TITLE
Make Sculpin::EVENT_AFTER_FORMAT more usefull

### DIFF
--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -170,7 +170,6 @@ class FormatterManager
 
         $this->eventDispatcher->dispatch(Sculpin::EVENT_BEFORE_FORMAT, new FormatEvent($formatContext));
         $response = $this->formatter($formatContext->formatter())->formatPage($formatContext);
-        $this->eventDispatcher->dispatch(Sculpin::EVENT_AFTER_FORMAT, new FormatEvent($formatContext));
 
         return $response;
     }
@@ -210,7 +209,6 @@ class FormatterManager
 
         $this->eventDispatcher->dispatch(Sculpin::EVENT_BEFORE_FORMAT, new FormatEvent($formatContext));
         $response = $this->formatter($formatContext->formatter())->formatBlocks($formatContext);
-        $this->eventDispatcher->dispatch(Sculpin::EVENT_AFTER_FORMAT, new FormatEvent($formatContext));
 
         return $response;
     }

--- a/src/Sculpin/Core/Sculpin.php
+++ b/src/Sculpin/Core/Sculpin.php
@@ -218,6 +218,7 @@ class Sculpin
                 }
                 $io->overwrite(sprintf("%3d%%", 100*((++$counter)/$total)), false);
             }
+            $this->eventDispatcher->dispatch(self::EVENT_AFTER_FORMAT, new SourceSetEvent($sourceSet));
             $io->write(sprintf(" (%d sources / %4.2f seconds)", $total, microtime(true) - $timer));
         }
 


### PR DESCRIPTION
Right now Sculpin::EVENT_AFTER_FORMAT isn't really useful as it just repeats Sculpin::EVENT_BEFORE_FORMAT. This PR makes it more useful by emitting a SourceSetEvent that makes the resulting source available for processing by event listeners.
