### PR TITLE
Add "sculpin new" command.

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -49,7 +49,9 @@ class NewCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->projectName = $input->getArgument('name');
-        $this->filesystem = new Filesystem();
+
+        $this->filesystem = $this->getContainer()->get('filesystem');
+
         if (!$this->filesystem->exists($this->projectName)) {
             $this->createDirectories();
             $this->createSculpinSiteFile();

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -38,9 +38,9 @@ class NewCommand extends AbstractCommand
         $prefix = $this->isStandaloneSculpin() ? '' : 'sculpin:';
 
         $this
-          ->setName($prefix.'new')
-          ->setDescription('Create a new site.')
-          ->addArgument('name', InputArgument::REQUIRED);
+            ->setName($prefix.'new')
+            ->setDescription('Create a new site.')
+            ->addArgument('name', InputArgument::REQUIRED);
     }
 
     /**

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -83,9 +83,7 @@ class NewCommand extends AbstractCommand
     private function createSculpinSiteFile()
     {
         $content = <<< CONTENT
----
 title: My New Sculpin Site
----
 CONTENT;
 
         $this->filesystem->dumpFile(

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -57,7 +57,6 @@ class NewCommand extends AbstractCommand
         $this->sourceDir = $this->projectName . DIRECTORY_SEPARATOR . 'source';
 
         $this->filesystem->mkdir([
-            $this->projectName,
             $this->configDir,
             $this->sourceDir,
         ]);

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -78,12 +78,15 @@ class NewCommand extends AbstractCommand
      */
     private function createSculpinSiteFile()
     {
-        $content = [];
-        $content[] = '---';
-        $content[] = 'title: My New Sculpin Site';
+        $content = <<< CONTENT
+---
+title: My New Sculpin Site
+---
+CONTENT;
+
         $this->filesystem->dumpFile(
             $this->configDir . DIRECTORY_SEPARATOR . 'sculpin_site.yml',
-            implode(PHP_EOL, $content)
+            $content
         );
     }
 
@@ -92,15 +95,15 @@ class NewCommand extends AbstractCommand
      */
     private function createIndexFile()
     {
-        $content = [];
-        $content[] = '---';
-        $content[] = '---';
-        $content[] = '# {{ site.title }}';
-        $content[] = PHP_EOL;
-        $content[] = 'Hello, world!';
+        $content = <<< CONTENT
+---
+---
+Hello, world!
+CONTENT;
+
         $this->filesystem->dumpFile(
             $this->sourceDir . DIRECTORY_SEPARATOR . 'index.md',
-            implode(PHP_EOL, $content)
+            $content
         );
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -2,7 +2,6 @@
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
-use Sculpin\Bundle\SculpinBundle\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Sculpin\Bundle\SculpinBundle\Command;
+
+use Sculpin\Bundle\SculpinBundle\Command\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class NewCommand extends AbstractCommand
+{
+    private $projectName;
+
+    /** @var Filesystem */
+    private $filesystem;
+
+    private $configDir;
+
+    private $sourceDir;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $prefix = $this->isStandaloneSculpin() ? '' : 'sculpin:';
+
+        $this
+          ->setName($prefix.'new')
+          ->setDescription('Create a new site.')
+          ->addArgument('name', InputArgument::REQUIRED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->projectName = $input->getArgument('name');
+        $this->filesystem = new Filesystem();
+        if (!$this->filesystem->exists($this->projectName)) {
+            $this->createDirectories();
+            $this->createSculpinSiteFile();
+            $this->createIndexFile();
+        }
+
+        $output->writeln("Project $this->projectName created.");
+    }
+
+    /**
+     * Create the directories needed for a Sculpin site.
+     */
+    private function createDirectories()
+    {
+        $this->configDir = $this->projectName . DIRECTORY_SEPARATOR . 'app/config';
+        $this->sourceDir = $this->projectName . DIRECTORY_SEPARATOR . 'source';
+
+        $this->filesystem->mkdir([
+            $this->projectName,
+            $this->configDir,
+            $this->sourceDir,
+        ]);
+    }
+
+    /**
+     * Create an example sculpin_site.yml file.
+     */
+    private function createSculpinSiteFile()
+    {
+        $content = [];
+        $content[] = '---';
+        $content[] = 'title: My New Sculpin Site';
+        $this->filesystem->dumpFile(
+            $this->configDir . DIRECTORY_SEPARATOR . 'sculpin_site.yml',
+            implode(PHP_EOL, $content)
+        );
+    }
+
+    /**
+     * Create an example index.md file.
+     */
+    private function createIndexFile()
+    {
+        $content = [];
+        $content[] = '---';
+        $content[] = '---';
+        $content[] = '# {{ site.title }}';
+        $content[] = PHP_EOL;
+        $content[] = 'Hello, world!';
+        $this->filesystem->dumpFile(
+            $this->sourceDir . DIRECTORY_SEPARATOR . 'index.md',
+            implode(PHP_EOL, $content)
+        );
+    }
+}

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -56,7 +56,7 @@ class NewCommand extends AbstractCommand
             $this->createIndexFile();
         }
 
-        $output->writeln("Project $this->projectName created.");
+        $output->writeln(sprintf("Project %s created.", $this->projectName));
     }
 
     /**

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -10,13 +10,24 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class NewCommand extends AbstractCommand
 {
+    /**
+     * @var string
+     */
     private $projectName;
 
-    /** @var Filesystem */
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
 
+    /**
+     * @var string
+     */
     private $configDir;
 
+    /**
+     * @var string
+     */
     private $sourceDir;
 
     /**

--- a/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/NewCommand.php
@@ -52,13 +52,15 @@ class NewCommand extends AbstractCommand
 
         $this->filesystem = $this->getContainer()->get('filesystem');
 
-        if (!$this->filesystem->exists($this->projectName)) {
+        if ($this->filesystem->exists($this->projectName)) {
+            $output->writeln(sprintf("<error>Project %s already exists.</error>", $this->projectName));
+        } else {
             $this->createDirectories();
             $this->createSculpinSiteFile();
             $this->createIndexFile();
-        }
 
-        $output->writeln(sprintf("Project %s created.", $this->projectName));
+            $output->writeln(sprintf("<info>Project %s created.</info>", $this->projectName));
+        }
     }
 
     /**


### PR DESCRIPTION
I've created this as a proof of concept, to quickly create the base directories and files needed for a new Sculpin site using a "sculpin new" command.

I wasn't sure if the `Filesystem` class was already available or being injected in automatically. If so, I'd be happy to refactor the code to incorporate this.

I also wasn't sure how much to create by default. At the moment I've just added `app/config/sculpin_site.yml` and `source/index.md` with minimal information.
