### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# This file is used by editors and IDEs to unify coding standards
+# @see http://EditorConfig.org
+# @standards  PHP: http://www.php-fig.org/psr/psr-2/
+root = true
+
+# Default configuration (applies to all file types)
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 4
+indent_style = space
+
+# Markdown customizations
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Add [EditorConfig](http://EditorConfig.org) file for editors & IDEs to easily support Sculpin coding standards, which are based on [PHP Coding Style Guide (PSR-2)](http://www.php-fig.org/psr/psr-2/) which also extends [PHP Basic Coding Standard [PSR-1]](http://www.php-fig.org/psr/psr-1).

In particular, setup EditorConfig to automate the following coding standards
  - [2.2 Character Encoding [PSR-1]](http://www.php-fig.org/psr/psr-1): PHP code MUST use only UTF-8 without BOM.
  - [2.2 Files [PSR-2]](http://www.php-fig.org/psr/psr-2): All PHP files MUST use the Unix LF (linefeed) line ending.
  - [2.2 Files [PSR-2]](http://www.php-fig.org/psr/psr-2): All PHP files MUST end with a single blank line.
  - [2.3 Lines [PSR-2]](http://www.php-fig.org/psr/psr-2): There MUST NOT be trailing whitespace at the end of non-blank lines.
  - [2.4 Indenting [PSR-2]](http://www.php-fig.org/psr/psr-2): Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.

Projects using EditorConfig  
https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig