### PR TITLE
Enforce a UTC timezone if none is set.

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -47,6 +47,10 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
         $this->kernel = $kernel;
         $this->embeddedComposer = $embeddedComposer;
 
+        if (function_exists('date_default_timezone_set') && function_exists('date_default_timezone_get')) {
+            date_default_timezone_set(@date_default_timezone_get());
+        }
+
         $version = $embeddedComposer->findPackage('sculpin/sculpin')->getPrettyVersion();
         if ($version !== Sculpin::GIT_VERSION && Sculpin::GIT_VERSION !== '@'.'git_version'.'@') {
             $version .= ' ('.Sculpin::GIT_VERSION.')';


### PR DESCRIPTION
This prevents Sculpin from blowing up in a misconfigured PHP environment. See issue #84 for more details.
