### PR TITLE
Revert forced trailing slash behavior.

### DIFF
--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -48,9 +48,9 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
             if (strpos(basename($relativeFilePath), 'index.') === false) {
                 $relativeUrlPath = $relativeFilePath;
             } else {
-                $relativeUrlPath = '/'.dirname($relativeFilePath).'/';
+                $relativeUrlPath = '/'.dirname($relativeFilePath);
             }
-            if ($relativeUrlPath == '/./') {
+            if ($relativeUrlPath == '/.') {
                 $relativeUrlPath = '/';
             }
         } else {

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -43,7 +43,7 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about/index.html',
-                    '/about/'
+                    '/about'
                 ),
             ),
 
@@ -62,7 +62,7 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
                 static::makeTestSource('_posts/2015-01-12-from-buttercup-protects-to-broadway.md'),
                 new Permalink(
                     '2015/01/12/from-buttercup-protects-to-broadway/index.html',
-                    '/2015/01/12/from-buttercup-protects-to-broadway/'
+                    '/2015/01/12/from-buttercup-protects-to-broadway'
                 ),
             ),
         );


### PR DESCRIPTION
I found where the trailing slash behavior was introduced and it has been fixed. We should not force trailing backslash if the user does not request it.