### PR TITLE
Include dot files in output generation

### DIFF
--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -144,6 +144,7 @@ class FilesystemDataSource implements DataSourceInterface
             ->finderFactory->createFinder()
             ->files()
             ->ignoreVCS(true)
+            ->ignoreDotFiles(false)
             ->date('>='.$sinceTimeLast)
             ->followLinks()
             ->in($this->sourceDir);


### PR DESCRIPTION
This change will include dotfiles (such as .htaccess) in the generated output, resolving issue #121. It continues to ignore VCS-related files (such as .git).