### PR TITLE
Issue #239: Replace short array syntax for PHP 5.3 compatibility

### DIFF
--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -48,7 +48,7 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
     public function __construct(ParserInterface $markdown, array $extensions = array())
     {
         $this->markdown = $markdown;
-        $this->markdown->header_id_func = [$this, 'generateHeaderId'];
+        $this->markdown->header_id_func = array($this, 'generateHeaderId');
         $this->extensions = $extensions;
     }
 
@@ -117,13 +117,13 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
 
         // Step 3: Convert spaces to dashes, and remove unwanted special
         // characters.
-        $map = [
+        $map = array(
             ' ' => '-',
             '(' => '',
             ')' => '',
             '[' => '',
             ']' => '',
-        ];
+        );
         return rawurlencode(strtolower(
             strtr($result, $map)
         ));

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
@@ -83,7 +83,7 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
             if ($indexType) {
                 foreach ($items as $item) {
                     $key = $this->injectedTaxonKey.'_'.$indexType.'_index_permalinks';
-                    $taxonIndexPermalinks = $item->data()->get($key) ?: [];
+                    $taxonIndexPermalinks = $item->data()->get($key) ?: array();
 
                     $taxonIndexPermalinks[$taxon] = $permalink;
 


### PR DESCRIPTION
    - Short array syntax was introduced in PHP 5.4 and is not backwards
      compatible.