### PR TITLE
This was going to lead to collisions!

### DIFF
--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
@@ -82,7 +82,7 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
 
             if ($indexType) {
                 foreach ($items as $item) {
-                    $key = $this->injectedTaxonKey.'_'.$indexType.'_index_permalinks';
+                    $key = $this->dataProviderName.'_'.$indexType.'_index_permalinks';
                     $taxonIndexPermalinks = $item->data()->get($key) ?: [];
 
                     $taxonIndexPermalinks[$taxon] = $permalink;


### PR DESCRIPTION
In writing the docs for this feature it became clear that this would be a problem if you had multiple content types with the same taxonomies available. posts -> tag_html_permalinks_index and projects -> tag_html_permalinks_index. Instead, we're going to do posts-> post_tags_html_permalinks_index &, projects -> project_tags_html_permlainks_index.