### PR TITLE
composer: bump to PHPUnit ~4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "twig/extensions": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "~4.7",
         "symfony/dom-crawler": "~2.6",
         "symfony/css-selector": "~2.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,3 +1,9 @@
+	{
+	    "require": {
+	        "payum/payum-bundle": "1.0.x-dev",
+	        "payum/core": "1.0.x-dev"
+	    }
+	}
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
@@ -781,7 +787,7 @@
             "require-dev": {
                 "doctrine/common": "*",
                 "monolog/monolog": "1.*",
-                "phpunit/phpunit": "3.7.*",
+                "phpunit/phpunit": "~4.7",
                 "symfony/class-loader": "*",
                 "zend/zend-cache1": "1.12",
                 "zend/zend-log1": "1.12",


### PR DESCRIPTION
There is PHPUnit 5.0 already out. It might be useful to bump to 4.7 to decrease upgrade issues.