### PR TITLE
Fix ArrayAccess setter for "set"-Prefixed methods in ProxySourceItem

### DIFF
--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -116,7 +116,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
             }
 
             $setMethod = 'set'.ucfirst($offset);
-            if (method_exists($setMethod)) {
+            if (method_exists($this, $setMethod)) {
                 return call_user_func(array($this, $setMethod, $value));
             }
 


### PR DESCRIPTION
`$proxy->offsetSet('foo', 'bar')` or `$proxy['foo'] = 'bar'` should call `$proxy->setFoo('bar')` if method `setFoo()` exists in the `ProxySourceItem`.

I am not sure if the magic `set*` implementation in `offsetSet` is desired after all.

1. This issue exists since Jan 5 2014 introduced here: https://github.com/sculpin/sculpin/commit/b5009c51512623456d782bcebbdb3d2f23270406#diff-93bd9bcccd85a4cb1252ac59d0f9c947R114
2. `offsetGet` does not not check for `get*` methods

