### PR TITLE
Fix generating id="" headers for headers that have markup.

### DIFF
--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -109,7 +109,7 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
             (?<= \\]) # Look behind to find ]
             (
                 \\(     # match (
-                [^\\)]*  # match everything except )
+                [^\\)]* # match everything except )
                 \\)     # match )
             )
 

--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -48,11 +48,7 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
     public function __construct(ParserInterface $markdown, array $extensions = array())
     {
         $this->markdown = $markdown;
-        $this->markdown->header_id_func = function($headerName) {
-            return rawurlencode(strtolower(
-                strtr($headerName, [' ' => '-'])
-            ));
-        };
+        $this->markdown->header_id_func = [$this, 'generateHeaderId'];
         $this->extensions = $extensions;
     }
 
@@ -90,4 +86,48 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
             }
         }
     }
+
+
+    /**
+     * This method is called to generate an id="" attribute for a header.
+     *
+     * @param string $headerText raw markdown input for the header name
+     * return string
+     */
+    public function generateHeaderId($headerText) {
+
+        // $headerText is completely raw markdown input. We need to strip it
+        // from all markup, because we are only interested in the actual 'text'
+        // part of it.
+
+        // Step 1: Remove html tags.
+        $result = strip_tags($headerText);
+
+        // Step 2: Remove all markdown links. To do this, we simply remove
+        // everything between ( and ) if the ( occurs right after a ].
+        $result = preg_replace('%
+            (?<= \\]) # Look behind to find ]
+            (
+                \\(     # match (
+                [^\\)]*  # match everything except )
+                \\)     # match )
+            )
+
+            %x', '', $result);
+
+        // Step 3: Convert spaces to dashes, and remove unwanted special
+        // characters.
+        $map = [
+            ' ' => '-',
+            '(' => '',
+            ')' => '',
+            '[' => '',
+            ']' => '',
+        ];
+        return rawurlencode(strtolower(
+            strtr($result, $map)
+        ));
+
+    }
+
 }


### PR DESCRIPTION
Fixes Issue #222

This change goes a bit further than the last PR. It now does a better
job stripping markup from headers to generate more accurate values for
the id="" attribute.

This is a table of headers that I've tested, and their new output:

    ## Header1
    ## Header2 [ ]
    ## <a href="http://sculpin.io/">Header3</a>
    ## <small>header4</small>
    ## [Sculpin](http://sculpin.io/)

Output for the preceeding headers:

    <h2 id="header1">Header1</h2>
    <h2 id="header2--">Header2 [ ]</h2>
    <h2 id="header3"><a href="http://sculpin.io/">Header3</a></h2>
    <h2 id="header4"><small>header4</small></h2>
    <h2 id="sculpin"><a href="http://sculpin.io/">Sculpin</a></h2>