### PR TITLE
Inject a {taxon}_{type}_index_permalinks for every type of taxonomy index created

### DIFF
--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
@@ -68,6 +68,10 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
                 $permalink = substr($permalink, 2);
             }
 
+            if (0 !== strpos($permalink, '/')) {
+                $permalink = '/'.$permalink;
+            }
+
             if ($permalink) {
                 // not sure if this is ever going to happen?
                 $generatedSource->data()->set('permalink', $permalink);


### PR DESCRIPTION
This replaces #192. I think this is a simpler approach and results in less code needing to be written.

Usage would be either:
```twig
            {% if page.tags %}
                <p class="tags">Tagged with
                    {% for tag in page.tags %}
                        <a class="tag" href="{{ site.url }}/{{ page.tag_html_index_permalinks[tag] }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
                    {% endfor %}
                </p>
            {% endif %}
```

... or

```twig
            {% if page.tags %}
                <p class="tags">Tagged with
                    {% for tag,permalink in page.tag_html_index_permalinks %}
                        <a class="tag" href="{{ site.url }}/{{ permalink }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
                    {% endfor %}
                </p>
            {% endif %}
```

Either would work.

The nice things over #192 are that 1) it only creates these for taxonomies for which an index page even exists and 2) it accounts for the fact that you might have several index pages (like an Atom/RSS feed vs an HTML one). It also does not mess with anything that would require changes to the config / extension meta programming stuff and we do not have to find a way to extract the URL building stuff.

ping @WyriHaximus 