### PR TITLE
Added permalink strategies for taxonomies

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
@@ -59,9 +59,20 @@ class Configuration implements ConfigurationInterface
                         // Default case is we want the user to specify just one
                         // taxonomy but we can allow for multiple if they want to.
                         ->ifString()
-                        ->then(function ($v) { return array($v); })
+                        ->then(function ($v) { return array(array('name' => $v)); })
                     ->end()
-                    ->prototype('scalar')->end()
+                    ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(function ($v) { return array('name' => $v); })
+                        ->end()
+                        ->children()
+                            ->scalarNode('name')->end()
+                            ->arrayNode('strategies')
+                                ->prototype('scalar')->end()
+                            ->end()
+                        ->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ConvertToLowercaseStrategy.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ConvertToLowercaseStrategy.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Contrib\Taxonomy\PermalinkStrategy;
+
+class ConvertToLowercaseStrategy implements PermalinkStrategyInterface {
+    public function process($str) {
+        return strtolower($str);
+    }
+}

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/PermalinkStrategyInterface.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/PermalinkStrategyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Contrib\Taxonomy\PermalinkStrategy;
+
+interface PermalinkStrategyInterface
+{
+    public function process($str);
+}

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ToyRocketStrategy.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ToyRocketStrategy.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Contrib\Taxonomy\PermalinkStrategy;
+
+class ToyRocketStrategy implements PermalinkStrategyInterface {
+    public function process($str) {
+        return '∙∙∙∙∙·▫▫ᵒᴼᵒ▫ₒₒ▫ᵒᴼᵒ▫ₒₒ▫ᵒᴼᵒ☼)==' . $str . '==>';
+    }
+}

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/TranslateSpacesToDashesStrategy.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/TranslateSpacesToDashesStrategy.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Contrib\Taxonomy\PermalinkStrategy;
+
+class TranslateSpacesToDashesStrategy implements PermalinkStrategyInterface {
+    public function process($str) {
+        return str_replace(' ', '-', $str);
+    }
+}

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Contrib\Taxonomy;
+
+use Sculpin\Contrib\Taxonomy\PermalinkStrategy\PermalinkStrategyInterface;
+
+class PermalinkStrategyCollection
+{
+
+    protected $strategies;
+
+    public function __construct()
+    {
+        $this->strategies = new \SplObjectStorage();
+    }
+
+    public function push(PermalinkStrategyInterface $strategy)
+    {
+        $this->strategies->attach($strategy);
+    }
+
+    public function process($str)
+    {
+        foreach ($this->strategies as $strategy) {
+            $str = $strategy->process($str);
+        }
+        return $str;
+    }
+
+}

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
@@ -21,21 +21,26 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
     private $dataProviderName;
     private $injectedTaxonKey;
     private $injectedTaxonItemsKey;
+    private $permalinkStrategyCollection;
 
     public function __construct(
         DataProviderManager $dataProviderManager,
         $dataProviderName,
         $injectedTaxonKey,
-        $injectedTaxonItemsKey
+        $injectedTaxonItemsKey,
+        PermalinkStrategyCollection $permalinkStrategyCollection
     ) {
         $this->dataProviderManager = $dataProviderManager;
         $this->dataProviderName = $dataProviderName; // post_tags
         $this->injectedTaxonKey = $injectedTaxonKey; // tag
         $this->injectedTaxonItemsKey = $injectedTaxonItemsKey; // tagged_posts
+        $this->permalinkStrategyCollection = $permalinkStrategyCollection;
     }
 
     public function generate(SourceInterface $source)
     {
+        $generatedSources = array();
+
         $dataProvider = $this->dataProviderManager->dataProvider($this->dataProviderName);
         $taxons = $dataProvider->provideData();
 
@@ -51,7 +56,8 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
             $permalink = dirname($permalink);
 
             if (preg_match('/^(.+?)\.(.+)$/', $basename, $matches)) {
-                $permalink = $permalink.'/'.$taxon.'/index.html';
+                $urlTaxon = $this->permalinkStrategyCollection->process($taxon);
+                $permalink = $permalink.'/'.$urlTaxon.'/index.html';
             } else {
                 // not sure what case this is?
             }


### PR DESCRIPTION
With permalink strategies the URL of taxonomies can be altered in a way suited to the wished of the site/blog author.

Example configuraton of `app/config/sculpin_kernel.yml`:

``` yml
sculpin_content_types:
    posts:
        taxonomies:
            - tags
            - name: categories
              strategies:
                - \Sculpin\Contrib\Taxonomy\PermalinkStrategy\ConvertToLowercaseStrategy
                - \Sculpin\Contrib\Taxonomy\PermalinkStrategy\TranslateSpacesToDashesStrategy
```

Looking for more strategy ideas to add before this is merged so we can give users a good selection.
