### PR TITLE
Fix call to SourceInterface::duplicate() with too many arguments

### DIFF
--- a/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
+++ b/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
@@ -96,7 +96,6 @@ class PaginationGenerator implements GeneratorInterface
         $pageNumber = 0;
         foreach ($slices as $slice) {
             $pageNumber++;
-            $options = array();
             $permalink = null;
             if ($pageNumber > 1) {
                 $permalink = $source->data()->get('permalink') ?: $source->relativePathname();
@@ -120,8 +119,7 @@ class PaginationGenerator implements GeneratorInterface
             }
 
             $generatedSource = $source->duplicate(
-                $source->sourceId().':page='.$pageNumber,
-                $options
+                $source->sourceId().':page='.$pageNumber
             );
 
             if (null !== $permalink) {


### PR DESCRIPTION

`PaginationGenerator::generate()` typehints a `SourceInterface` so the `duplicate()` method has no `$options` argument. `$options` was an empty array anyway.