### PR TITLE
Import original data for a source when init is called again

### DIFF
--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -57,6 +57,8 @@ class FileSource extends AbstractSource
     {
         parent::init($hasChanged);
 
+        $originalData = $this->data;
+
         if ($this->isRaw) {
             $this->useFileReference = true;
             $this->data = new Data;
@@ -112,6 +114,10 @@ class FileSource extends AbstractSource
             }
 
             $this->data->set('calculated_date', $this->data->get('date'));
+        }
+
+        if ($originalData) {
+            $this->data->import($originalData, false);
         }
     }
 }


### PR DESCRIPTION
There exists cases where calling init on an existing source would lose data set from previous calls. The problem is that any time a file is asked to be reprocessed (happens when updated as a part of a collection and other hard to track down cases) the metadata would be read in again from the file. The side effect of this is that ONLY the metadata coming in from the frontmatter would remain. Any metadata set by other extensions or other parts of Sculpin core (things like date tracking and auto layout for proxy source collections) would be lost on init.

This patch works by saving a copy of the data before the new metadata is processed. Afterwards, if data was there originally, it imports it on top of the new metdata w/ clobber set to `false`. This will ensure that data that is already set will not be overwritten by the old data.

---

# Potential Negative Side Effects

This could be a performance issue as we'll be doing import a lot more often than we were before. I don't think I've ever tested that code for performance so this could hurt people with larger sites. Hard to know what impact it might have but it is a thing to consider.



/cc @coderabbi @WyriHaximus @beryllium