### PR TITLE
check directory is writeable after checking it exists

### DIFF
--- a/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
@@ -54,11 +54,11 @@ EOF
         $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         $filesystem   = $this->getContainer()->get('filesystem');
 
-        if (!is_writable($cacheDir)) {
-            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $cacheDir));
-        }
-
         if ($filesystem->exists($cacheDir)) {
+            if (!is_writable($cacheDir)) {
+                throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $cacheDir));
+            }
+
             $filesystem->remove($cacheDir);
         }
     }


### PR DESCRIPTION
```
sculpin cache:clear

  [RuntimeException]                                                                        
  Unable to write in the "/path/to/project/app/cache/dev" directory  

cache:clear
```

If you create the directory `app/cache/dev` then it'll run without error, and remove the directory and cause the error on the next run.
