### PR TITLE
Add mkdn extension to markdown extension list

### DIFF
--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('parser_class')->defaultValue('Sculpin\Bundle\MarkdownBundle\PhpMarkdownExtraParser')->end()
                 ->arrayNode('extensions')
-                    ->defaultValue(array('md', 'mdown', 'markdown'))
+                    ->defaultValue(array('md', 'mdown', 'mkdn', 'markdown'))
                     ->prototype('scalar')->end()
                 ->end()
             ->end();


### PR DESCRIPTION
mkdn is an acceptable extension as per
https://github.com/github/markup/tree/master#markups