### PR TITLE
Fixing the "no index.html file when no post are available" bug

### DIFF
--- a/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
+++ b/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
@@ -62,6 +62,9 @@ class PaginationGenerator implements GeneratorInterface
             switch ($matches[1]) {
                 case 'data':
                     $data = $this->dataProviderManager->dataProvider($matches[2])->provideData();
+                    if (!count($data)) {
+                        $data = array('');
+                    }
                     break;
                 case 'page':
                     $data = $source->data()->get($matches[2]);

--- a/src/Sculpin/Tests/Functional/Fixture/source/blog_index.html
+++ b/src/Sculpin/Tests/Functional/Fixture/source/blog_index.html
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Home
+generator: pagination
+pagination:
+max_per_page: 3
+use:
+- posts
+---
+{% for post in page.pagination.items %}
+<article>
+    <header>
+        <h2><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></h2>
+    </header>
+    <div>
+        {{ post.blocks.content|raw }}
+    </div>
+    {% if post.meta.tags %}
+    <p class="tags">
+        Tags:
+        {% for tag in post.meta.tags %}
+        <a href="{{ site.url }}/blog/tags/{{ tag|url_encode(true) }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+    </p>
+    {% endif %}
+</article>
+{% endfor %}
+{% if page.pagination.previous_page or page.pagination.next_page %}
+<nav>
+    {% if page.pagination.previous_page %}<a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer Posts</a>{% endif %}<br />
+    {% if page.pagination.next_page %}<a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older Posts</a>{% endif %}<br />
+</nav>
+{% endif %}

--- a/src/Sculpin/Tests/Functional/GenerateFromPostsTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromPostsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Sculpin\Tests\Functional;
+
+class GenerateFromPostsTest extends FunctionalTestCase
+{
+    /** @test */
+    public function shouldGenerateAnHtmlFileFromEmptyPost()
+    {
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/blog_index.html', '/source/index.html');
+        $this->addProjectDirectory(__DIR__ . '/Fixture/source/_posts');
+
+        $this->executeSculpin('generate');
+
+        $this->assertProjectHasGeneratedFile('/index.html');
+    }
+}


### PR DESCRIPTION
Forcing the PaginationGenerator to pass through one instance of an empty list of items if no post exists
fixes #152 
## 

Hi there, here is a proposal for fixing this old issue. I didn't found guidelines about testing, but I added a functional test anyway.

Hope this helps.
