### PR TITLE
allow slug to specify directory separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Nothing.
+- [#343](https://github.com/sculpin/sculpin/pull/343) slugs are used literally
+  and not escaped again.
 
 ## 2.1.1 - 2017-03-24
 
@@ -31,4 +32,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  generator introduced by [#233](https://github.com/sculpin/sculpin/pull/233)
 - [#281](https://github.com/sculpin/sculpin/pull/281) fixed pagination generator
   not producing page for empty list of items.
-

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -204,7 +204,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
         if (function_exists('iconv')) {
             $param = @iconv('utf-8', 'us-ascii//TRANSLIT', $param);
         }
-        $param = preg_replace('/[^a-zA-Z0-9 -]/', '', $param);
+        $param = preg_replace('/[^a-zA-Z0-9 -\/]/', '', $param);
         $param = strtolower($param);
         $param = preg_replace('/[\s-]+/', $space, $param);
 

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -115,13 +115,13 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
                 $permalink = preg_replace('/:day/', $day, $permalink);
                 $permalink = preg_replace('/:dy/', $dy, $permalink);
                 $permalink = preg_replace('/:title/', $this->normalize($title), $permalink);
-                $permalink = preg_replace('/:slug_title/', $this->normalize($slug ?: $title), $permalink);
+                $permalink = preg_replace('/:slug_title/', $slug ?: $this->normalize($title), $permalink);
                 $filename = $pathname;
                 if ($isDatePath = $this->isDatePath($pathname)) {
                     $filename = $isDatePath[3];
                 }
                 $permalink = preg_replace('/:filename/', $filename, $permalink);
-                $permalink = preg_replace('/:slug_filename/', $this->normalize($slug ?: $filename), $permalink);
+                $permalink = preg_replace('/:slug_filename/', $slug ?: $this->normalize($filename), $permalink);
                 if (strrpos($filename, DIRECTORY_SEPARATOR) !== false) {
                     $basename = substr($filename, strrpos($filename, DIRECTORY_SEPARATOR)+1);
                 } else {
@@ -204,7 +204,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
         if (function_exists('iconv')) {
             $param = @iconv('utf-8', 'us-ascii//TRANSLIT', $param);
         }
-        $param = preg_replace('/[^a-zA-Z0-9 -\/]/', '', $param);
+        $param = preg_replace('/[^a-zA-Z0-9 -]/', '', $param);
         $param = strtolower($param);
         $param = preg_replace('/[\s-]+/', $space, $param);
 

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -77,12 +77,12 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
             array(
                 'blog/:year/:month/:day/:slug_title',
                 static::makeTestSource('about.md', array(
-                    'slug' => 'some-about-me',
+                    'slug' => 'some/about-me',
                     'calculated_date' => mktime(0, 0, 0, 1, 12, 2005)
                 )),
                 new Permalink(
-                    'blog/2005/01/12/some-about-me/index.html',
-                    '/blog/2005/01/12/some-about-me'
+                    'blog/2005/01/12/some/about-me/index.html',
+                    '/blog/2005/01/12/some/about-me'
                 ),
             ),
 


### PR DESCRIPTION
i want to define slugs with paths in them. i see no reason why this should not be allowed, as e.g. pretty uses the path to the file which also contains folders. in my project it works fine with this change.