### PR TITLE
Fix ProxySource::setFormattedContent()

### DIFF
--- a/src/Sculpin/Core/Source/ProxySource.php
+++ b/src/Sculpin/Core/Source/ProxySource.php
@@ -146,7 +146,7 @@ class ProxySource implements SourceInterface
      */
     public function setFormattedContent($formattedContent = null)
     {
-        return $this->source->formattedContent($formattedContent);
+        return $this->source->setFormattedContent($formattedContent);
     }
 
     /**

--- a/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Core\Tests\Source;
+
+use Sculpin\Core\Source\ProxySource;
+
+class ProxySourceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetFormattedContent()
+    {
+        $source = $this->getMock('Sculpin\Core\Source\SourceInterface');
+        $source
+            ->expects($this->once())
+            ->method('setFormattedContent')
+            ->with($this->equalTo('hello world'));
+
+        $SUT = new ProxySource($source);
+        $SUT->setFormattedContent('hello world');
+    }
+}


### PR DESCRIPTION
`ProxySource::setFormattedContent()` did not call the correct method on the decorated object.