### PR TITLE
Sanitizing url path for Windows platform in SourcePermalinkFactory

### DIFF
--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -61,6 +61,9 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
             $relativeUrlPath = '/'.$relativeUrlPath;
         }
 
+        // Sanitizing url from windows file path
+        $relativeUrlPath = str_replace('\\', '/', $relativeUrlPath);
+
         return new Permalink($relativeFilePath, $relativeUrlPath);
     }
 

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -65,6 +65,15 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
                     '/2015/01/12/from-buttercup-protects-to-broadway'
                 ),
             ),
+
+            array(
+                ':basename.html',
+                static::makeTestSource('some\windows\path.md'),
+                new Permalink(
+                    'some\windows\path.html',
+                    '/some/windows/path.html'
+                ),
+            ),
         );
     }
 


### PR DESCRIPTION
fixes #275 

Not a big fan of the str_replace based on the '/' string constant, but using DIRECTORY_SEPARATOR makes testing this behavior impossible outside of windows platform.
