### PR TITLE
Fix regression introduced by #233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [#345](https://github.com/sculpin/sculpin/pull/345) fixed regression in permalink
+ generator introduced by [#233](https://github.com/sculpin/sculpin/pull/233)
 - [#281](https://github.com/sculpin/sculpin/pull/281) fixed pagination generator
   not producing page for empty list of items.
 

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -133,8 +133,12 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
                 $permalink = preg_replace('/:basename_real/', $basename, $permalink);
                 $permalink = preg_replace('/:basename/', $prettyBasename, $permalink);
 
-                if (substr($permalink, -5, 5) != '.html') {
-                    $permalink = rtrim($permalink, '/').'/';
+                if (preg_match('#(^|[\\/])[^.]+$#', $permalink)
+                    // Exclude .md and .twig for BC
+                    || substr($permalink, -3, 3) === '.md'
+                    || substr($permalink, -5, 5) === '.twig'
+                ) {
+                    $permalink = rtrim($permalink, '/') . '/';
                 }
 
                 if (substr($permalink, -1, 1) == '/') {

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -131,6 +131,24 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
 
+            'Permalink for .xml' => array(
+                ':filename',
+                static::makeTestSource('about.xml'),
+                new Permalink(
+                    'about.xml',
+                    '/about.xml'
+                ),
+            ),
+
+            'Permalink for .json' => array(
+                ':filename',
+                static::makeTestSource('about.json'),
+                new Permalink(
+                    'about.json',
+                    '/about.json'
+                ),
+            ),
+
             'Permalink with trailing slash' => array(
                 ':basename/',
                 static::makeTestSource('about.md'),


### PR DESCRIPTION
This fix limits scope of #233 to permalinks that have no extension or end in '.md' or '.twig'