### PR TITLE
Enable access to a map between normalized and non-normalized taxon.

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
@@ -239,6 +239,10 @@ class SculpinContentTypesExtension extends Extension
                         }
                     }
                 }
+
+                // TODO: This should be configurable.
+                $taxonomyNormalizedName = $taxonomyName.'_normalized';
+
                 $taxon = Inflector::singularize($taxonomyName);
 
                 $taxonomyDataProviderName = $type.'_'.$taxonomyName;
@@ -251,6 +255,8 @@ class SculpinContentTypesExtension extends Extension
                 $taxonomyDataProvider->addArgument(new Reference('sculpin.data_provider_manager'));
                 $taxonomyDataProvider->addArgument($type);
                 $taxonomyDataProvider->addArgument($taxonomyName);
+                $taxonomyDataProvider->addArgument($taxonomyNormalizedName);
+                $taxonomyDataProvider->addArgument($permalinkStrategies);
                 $taxonomyDataProvider->addTag('kernel.event_subscriber');
                 $taxonomyDataProvider->addTag('sculpin.data_provider', array('alias' => $taxonomyDataProviderName));
                 $container->setDefinition($taxonomyDataProviderId, $taxonomyDataProvider);

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
@@ -23,15 +23,21 @@ class ProxySourceTaxonomyDataProvider implements DataProviderInterface, EventSub
     private $dataProviderManager;
     private $dataProviderName;
     private $taxonomyKey;
+    private $taxonomyNormalizedKey;
+    private $permalinkStrategyCollection;
 
     public function __construct(
         DataProviderManager $dataProviderManager,
         $dataProviderName,
-        $taxonomyKey
+        $taxonomyKey,
+        $taxonomyNormalizedKey,
+        $permalinkStrategyCollection
     ) {
         $this->dataProviderManager = $dataProviderManager;
         $this->dataProviderName = $dataProviderName;
         $this->taxonomyKey = $taxonomyKey;
+        $this->taxonomyNormalizedKey = $taxonomyNormalizedKey;
+        $this->permalinkStrategyCollection = $permalinkStrategyCollection;
     }
 
     public function provideData()
@@ -54,12 +60,15 @@ class ProxySourceTaxonomyDataProvider implements DataProviderInterface, EventSub
         foreach ($dataProvider->provideData() as $item) {
             if ($itemTaxons = $item->data()->get($this->taxonomyKey)) {
                 $normalizedItemTaxons = array();
+                $normalizedItemTaxonNormalized[] = array();
                 foreach ((array) $itemTaxons as $itemTaxon) {
                     $normalizedItemTaxon = trim($itemTaxon);
                     $taxons[$normalizedItemTaxon][] = $item;
                     $normalizedItemTaxons[] = $normalizedItemTaxon;
+                    $normalizedItemTaxonNormalized[$normalizedItemTaxon] = $this->permalinkStrategyCollection->process($normalizedItemTaxon);;
                 }
                 $item->data()->set($this->taxonomyKey, $normalizedItemTaxons);
+                $item->data()->set($this->taxonomyNormalizedKey, $normalizedItemTaxonNormalized);
             }
         }
 


### PR DESCRIPTION
I found it useful to be able to access this for creating links to sources that are tagged (or any other taxonomy) when you have setup permalink strategies. I used the permalink strategies for the first time on [ddd.io](http://ddd.io) and found it was impossible to generate links back to the tags from the post pages themselves.

Related, I think it would make sense to change this someday to actually return a map of tag to permalink instead. We should not have two locations for creating permalinks... both in the template and in the code. We should present it from the code side of things so the template can just reference it.

Would love feedback from @WyriHaximus before merging.