### PR TITLE
A small amount of cleanup.

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -154,7 +154,7 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
         $this->kernel->boot();
 
         foreach ($this->kernel->getBundles() as $bundle) {
-            if ($bundle instanceof BundleInterface) {
+            if ($bundle instanceof Bundle) {
                 $bundle->registerCommands($this);
             }
         }

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -114,11 +114,13 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
             $this->registerCommands();
         }
 
-        parent::doRun($input, $output);
+        $exitCode = parent::doRun($input, $output);
 
         foreach ($this->getMissingSculpinBundlesMessages() as $message) {
             $output->writeln($message);
         }
+
+        return $exitCode;
     }
 
     public function getMissingSculpinBundlesMessages()

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -11,8 +11,8 @@
 
 namespace Sculpin\Bundle\SculpinBundle\Console;
 
-use Dflydev\EmbeddedComposer\Core\EmbeddedComposer;
 use Dflydev\EmbeddedComposer\Core\EmbeddedComposerAwareInterface;
+use Dflydev\EmbeddedComposer\Core\EmbeddedComposerInterface;
 use Sculpin\Core\Sculpin;
 use Sculpin\Bundle\SculpinBundle\Command\DumpAutoloadCommand;
 use Sculpin\Bundle\SculpinBundle\Command\InstallCommand;
@@ -26,7 +26,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -42,10 +41,10 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
     /**
      * Constructor.
      *
-     * @param KernelInterface  $kernel           A KernelInterface instance
-     * @param EmbeddedComposer $embeddedComposer Composer Class Loader
+     * @param KernelInterface           $kernel           A KernelInterface instance
+     * @param EmbeddedComposerInterface $embeddedComposer Composer Class Loader
      */
-    public function __construct(KernelInterface $kernel, EmbeddedComposer $embeddedComposer)
+    public function __construct(KernelInterface $kernel, EmbeddedComposerInterface $embeddedComposer)
     {
         $this->kernel = $kernel;
         $this->embeddedComposer = $embeddedComposer;
@@ -142,7 +141,7 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
     /**
      * Get Kernel
      *
-     * @return Kernel
+     * @return KernelInterface
      */
     public function getKernel()
     {

--- a/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Clear and Warmup the cache.
  *
- * Originally from FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+ * Originally from FrameworkBundle/Command/CacheClearCommand.php
  *
  * @author Francis Besset <francis.besset@gmail.com>
  * @author Fabien Potencier <fabien@symfony.com>


### PR DESCRIPTION
Probably everything here is self-explanatory. Nonetheless:
- Check the [BundleInterface API docs](http://api.symfony.com/2.3/Symfony/Component/HttpKernel/Bundle/BundleInterface.html)
- The base [Kernel class boot method](https://github.com/symfony/HttpKernel/blob/2.3/Kernel.php#L116) largely accomplishes the same work as the override, which ends up compiling the container twice (see `Kernel::initializeContainer()`). (2016 August 12: Well, apparently not. The override is what allowed tests to pass. I've removed that commit.)
