### PR TITLE
Bump to PHP7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,10 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
-      env:
-        - DEPS=lowest
-    - php: hhvm
-      env:
-        - DEPS=locked
-    - php: hhvm
-      env:
-        - DEPS=latest
 
 before_install:
   - travis_retry composer self-update
-  - if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini ; fi
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini ; fi
 
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,29 +8,14 @@ cache:
 
 matrix:
   include:
-    - php: 5.4
-      env:
-        - DEPS=latest
-    - php: 5.5
-      env:
-        - DEPS=latest
-    - php: 5.6
+    - php: 7.0
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.0
       env:
         - DEPS=locked
         - CHECK_CS=true
         - TEST_COVERAGE=true
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7.0
-      env:
-        - DEPS=lowest
-    - php: 7.0
-      env:
-        - DEPS=locked
     - php: 7.0
       env:
         - DEPS=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,16 @@ matrix:
         - DEPS=lowest
     - php: 7.1
       env:
-        - DEPS=locked
         - CHECK_CS=true
         - TEST_COVERAGE=true
-    - php: 7.1
-      env:
-        - DEPS=latest
     - php: 7.2
 
 before_install:
-  - travis_retry composer self-update
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini ; fi
 
 install:
-  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable --no-interaction ; fi
-  - if [[ $DEPS == 'locked' ]]; then travis_retry composer install --no-interaction ; fi
+  - if [[ $DEPS != 'lowest' ]]; then travis_retry composer install --no-interaction ; fi
   - composer show
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,14 @@ cache:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.1
       env:
         - DEPS=lowest
-    - php: 7.0
+    - php: 7.1
       env:
         - DEPS=locked
         - CHECK_CS=true
         - TEST_COVERAGE=true
-    - php: 7.0
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=locked
     - php: 7.1
       env:
         - DEPS=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
+    - php: 7.2
 
 before_install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "seld/jsonlint": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.4",
+        "phpunit/phpunit": "^6.4",
         "symfony/dom-crawler": "~2.6",
         "symfony/css-selector": "~2.6",
         "squizlabs/php_codesniffer": "^2.8"

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4",
-        "symfony/dom-crawler": "~2.6",
-        "symfony/css-selector": "~2.6",
+        "symfony/dom-crawler": "^3.3",
+        "symfony/css-selector": "^3.3",
         "squizlabs/php_codesniffer": "^2.8"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
+        "php": "^7.0",
         "dflydev/ant-path-matcher": "1.*",
         "dflydev/apache-mime-types": "~1.0,>=1.0.1",
         "dflydev/canal": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "seld/jsonlint": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.4",
         "symfony/dom-crawler": "~2.6",
         "symfony/css-selector": "~2.6",
         "squizlabs/php_codesniffer": "^2.8"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "dflydev/ant-path-matcher": "1.*",
         "dflydev/apache-mime-types": "~1.0,>=1.0.1",
         "dflydev/canal": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "720cf6f71d6402bce20d609c2711efcf",
+    "content-hash": "f25b2aff74e879cf62f1f81b84cc8e02",
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.0.7",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12"
+                "reference": "36344aeffdc37711335563e6108cda86566432a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
-                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/36344aeffdc37711335563e6108cda86566432a6",
+                "reference": "36344aeffdc37711335563e6108cda86566432a6",
                 "shasum": ""
             },
             "require": {
@@ -63,20 +63,20 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-03-06T11:59:08+00:00"
+            "time": "2017-11-13T15:51:25+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "1.4.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "7ee2a5e1cf32e9c8439445fe8dce2c046c2abebd"
+                "reference": "c639623fa2178b404ed4bab80f0d1263853fa4ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/7ee2a5e1cf32e9c8439445fe8dce2c046c2abebd",
-                "reference": "7ee2a5e1cf32e9c8439445fe8dce2c046c2abebd",
+                "url": "https://api.github.com/repos/composer/composer/zipball/c639623fa2178b404ed4bab80f0d1263853fa4ae",
+                "reference": "c639623fa2178b404ed4bab80f0d1263853fa4ae",
                 "shasum": ""
             },
             "require": {
@@ -109,7 +109,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -140,7 +140,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2017-03-10T08:29:45+00:00"
+            "time": "2017-09-11T14:59:26+00:00"
         },
         {
             "name": "composer/semver",
@@ -206,16 +206,16 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "96c6a07b05b716e89a44529d060bc7f5c263cb13"
+                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/96c6a07b05b716e89a44529d060bc7f5c263cb13",
-                "reference": "96c6a07b05b716e89a44529d060bc7f5c263cb13",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
+                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
                 "shasum": ""
             },
             "require": {
@@ -263,7 +263,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2016-09-28T07:17:45+00:00"
+            "time": "2017-04-03T19:08:52+00:00"
         },
         {
             "name": "dflydev/ant-path-matcher",
@@ -784,20 +784,23 @@
         },
         {
             "name": "evenement/evenement",
-            "version": "v2.0.0",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/igorw/evenement.git",
-                "reference": "f6e843799fd4f4184d54d8fc7b5b3551c9fa803e"
+                "reference": "6ba9a777870ab49f417e703229d53931ed40fd7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/igorw/evenement/zipball/f6e843799fd4f4184d54d8fc7b5b3551c9fa803e",
-                "reference": "f6e843799fd4f4184d54d8fc7b5b3551c9fa803e",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/6ba9a777870ab49f417e703229d53931ed40fd7a",
+                "reference": "6ba9a777870ab49f417e703229d53931ed40fd7a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0||^5.7||^4.8.35"
             },
             "type": "library",
             "extra": {
@@ -817,8 +820,7 @@
             "authors": [
                 {
                     "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch",
-                    "homepage": "http://wiedler.ch/igor/"
+                    "email": "igor@wiedler.ch"
                 }
             ],
             "description": "Événement is a very simple event dispatching library for PHP",
@@ -826,20 +828,20 @@
                 "event-dispatcher",
                 "event-emitter"
             ],
-            "time": "2012-11-02T14:49:47+00:00"
+            "time": "2017-07-17T17:39:19+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.2.0",
+            "version": "5.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "e3c9bccdc38bbd09bcac0131c00f3be58368b416"
+                "reference": "d283e11b6e14c6f4664cf080415c4341293e5bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/e3c9bccdc38bbd09bcac0131c00f3be58368b416",
-                "reference": "e3c9bccdc38bbd09bcac0131c00f3be58368b416",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/d283e11b6e14c6f4664cf080415c4341293e5bbd",
+                "reference": "d283e11b6e14c6f4664cf080415c4341293e5bbd",
                 "shasum": ""
             },
             "require": {
@@ -848,7 +850,6 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.1",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpdocumentor/phpdocumentor": "~2",
                 "phpunit/phpunit": "^4.8.22"
             },
             "bin": [
@@ -893,7 +894,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2017-03-22T22:43:35+00:00"
+            "time": "2017-10-21T13:15:38+00:00"
         },
         {
             "name": "michelf/php-markdown",
@@ -1098,20 +1099,23 @@
         },
         {
             "name": "react/event-loop",
-            "version": "v0.4.2",
+            "version": "v0.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "164799f73175e1c80bba92a220ea35df6ca371dd"
+                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/164799f73175e1c80bba92a220ea35df6ca371dd",
-                "reference": "164799f73175e1c80bba92a220ea35df6ca371dd",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
+                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
             },
             "suggest": {
                 "ext-event": "~1.0",
@@ -1119,11 +1123,6 @@
                 "ext-libevent": ">=0.1.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.5-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "React\\EventLoop\\": "src"
@@ -1138,7 +1137,7 @@
                 "asynchronous",
                 "event-loop"
             ],
-            "time": "2016-03-08T02:09:32+00:00"
+            "time": "2017-04-27T10:56:23+00:00"
         },
         {
             "name": "react/http",
@@ -1182,20 +1181,23 @@
         },
         {
             "name": "react/promise",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "2760f3898b7e931aa71153852dcd48a75c9b95db"
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/2760f3898b7e931aa71153852dcd48a75c9b95db",
-                "reference": "2760f3898b7e931aa71153852dcd48a75c9b95db",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/62785ae604c8d69725d693eb370e1d67e94c4053",
+                "reference": "62785ae604c8d69725d693eb370e1d67e94c4053",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "autoload": {
@@ -1221,7 +1223,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2016-12-22T14:09:01+00:00"
+            "time": "2017-03-25T12:08:31+00:00"
         },
         {
             "name": "react/socket",
@@ -1452,16 +1454,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "791f8c594f300d246cdf01c6b3e1e19611e301d8"
+                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/791f8c594f300d246cdf01c6b3e1e19611e301d8",
-                "reference": "791f8c594f300d246cdf01c6b3e1e19611e301d8",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
+                "reference": "50d63f2858d87c4738d5b76a7dcbb99fa8cf7c77",
                 "shasum": ""
             },
             "require": {
@@ -1497,7 +1499,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2017-03-06T16:42:24+00:00"
+            "time": "2017-06-18T15:11:04+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -1545,16 +1547,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "06ce6bb46c24963ec09323da45d0f4f85d3cecd2"
+                "reference": "f4f3f1d7090c464434bbbc3e8aa2b41149c59196"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/06ce6bb46c24963ec09323da45d0f4f85d3cecd2",
-                "reference": "06ce6bb46c24963ec09323da45d0f4f85d3cecd2",
+                "url": "https://api.github.com/repos/symfony/config/zipball/f4f3f1d7090c464434bbbc3e8aa2b41149c59196",
+                "reference": "f4f3f1d7090c464434bbbc3e8aa2b41149c59196",
                 "shasum": ""
             },
             "require": {
@@ -1597,20 +1599,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-01T18:13:50+00:00"
+            "time": "2017-11-07T11:56:23+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "81508e6fac4476771275a3f4f53c3fee9b956bfa"
+                "reference": "7cad097cf081c0ab3d0322cc38d34ee80484d86f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/81508e6fac4476771275a3f4f53c3fee9b956bfa",
-                "reference": "81508e6fac4476771275a3f4f53c3fee9b956bfa",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7cad097cf081c0ab3d0322cc38d34ee80484d86f",
+                "reference": "7cad097cf081c0ab3d0322cc38d34ee80484d86f",
                 "shasum": ""
             },
             "require": {
@@ -1658,20 +1660,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-04T11:00:12+00:00"
+            "time": "2017-11-16T15:20:19+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e90099a2958d4833a02d05b504cc06e1c234abcc"
+                "reference": "a0a29e9867debabdace779a20a9385c623a23bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e90099a2958d4833a02d05b504cc06e1c234abcc",
-                "reference": "e90099a2958d4833a02d05b504cc06e1c234abcc",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/a0a29e9867debabdace779a20a9385c623a23bbd",
+                "reference": "a0a29e9867debabdace779a20a9385c623a23bbd",
                 "shasum": ""
             },
             "require": {
@@ -1715,20 +1717,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18T19:13:35+00:00"
+            "time": "2017-10-24T13:48:52+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "efdbeefa454a41154fd99a6f0489f0e9cb46c497"
+                "reference": "bc845111480786a9a68b39578ecdf27d9a6a44ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/efdbeefa454a41154fd99a6f0489f0e9cb46c497",
-                "reference": "efdbeefa454a41154fd99a6f0489f0e9cb46c497",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/bc845111480786a9a68b39578ecdf27d9a6a44ec",
+                "reference": "bc845111480786a9a68b39578ecdf27d9a6a44ec",
                 "shasum": ""
             },
             "require": {
@@ -1778,20 +1780,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-28T12:31:05+00:00"
+            "time": "2017-11-07T14:08:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "bb4ec47e8e109c1c1172145732d0aa468d967cd0"
+                "reference": "b59aacf238fadda50d612c9de73b74751872a903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/bb4ec47e8e109c1c1172145732d0aa468d967cd0",
-                "reference": "bb4ec47e8e109c1c1172145732d0aa468d967cd0",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b59aacf238fadda50d612c9de73b74751872a903",
+                "reference": "b59aacf238fadda50d612c9de73b74751872a903",
                 "shasum": ""
             },
             "require": {
@@ -1838,20 +1840,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T08:33:48+00:00"
+            "time": "2017-11-05T15:25:56+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e542d4765092d22552b1bf01ddccfb01d98ee325"
+                "reference": "10507c5f24577b0ad971b0d22097c823b2b45dd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e542d4765092d22552b1bf01ddccfb01d98ee325",
-                "reference": "e542d4765092d22552b1bf01ddccfb01d98ee325",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/10507c5f24577b0ad971b0d22097c823b2b45dd3",
+                "reference": "10507c5f24577b0ad971b0d22097c823b2b45dd3",
                 "shasum": ""
             },
             "require": {
@@ -1887,20 +1889,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18T17:06:33+00:00"
+            "time": "2017-11-07T14:08:47+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5fc4b5cab38b9d28be318fcffd8066988e7d9451"
+                "reference": "efeceae6a05a9b2fcb3391333f1d4a828ff44ab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5fc4b5cab38b9d28be318fcffd8066988e7d9451",
-                "reference": "5fc4b5cab38b9d28be318fcffd8066988e7d9451",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/efeceae6a05a9b2fcb3391333f1d4a828ff44ab8",
+                "reference": "efeceae6a05a9b2fcb3391333f1d4a828ff44ab8",
                 "shasum": ""
             },
             "require": {
@@ -1936,7 +1938,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T08:33:48+00:00"
+            "time": "2017-11-05T15:25:56+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -1993,16 +1995,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "18d7a01ac14ffa5a652a635c402b9777f858fc1a"
+                "reference": "5f099c72654b4a18e82679a10a1a23bbfa75d87e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/18d7a01ac14ffa5a652a635c402b9777f858fc1a",
-                "reference": "18d7a01ac14ffa5a652a635c402b9777f858fc1a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/5f099c72654b4a18e82679a10a1a23bbfa75d87e",
+                "reference": "5f099c72654b4a18e82679a10a1a23bbfa75d87e",
                 "shasum": ""
             },
             "require": {
@@ -2010,10 +2012,11 @@
                 "psr/log": "~1.0",
                 "symfony/debug": "^2.6.2",
                 "symfony/event-dispatcher": "^2.6.7|~3.0.0",
-                "symfony/http-foundation": "~2.7.20|~2.8.13|~3.1.6"
+                "symfony/http-foundation": "~2.7.36|~2.8.29|~3.1.6"
             },
             "conflict": {
-                "symfony/config": "<2.7"
+                "symfony/config": "<2.7",
+                "twig/twig": "<1.34|<2.4,>=2"
             },
             "require-dev": {
                 "symfony/browser-kit": "~2.3|~3.0.0",
@@ -2071,20 +2074,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-06T03:54:35+00:00"
+            "time": "2017-11-16T17:43:55+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.3.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
-                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -2096,7 +2099,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -2130,20 +2133,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "41336b20b52f5fd5b42a227e394e673c8071118f"
+                "reference": "d25449e031f600807949aab7cadbf267712f4eee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/41336b20b52f5fd5b42a227e394e673c8071118f",
-                "reference": "41336b20b52f5fd5b42a227e394e673c8071118f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d25449e031f600807949aab7cadbf267712f4eee",
+                "reference": "d25449e031f600807949aab7cadbf267712f4eee",
                 "shasum": ""
             },
             "require": {
@@ -2179,20 +2182,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-04T12:20:59+00:00"
+            "time": "2017-11-05T15:25:56+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2a7bab3c16f6f452c47818fdd08f3b1e49ffcf7d"
+                "reference": "d819bf267e901727141fe828ae888486fd21236e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2a7bab3c16f6f452c47818fdd08f3b1e49ffcf7d",
-                "reference": "2a7bab3c16f6f452c47818fdd08f3b1e49ffcf7d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d819bf267e901727141fe828ae888486fd21236e",
+                "reference": "d819bf267e901727141fe828ae888486fd21236e",
                 "shasum": ""
             },
             "require": {
@@ -2228,27 +2231,28 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-01T18:13:50+00:00"
+            "time": "2017-11-05T15:25:56+00:00"
         },
         {
             "name": "twig/extensions",
-            "version": "v1.4.1",
+            "version": "v1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig-extensions.git",
-                "reference": "f0bb8431c8691f5a39f1017d9a5967a082bf01ff"
+                "reference": "d188c76168b853481cc75879ea045bf93d718e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/f0bb8431c8691f5a39f1017d9a5967a082bf01ff",
-                "reference": "f0bb8431c8691f5a39f1017d9a5967a082bf01ff",
+                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/d188c76168b853481cc75879ea045bf93d718e9c",
+                "reference": "d188c76168b853481cc75879ea045bf93d718e9c",
                 "shasum": ""
             },
             "require": {
-                "twig/twig": "~1.20|~2.0"
+                "twig/twig": "~1.27|~2.0"
             },
             "require-dev": {
-                "symfony/translation": "~2.3"
+                "symfony/phpunit-bridge": "~3.3@dev",
+                "symfony/translation": "~2.3|~3.0"
             },
             "suggest": {
                 "symfony/translation": "Allow the time_diff output to be translated"
@@ -2256,12 +2260,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Twig_Extensions_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\Extensions\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2280,24 +2287,24 @@
                 "i18n",
                 "text"
             ],
-            "time": "2016-10-25T17:34:14+00:00"
+            "time": "2017-06-08T18:19:53+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "05cf49921b13f6f01d3cfdf9018cfa7a8086fd5a"
+                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/05cf49921b13f6f01d3cfdf9018cfa7a8086fd5a",
-                "reference": "05cf49921b13f6f01d3cfdf9018cfa7a8086fd5a",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/daa657073e55b0a78cce8fdd22682fddecc6385f",
+                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.7"
+                "php": ">=5.3.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
@@ -2307,12 +2314,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.33-dev"
+                    "dev-master": "1.35-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2342,7 +2352,48 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-03-22T15:40:09+00:00"
+            "time": "2017-09-27T18:06:46+00:00"
+        },
+        {
+            "name": "webignition/disallowed-character-terminated-string",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webignition/disallowed-character-terminated-string.git",
+                "reference": "25d12868c82b56bc0d04278e31594385ba4dddc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webignition/disallowed-character-terminated-string/zipball/25d12868c82b56bc0d04278e31594385ba4dddc4",
+                "reference": "25d12868c82b56bc0d04278e31594385ba4dddc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jon Cram",
+                    "email": "jon@webignition.net"
+                }
+            ],
+            "description": "A string terminated by one or more disallowed characters",
+            "homepage": "https://github.com/webignition/disallowed-character-terminated-string",
+            "keywords": [
+                "string",
+                "terminated"
+            ],
+            "time": "2012-07-16T21:29:50+00:00"
         },
         {
             "name": "webignition/internet-media-type",
@@ -2396,25 +2447,31 @@
         },
         {
             "name": "webignition/quoted-string",
-            "version": "0.1",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webignition/quoted-string.git",
-                "reference": "43fa25f8c81eaa5aef4c2376703fe90d1449fdf8"
+                "reference": "88b36b7be067796683ab3668e175322842dd5313"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webignition/quoted-string/zipball/43fa25f8c81eaa5aef4c2376703fe90d1449fdf8",
-                "reference": "43fa25f8c81eaa5aef4c2376703fe90d1449fdf8",
+                "url": "https://api.github.com/repos/webignition/quoted-string/zipball/88b36b7be067796683ab3668e175322842dd5313",
+                "reference": "88b36b7be067796683ab3668e175322842dd5313",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.5.0",
+                "webignition/string-parser": ">=0.2.3,<1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "3.*"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "": "src/"
+                "psr-4": {
+                    "webignition\\QuotedString\\": "src/",
+                    "webignition\\Tests\\QuotedString\\": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2433,29 +2490,35 @@
                 "parser",
                 "quoted-string"
             ],
-            "time": "2012-08-15T16:52:06+00:00"
+            "time": "2017-05-11T11:41:31+00:00"
         },
         {
             "name": "webignition/string-parser",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webignition/string-parser.git",
-                "reference": "eaa5a393ef3585783f6ef28558ef5183af00dcf7"
+                "reference": "8591e28c05bd250bcc67b8001f3588995b9ef74b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webignition/string-parser/zipball/eaa5a393ef3585783f6ef28558ef5183af00dcf7",
-                "reference": "eaa5a393ef3585783f6ef28558ef5183af00dcf7",
+                "url": "https://api.github.com/repos/webignition/string-parser/zipball/8591e28c05bd250bcc67b8001f3588995b9ef74b",
+                "reference": "8591e28c05bd250bcc67b8001f3588995b9ef74b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.3.0",
+                "webignition/disallowed-character-terminated-string": ">=1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "3.*"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "": "src/"
+                "psr-4": {
+                    "webignition\\StringParser\\": "src/",
+                    "webignition\\Tests\\StringParser\\": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2474,38 +2537,38 @@
                 "parser",
                 "string"
             ],
-            "time": "2014-04-23T09:31:03+00:00"
+            "time": "2017-05-11T10:04:12+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -2530,20 +2593,65 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -2584,26 +2692,26 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -2629,24 +2737,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-08-30T18:51:59+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -2676,37 +2784,37 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -2739,43 +2847,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -2801,20 +2910,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "8ebba84e5bd74fc5fdeb916b38749016c7232f93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/8ebba84e5bd74fc5fdeb916b38749016c7232f93",
+                "reference": "8ebba84e5bd74fc5fdeb916b38749016c7232f93",
                 "shasum": ""
             },
             "require": {
@@ -2848,7 +2957,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-24T15:00:59+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2942,29 +3051,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2987,44 +3096,54 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-08-20T05:47:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.35",
+            "version": "5.7.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
+                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
-                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b1c822a68ae6577df38a59eb49b046712ec0f6a",
+                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0.3|~2.0",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -3033,7 +3152,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -3059,30 +3178,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06T05:18:07+00:00"
+            "time": "2017-11-14T14:50:51+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -3090,7 +3212,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -3115,7 +3237,52 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -3183,23 +3350,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -3231,32 +3398,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3281,25 +3448,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -3308,7 +3475,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3348,7 +3515,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3402,17 +3569,63 @@
             "time": "2015-10-12T03:26:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18T15:18:39+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -3424,7 +3637,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3452,23 +3665,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -3487,20 +3750,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
                 "shasum": ""
             },
             "require": {
@@ -3565,20 +3828,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-05-22T02:43:20+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "742bd688bd778dde8991ba696cb372570610afcd"
+                "reference": "b7b041487197fb6d803b7edbcaae7f00a793b1c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/742bd688bd778dde8991ba696cb372570610afcd",
-                "reference": "742bd688bd778dde8991ba696cb372570610afcd",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b7b041487197fb6d803b7edbcaae7f00a793b1c4",
+                "reference": "b7b041487197fb6d803b7edbcaae7f00a793b1c4",
                 "shasum": ""
             },
             "require": {
@@ -3618,20 +3881,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T08:33:48+00:00"
+            "time": "2017-11-05T15:25:56+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.8.18",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "24b1a3ffa5b64e4f8b1c5f2cdffd16368640704a"
+                "reference": "eeb78092b5cc95b9e37017887da0e39f1530b8a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/24b1a3ffa5b64e4f8b1c5f2cdffd16368640704a",
-                "reference": "24b1a3ffa5b64e4f8b1c5f2cdffd16368640704a",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/eeb78092b5cc95b9e37017887da0e39f1530b8a8",
+                "reference": "eeb78092b5cc95b9e37017887da0e39f1530b8a8",
                 "shasum": ""
             },
             "require": {
@@ -3674,7 +3937,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T08:33:48+00:00"
+            "time": "2017-11-05T15:25:56+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "424fd312e7ca054e4547fc8bc925a9c4",
+    "content-hash": "40527714bf07845ddbea7a6c12681b09",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3983,25 +3983,25 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.31",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "b7b041487197fb6d803b7edbcaae7f00a793b1c4"
+                "reference": "66e6e046032ebdf1f562c26928549f613d428bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b7b041487197fb6d803b7edbcaae7f00a793b1c4",
-                "reference": "b7b041487197fb6d803b7edbcaae7f00a793b1c4",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/66e6e046032ebdf1f562c26928549f613d428bd1",
+                "reference": "66e6e046032ebdf1f562c26928549f613d428bd1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -4032,28 +4032,28 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05T15:25:56+00:00"
+            "time": "2017-11-05T15:47:03+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.8.31",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "eeb78092b5cc95b9e37017887da0e39f1530b8a8"
+                "reference": "cebe3c068867956e012d9135282ba6a05d8a259e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/eeb78092b5cc95b9e37017887da0e39f1530b8a8",
-                "reference": "eeb78092b5cc95b9e37017887da0e39f1530b8a8",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/cebe3c068867956e012d9135282ba6a05d8a259e",
+                "reference": "cebe3c068867956e012d9135282ba6a05d8a259e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.8|~3.0.0"
+                "symfony/css-selector": "~2.8|~3.0"
             },
             "suggest": {
                 "symfony/css-selector": ""
@@ -4061,7 +4061,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -4088,7 +4088,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05T15:25:56+00:00"
+            "time": "2017-11-05T15:47:03+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f25b2aff74e879cf62f1f81b84cc8e02",
+    "content-hash": "0c2da1ed4a14997456fd5627d10f60df",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2641,6 +2641,108 @@
             "time": "2017-10-19T19:58:43+00:00"
         },
         {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0.1",
             "source": {
@@ -2851,40 +2953,41 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "5.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.2.x-dev"
                 }
             },
             "autoload": {
@@ -2910,7 +3013,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2017-11-03T13:47:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3100,16 +3203,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.25",
+            "version": "6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a"
+                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b1c822a68ae6577df38a59eb49b046712ec0f6a",
-                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/562f7dc75d46510a4ed5d16189ae57fbe45a9932",
+                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932",
                 "shasum": ""
             },
             "require": {
@@ -3118,33 +3221,35 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.2.2",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^4.0.3",
+                "sebastian/comparator": "^2.0.2",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -3152,7 +3257,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.4.x-dev"
                 }
             },
             "autoload": {
@@ -3178,33 +3283,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-14T14:50:51+00:00"
+            "time": "2017-11-08T11:26:09+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
+                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -3212,7 +3317,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -3237,7 +3342,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2017-08-03T14:08:16+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3286,30 +3391,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.0",
+                "sebastian/diff": "^2.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -3340,38 +3445,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2017-11-03T07:16:52+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3398,32 +3503,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -3448,34 +3553,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -3515,27 +3620,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -3543,7 +3648,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3566,33 +3671,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -3612,32 +3718,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -3665,7 +3816,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3940,6 +4091,46 @@
             "time": "2017-11-05T15:25:56+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.2.0",
             "source": {
@@ -3998,7 +4189,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.4|^7.0"
+        "php": "^7.0"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c2da1ed4a14997456fd5627d10f60df",
+    "content-hash": "424fd312e7ca054e4547fc8bc925a9c4",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4189,7 +4189,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Compiler/MapPass.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Compiler/MapPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MapPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $typesId = self::generateId('types');
         $types = $container->getParameter($typesId);

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Compiler/MapPass.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Compiler/MapPass.php
@@ -11,8 +11,8 @@
 
 namespace Sculpin\Bundle\ContentTypesBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class MapPass implements CompilerPassInterface

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Compiler/MapPass.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Compiler/MapPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -33,7 +33,7 @@ class MapPass implements CompilerPassInterface
 
             foreach ($container->findTaggedServiceIds($mapId) as $id => $tagAttributes) {
                 foreach ($tagAttributes as $attributes) {
-                    $definition->addMethodCall('addMap', array(new Reference($id)));
+                    $definition->addMethodCall('addMap', [new Reference($id)]);
                 }
             }
         }
@@ -41,11 +41,11 @@ class MapPass implements CompilerPassInterface
 
     private static function generateId($value)
     {
-        return implode('.', array('sculpin_content_types', $value));
+        return implode('.', ['sculpin_content_types', $value]);
     }
 
     private static function generateTypesId($type, $value)
     {
-        return implode('.', array('sculpin_content_types.types', $type, $value));
+        return implode('.', ['sculpin_content_types.types', $type, $value]);
     }
 }

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -46,7 +46,7 @@ class Configuration implements ConfigurationInterface
                         // path but we can allow for multiple if they want to.
                         ->ifString()
                         ->then(function ($v) {
-                            return array($v);
+                            return [$v];
                         })
                     ->end()
                     ->prototype('scalar')->end()
@@ -62,14 +62,14 @@ class Configuration implements ConfigurationInterface
                         // taxonomy but we can allow for multiple if they want to.
                         ->ifString()
                         ->then(function ($v) {
-                            return array(array('name' => $v));
+                            return [['name' => $v]];
                         })
                     ->end()
                     ->prototype('array')
                         ->beforeNormalization()
                             ->ifString()
                             ->then(function ($v) {
-                                return array('name' => $v);
+                                return ['name' => $v];
                             })
                         ->end()
                         ->children()

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
@@ -43,7 +43,7 @@ class SculpinContentTypesExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
@@ -12,7 +12,22 @@
 namespace Sculpin\Bundle\ContentTypesBundle\DependencyInjection;
 
 use Doctrine\Common\Inflector\Inflector;
+use Sculpin\Contrib\ProxySourceCollection\ProxySourceCollection;
+use Sculpin\Contrib\ProxySourceCollection\ProxySourceCollectionDataProvider;
+use Sculpin\Contrib\ProxySourceCollection\ProxySourceItem;
+use Sculpin\Contrib\ProxySourceCollection\SimpleProxySourceItemFactory;
+use Sculpin\Contrib\ProxySourceCollection\Sorter\DefaultSorter;
 use Sculpin\Contrib\Taxonomy\PermalinkStrategyCollection;
+use Sculpin\Contrib\Taxonomy\ProxySourceTaxonomyDataProvider;
+use Sculpin\Contrib\Taxonomy\ProxySourceTaxonomyIndexGenerator;
+use Sculpin\Core\Source\Filter\AntPathFilter;
+use Sculpin\Core\Source\Filter\ChainFilter;
+use Sculpin\Core\Source\Filter\DraftsFilter;
+use Sculpin\Core\Source\Filter\MetaFilter;
+use Sculpin\Core\Source\Map\CalculatedDateFromFilenameMap;
+use Sculpin\Core\Source\Map\ChainMap;
+use Sculpin\Core\Source\Map\DefaultDataMap;
+use Sculpin\Core\Source\Map\DraftsMap;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -50,7 +65,7 @@ class SculpinContentTypesExtension extends Extension
 
             $itemClassId = self::generateTypesId($type, 'item.class');
             if (! $container->hasParameter($itemClassId)) {
-                $container->setParameter($itemClassId, 'Sculpin\Contrib\ProxySourceCollection\ProxySourceItem');
+                $container->setParameter($itemClassId, ProxySourceItem::class);
             }
 
             //
@@ -60,7 +75,7 @@ class SculpinContentTypesExtension extends Extension
             $collectionSorterId = self::generateTypesId($type, 'collection.sorter');
 
             if (! $container->hasDefinition($collectionSorterId)) {
-                $collectionSorter = new Definition('Sculpin\Contrib\ProxySourceCollection\Sorter\DefaultSorter');
+                $collectionSorter = new Definition(DefaultSorter::class);
                 $container->setDefinition($collectionSorterId, $collectionSorter);
             }
 
@@ -70,7 +85,7 @@ class SculpinContentTypesExtension extends Extension
 
             $collectionId = self::generateTypesId($type, 'collection');
 
-            $collection = new Definition('Sculpin\Contrib\ProxySourceCollection\ProxySourceCollection');
+            $collection = new Definition(ProxySourceCollection::class);
             $collection->addArgument([]);
             $collection->addArgument(new Reference($collectionSorterId));
             $container->setDefinition($collectionId, $collection);
@@ -92,7 +107,7 @@ class SculpinContentTypesExtension extends Extension
 
                 $pathFilterId = self::generateTypesId($type, 'path_filter');
 
-                $pathFilter = new Definition('Sculpin\Core\Source\Filter\AntPathFilter');
+                $pathFilter = new Definition(AntPathFilter::class);
                 $pathFilter->addArgument($setup['path']);
                 $pathFilter->addArgument(new Reference('sculpin.matcher'));
                 $container->setDefinition($pathFilterId, $pathFilter);
@@ -110,7 +125,7 @@ class SculpinContentTypesExtension extends Extension
 
                 $metaFilterId = self::generateTypesId($type, 'meta_filter');
 
-                $metaFilter = new Definition('Sculpin\Core\Source\Filter\MetaFilter');
+                $metaFilter = new Definition(MetaFilter::class);
                 $metaFilter->addArgument($key);
                 $metaFilter->addArgument($value);
                 $container->setDefinition($metaFilterId, $metaFilter);
@@ -124,7 +139,7 @@ class SculpinContentTypesExtension extends Extension
                 //
 
                 $orFilterId = self::generateTypesId($type, 'or_filter');
-                $orFilter = new Definition('Sculpin\Core\Source\Filter\ChainFilter');
+                $orFilter = new Definition(ChainFilter::class);
                 $orFilter->addArgument($orFilters);
                 $orFilter->addArgument(true);
                 $container->setDefinition($orFilterId, $orFilter);
@@ -144,7 +159,7 @@ class SculpinContentTypesExtension extends Extension
                 $publishDrafts = 'prod' !== $container->getParameter('kernel.environment');
             }
 
-            $draftsFilter = new Definition('Sculpin\Core\Source\Filter\DraftsFilter');
+            $draftsFilter = new Definition(DraftsFilter::class);
             $draftsFilter->addArgument($publishDrafts);
             $container->setDefinition($draftsFilterId, $draftsFilter);
 
@@ -156,7 +171,7 @@ class SculpinContentTypesExtension extends Extension
 
             $filterId = self::generateTypesId($type, 'filter');
 
-            $filter = new Definition('Sculpin\Core\Source\Filter\ChainFilter');
+            $filter = new Definition(ChainFilter::class);
             $filter->addArgument($filters);
             $container->setDefinition($filterId, $filter);
 
@@ -165,7 +180,7 @@ class SculpinContentTypesExtension extends Extension
             //
 
             $defaultDataMapId = self::generateTypesId($type, 'default_data_map');
-            $defaultDataMap = new Definition('Sculpin\Core\Source\Map\DefaultDataMap');
+            $defaultDataMap = new Definition(DefaultDataMap::class);
             $defaultDataMap->addArgument([
                 'layout' => $setup['layout'] ?? $singularName,
                 'permalink' => $setup['permalink'] ?? 'none',
@@ -178,7 +193,7 @@ class SculpinContentTypesExtension extends Extension
             //
 
             $calculatedDateFromFilenameMapId = self::generateTypesId($type, 'calculated_date_from_filename_map');
-            $calculatedDateFromFilenameMap = new Definition('Sculpin\Core\Source\Map\CalculatedDateFromFilenameMap');
+            $calculatedDateFromFilenameMap = new Definition(CalculatedDateFromFilenameMap::class);
             $calculatedDateFromFilenameMap->addTag(self::generateTypesId($type, 'map'));
             $container->setDefinition($calculatedDateFromFilenameMapId, $calculatedDateFromFilenameMap);
 
@@ -187,7 +202,7 @@ class SculpinContentTypesExtension extends Extension
             //
 
             $draftsMapId = self::generateTypesId($type, 'drafts_map');
-            $draftsMap = new Definition('Sculpin\Core\Source\Map\DraftsMap');
+            $draftsMap = new Definition(DraftsMap::class);
             $draftsMap->addTag(self::generateTypesId($type, 'map'));
             $container->setDefinition($draftsMapId, $draftsMap);
 
@@ -196,7 +211,7 @@ class SculpinContentTypesExtension extends Extension
             //
 
             $mapId = self::generateTypesId($type, 'map');
-            $map = new Definition('Sculpin\Core\Source\Map\ChainMap');
+            $map = new Definition(ChainMap::class);
             $container->setDefinition($mapId, $map);
 
             //
@@ -204,7 +219,7 @@ class SculpinContentTypesExtension extends Extension
             //
 
             $factoryId = self::generateTypesId($type, 'item_factory');
-            $factory = new Definition('Sculpin\Contrib\ProxySourceCollection\SimpleProxySourceItemFactory');
+            $factory = new Definition(SimpleProxySourceItemFactory::class);
             $factory->addArgument(self::generatePlaceholder($itemClassId));
             $container->setDefinition($factoryId, $factory);
 
@@ -213,7 +228,7 @@ class SculpinContentTypesExtension extends Extension
             //
 
             $dataProviderId = self::generateTypesId($type, 'data_provider');
-            $dataProvider = new Definition('Sculpin\Contrib\ProxySourceCollection\ProxySourceCollectionDataProvider');
+            $dataProvider = new Definition(ProxySourceCollectionDataProvider::class);
             $dataProvider->addArgument(new Reference('sculpin.formatter_manager'));
             $dataProvider->addArgument($type);
             $dataProvider->addArgument($singularName);
@@ -245,7 +260,7 @@ class SculpinContentTypesExtension extends Extension
                 $reversedName = $taxon.'_'.$type;
 
                 $taxonomyDataProviderId = self::generateTypesId($type, $taxonomyName.'_data_provider');
-                $taxonomyDataProvider = new Definition('Sculpin\Contrib\Taxonomy\ProxySourceTaxonomyDataProvider');
+                $taxonomyDataProvider = new Definition(ProxySourceTaxonomyDataProvider::class);
                 $taxonomyDataProvider->addArgument(new Reference('sculpin.data_provider_manager'));
                 $taxonomyDataProvider->addArgument($type);
                 $taxonomyDataProvider->addArgument($taxonomyName);
@@ -254,7 +269,7 @@ class SculpinContentTypesExtension extends Extension
                 $container->setDefinition($taxonomyDataProviderId, $taxonomyDataProvider);
 
                 $taxonomyIndexGeneratorId = self::generateTypesId($type, $taxonomyName.'_index_generator');
-                $taxonomyIndexGenerator = new Definition('Sculpin\Contrib\Taxonomy\ProxySourceTaxonomyIndexGenerator');
+                $taxonomyIndexGenerator = new Definition(ProxySourceTaxonomyIndexGenerator::class);
                 $taxonomyIndexGenerator->addArgument(new Reference('sculpin.data_provider_manager'));
                 $taxonomyIndexGenerator->addArgument($taxonomyDataProviderName);
                 $taxonomyIndexGenerator->addArgument($taxon);

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -43,10 +43,10 @@ class SculpinContentTypesExtension extends Extension
             }
 
             // What should use use for the singular name?
-            $singularName = isset($setup['singular_name']) ? $setup['singular_name'] : Inflector::singularize($type);
+            $singularName = $setup['singular_name'] ?? Inflector::singularize($type);
 
             // How is the type detected?
-            $detectionTypes = is_array($setup['type']) ? $setup['type'] : array($setup['type']);
+            $detectionTypes = is_array($setup['type']) ? $setup['type'] : [$setup['type']];
 
             $itemClassId = self::generateTypesId($type, 'item.class');
             if (! $container->hasParameter($itemClassId)) {
@@ -71,19 +71,19 @@ class SculpinContentTypesExtension extends Extension
             $collectionId = self::generateTypesId($type, 'collection');
 
             $collection = new Definition('Sculpin\Contrib\ProxySourceCollection\ProxySourceCollection');
-            $collection->addArgument(array());
+            $collection->addArgument([]);
             $collection->addArgument(new Reference($collectionSorterId));
             $container->setDefinition($collectionId, $collection);
 
             // Contains all of our filters.
-            $filters = array();
+            $filters = [];
 
             // Contains all of our "or" filters.
-            $orFilters = array();
+            $orFilters = [];
 
             if (in_array('path', $detectionTypes)) {
                 if (0 == count($setup['path'])) {
-                    $setup['path'] = array('_'.$type);
+                    $setup['path'] = ['_'.$type];
                 }
 
                 //
@@ -105,8 +105,8 @@ class SculpinContentTypesExtension extends Extension
                 // Meta Filter
                 //
 
-                $key = isset($setup['meta_key']) ? $setup['meta_key'] : 'type';
-                $value = isset($setup['meta']) ? $setup['meta'] : $singularName;
+                $key = $setup['meta_key'] ?? 'type';
+                $value = $setup['meta'] ?? $singularName;
 
                 $metaFilterId = self::generateTypesId($type, 'meta_filter');
 
@@ -166,10 +166,10 @@ class SculpinContentTypesExtension extends Extension
 
             $defaultDataMapId = self::generateTypesId($type, 'default_data_map');
             $defaultDataMap = new Definition('Sculpin\Core\Source\Map\DefaultDataMap');
-            $defaultDataMap->addArgument(array(
-                'layout' => isset($setup['layout']) ? $setup['layout'] : $singularName,
-                'permalink' => isset($setup['permalink']) ? $setup['permalink'] : 'none',
-            ));
+            $defaultDataMap->addArgument([
+                'layout' => $setup['layout'] ?? $singularName,
+                'permalink' => $setup['permalink'] ?? 'none',
+            ]);
             $defaultDataMap->addTag(self::generateTypesId($type, 'map'));
             $container->setDefinition($defaultDataMapId, $defaultDataMap);
 
@@ -221,7 +221,7 @@ class SculpinContentTypesExtension extends Extension
             $dataProvider->addArgument(new Reference($filterId));
             $dataProvider->addArgument(new Reference($mapId));
             $dataProvider->addArgument(new Reference($factoryId));
-            $dataProvider->addTag('sculpin.data_provider', array('alias' => $type));
+            $dataProvider->addTag('sculpin.data_provider', ['alias' => $type]);
             $dataProvider->addTag('kernel.event_subscriber');
             $container->setDefinition($dataProviderId, $dataProvider);
 
@@ -250,7 +250,7 @@ class SculpinContentTypesExtension extends Extension
                 $taxonomyDataProvider->addArgument($type);
                 $taxonomyDataProvider->addArgument($taxonomyName);
                 $taxonomyDataProvider->addTag('kernel.event_subscriber');
-                $taxonomyDataProvider->addTag('sculpin.data_provider', array('alias' => $taxonomyDataProviderName));
+                $taxonomyDataProvider->addTag('sculpin.data_provider', ['alias' => $taxonomyDataProviderName]);
                 $container->setDefinition($taxonomyDataProviderId, $taxonomyDataProvider);
 
                 $taxonomyIndexGeneratorId = self::generateTypesId($type, $taxonomyName.'_index_generator');
@@ -260,7 +260,7 @@ class SculpinContentTypesExtension extends Extension
                 $taxonomyIndexGenerator->addArgument($taxon);
                 $taxonomyIndexGenerator->addArgument($reversedName);
                 $taxonomyIndexGenerator->addArgument($permalinkStrategies);
-                $taxonomyIndexGenerator->addTag('sculpin.generator', array('alias' => $taxonomyIndexGeneratorName));
+                $taxonomyIndexGenerator->addTag('sculpin.generator', ['alias' => $taxonomyIndexGeneratorName]);
                 $container->setDefinition($taxonomyIndexGeneratorId, $taxonomyIndexGenerator);
             }
         }
@@ -273,11 +273,11 @@ class SculpinContentTypesExtension extends Extension
 
     private static function generateId($value)
     {
-        return implode('.', array('sculpin_content_types', $value));
+        return implode('.', ['sculpin_content_types', $value]);
     }
 
     private static function generateTypesId($type, $value)
     {
-        return implode('.', array('sculpin_content_types.types', $type, $value));
+        return implode('.', ['sculpin_content_types.types', $type, $value]);
     }
 }

--- a/src/Sculpin/Bundle/ContentTypesBundle/SculpinContentTypesBundle.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/SculpinContentTypesBundle.php
@@ -25,7 +25,7 @@ class SculpinContentTypesBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new MapPass);
     }

--- a/src/Sculpin/Bundle/ContentTypesBundle/SculpinContentTypesBundle.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/SculpinContentTypesBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Bundle\MarkdownBundle\DependencyInjection;
 
+use Sculpin\Bundle\MarkdownBundle\PhpMarkdownExtraParser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -33,7 +34,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('parser_class')
-                    ->defaultValue('Sculpin\Bundle\MarkdownBundle\PhpMarkdownExtraParser')
+                    ->defaultValue(PhpMarkdownExtraParser::class)
                 ->end()
                 ->arrayNode('extensions')
                     ->defaultValue(['md', 'mdown', 'mkdn', 'markdown'])

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -36,7 +36,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('Sculpin\Bundle\MarkdownBundle\PhpMarkdownExtraParser')
                 ->end()
                 ->arrayNode('extensions')
-                    ->defaultValue(array('md', 'mdown', 'mkdn', 'markdown'))
+                    ->defaultValue(['md', 'mdown', 'mkdn', 'markdown'])
                     ->prototype('scalar')->end()
                 ->end()
             ->end();

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\MarkdownBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -31,7 +31,7 @@ class SculpinMarkdownExtension extends Extension
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('sculpin_markdown.parser.class', $config['parser_class']);

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
@@ -26,7 +26,7 @@ class SculpinMarkdownExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -91,7 +91,6 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
      * This method is called to generate an id="" attribute for a header.
      *
      * @param string $headerText raw markdown input for the header name
-     * @return string
      */
     public function generateHeaderId(string $headerText): string
     {

--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -37,18 +37,17 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
      *
      * @var array
      */
-    protected $extensions = array();
+    protected $extensions = [];
 
     /**
      * Constructor.
      *
-     * @param ParserInterface $markdown
      * @param array           $extensions Extensions
      */
-    public function __construct(ParserInterface $markdown, array $extensions = array())
+    public function __construct(ParserInterface $markdown, array $extensions = [])
     {
         $this->markdown = $markdown;
-        $this->markdown->header_id_func = array($this, 'generateHeaderId');
+        $this->markdown->header_id_func = [$this, 'generateHeaderId'];
         $this->extensions = $extensions;
     }
 
@@ -65,9 +64,9 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             Sculpin::EVENT_BEFORE_RUN => 'beforeRun',
-        );
+        ];
     }
 
     /**
@@ -94,7 +93,7 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
      * @param string $headerText raw markdown input for the header name
      * @return string
      */
-    public function generateHeaderId($headerText)
+    public function generateHeaderId(string $headerText): string
     {
 
         // $headerText is completely raw markdown input. We need to strip it
@@ -118,13 +117,13 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
 
         // Step 3: Convert spaces to dashes, and remove unwanted special
         // characters.
-        $map = array(
+        $map = [
             ' ' => '-',
             '(' => '',
             ')' => '',
             '[' => '',
             ']' => '',
-        );
+        ];
         return rawurlencode(strtolower(
             strtr($result, $map)
         ));

--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -54,7 +54,7 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(ConverterContextInterface $converterContext)
+    public function convert(ConverterContextInterface $converterContext): void
     {
         $converterContext->setContent($this->markdown->transform($converterContext->content()));
     }
@@ -74,7 +74,7 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
      *
      * @param SourceSetEvent $sourceSetEvent Source Set Event
      */
-    public function beforeRun(SourceSetEvent $sourceSetEvent)
+    public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
         foreach ($sourceSetEvent->updatedSources() as $source) {
             foreach ($this->extensions as $extension) {

--- a/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownExtraParser.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownExtraParser.php
@@ -13,7 +13,7 @@ class PhpMarkdownExtraParser extends MarkdownExtra implements ParserInterface
     /**
      * {@inheritdoc}
      */
-    public function transform($content)
+    public function transform($content): string
     {
         return parent::transform($content);
     }

--- a/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownExtraParser.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownExtraParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Bundle\MarkdownBundle;
 

--- a/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownParser.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownParser.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Bundle\MarkdownBundle;
 

--- a/src/Sculpin/Bundle/MarkdownBundle/SculpinMarkdownBundle.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/SculpinMarkdownBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/MarkdownBundle/SculpinMarkdownBundle.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/SculpinMarkdownBundle.php
@@ -20,5 +20,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SculpinMarkdownBundle extends Bundle
 {
-    const CONVERTER_NAME = 'markdown';
+    public const CONVERTER_NAME = 'markdown';
 }

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/ConvertListener.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/ConvertListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -29,11 +29,11 @@ class ConvertListener implements EventSubscriberInterface
      *
      * @var array
      */
-    protected static $addPlaceholderRe = array(
+    protected static $addPlaceholderRe = [
         '/^({%\s+block\s+(\w+).+?%})$/m',  // {% %} style code
         '/^({%\s+endblock\s+%})$/m',       // {% %} style code
         '/^({{.+?}})$/m',                  // {{ }} style code
-    );
+    ];
 
     /**
      * Placeholder text
@@ -54,10 +54,10 @@ class ConvertListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             Sculpin::EVENT_BEFORE_CONVERT => 'beforeConvert',
             Sculpin::EVENT_AFTER_CONVERT => 'afterConvert',
-        );
+        ];
     }
 
     /**

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/ConvertListener.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/ConvertListener.php
@@ -65,7 +65,7 @@ class ConvertListener implements EventSubscriberInterface
      *
      * @param ConvertEvent $convertEvent Convert Event
      */
-    public function beforeConvert(ConvertEvent $convertEvent)
+    public function beforeConvert(ConvertEvent $convertEvent): void
     {
         if ($convertEvent->isHandledBy(SculpinMarkdownBundle::CONVERTER_NAME, SculpinTwigBundle::FORMATTER_NAME)) {
             $content = $convertEvent->source()->content();
@@ -86,7 +86,7 @@ class ConvertListener implements EventSubscriberInterface
      *
      * @param ConvertEvent $convertEvent Convert event
      */
-    public function afterConvert(ConvertEvent $convertEvent)
+    public function afterConvert(ConvertEvent $convertEvent): void
     {
         if ($convertEvent->isHandledBy(SculpinMarkdownBundle::CONVERTER_NAME, SculpinTwigBundle::FORMATTER_NAME)) {
             $content = $convertEvent->source()->content();

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/DependencyInjection/SculpinMarkdownTwigCompatExtension.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/DependencyInjection/SculpinMarkdownTwigCompatExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\MarkdownTwigCompatBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -28,7 +28,7 @@ class SculpinMarkdownTwigCompatExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
     }
 }

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/DependencyInjection/SculpinMarkdownTwigCompatExtension.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/DependencyInjection/SculpinMarkdownTwigCompatExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/DependencyInjection/SculpinMarkdownTwigCompatExtension.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/DependencyInjection/SculpinMarkdownTwigCompatExtension.php
@@ -26,7 +26,7 @@ class SculpinMarkdownTwigCompatExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/SculpinMarkdownTwigCompatBundle.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/SculpinMarkdownTwigCompatBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\PaginationBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -31,7 +31,7 @@ class SculpinPaginationExtension extends Extension
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('sculpin_pagination.max_per_page', $config['max_per_page']);

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
@@ -26,7 +26,7 @@ class SculpinPaginationExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
+++ b/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -42,7 +42,7 @@ class PaginationGenerator implements GeneratorInterface
      * @param DataProviderManager $dataProviderManager Data Provider Manager
      * @param int                 $maxPerPage          Max items per page
      */
-    public function __construct(DataProviderManager $dataProviderManager, $maxPerPage)
+    public function __construct(DataProviderManager $dataProviderManager, int $maxPerPage)
     {
         $this->dataProviderManager = $dataProviderManager;
         $this->maxPerPage = $maxPerPage;
@@ -54,7 +54,7 @@ class PaginationGenerator implements GeneratorInterface
     public function generate(SourceInterface $source)
     {
         $data = null;
-        $config = $source->data()->get('pagination') ?: array();
+        $config = $source->data()->get('pagination') ?: [];
         if (!isset($config['provider'])) {
             $config['provider'] = 'data.posts';
         }
@@ -63,7 +63,7 @@ class PaginationGenerator implements GeneratorInterface
                 case 'data':
                     $data = $this->dataProviderManager->dataProvider($matches[2])->provideData();
                     if (!count($data)) {
-                        $data = array('');
+                        $data = [''];
                     }
                     break;
                 case 'page':
@@ -76,15 +76,15 @@ class PaginationGenerator implements GeneratorInterface
             return;
         }
 
-        $maxPerPage = isset($config['max_per_page']) ? $config['max_per_page'] : $this->maxPerPage;
+        $maxPerPage = $config['max_per_page'] ?? $this->maxPerPage;
 
-        $slices = array();
-        $slice = array();
+        $slices = [];
+        $slice = [];
         $totalItems = 0;
         foreach ($data as $k => $v) {
             if (count($slice) == $maxPerPage) {
                 $slices[] = $slice;
-                $slice = array();
+                $slice = [];
             }
 
             $slice[$k] = $v;
@@ -95,7 +95,7 @@ class PaginationGenerator implements GeneratorInterface
             $slices[] = $slice;
         }
 
-        $sources = array();
+        $sources = [];
         $pageNumber = 0;
         foreach ($slices as $slice) {
             $pageNumber++;

--- a/src/Sculpin/Bundle/PaginationBundle/SculpinPaginationBundle.php
+++ b/src/Sculpin/Bundle/PaginationBundle/SculpinPaginationBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
@@ -11,9 +11,9 @@
 
 namespace Sculpin\Bundle\PostsBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * Sculpin Posts Extension.

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
@@ -25,7 +25,7 @@ class SculpinPostsExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/PostsBundle/SculpinPostsBundle.php
+++ b/src/Sculpin/Bundle/PostsBundle/SculpinPostsBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
@@ -22,8 +22,6 @@ abstract class AbstractCommand extends ContainerAwareCommand
 {
     /**
      * Test to see if Sculpin is running in standalone mode.
-     *
-     * @return bool
      */
     protected function isStandaloneSculpin(): bool
     {

--- a/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
+use Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle;
 use Sculpin\Core\Console\Command\ContainerAwareCommand;
 
 /**
@@ -25,6 +26,6 @@ abstract class AbstractCommand extends ContainerAwareCommand
      */
     protected function isStandaloneSculpin(): bool
     {
-        return class_exists('Sculpin\\Bundle\\StandaloneBundle\\SculpinStandaloneBundle', false);
+        return class_exists(SculpinStandaloneBundle::class, false);
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -25,7 +25,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
      *
      * @return bool
      */
-    protected function isStandaloneSculpin()
+    protected function isStandaloneSculpin(): bool
     {
         return class_exists('Sculpin\\Bundle\\StandaloneBundle\\SculpinStandaloneBundle', false);
     }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -28,13 +28,13 @@
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
+use Sculpin\Core\Console\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Definition;
-use Sculpin\Core\Console\Command\ContainerAwareCommand;
 
 /**
  * A console command for retrieving information about services

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -47,7 +47,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('container:debug')
@@ -124,7 +124,7 @@ EOF
      *
      * @throws \LogicException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $this->validateInput($input);
 
@@ -170,7 +170,7 @@ EOF
         }
     }
 
-    protected function validateInput(InputInterface $input)
+    protected function validateInput(InputInterface $input): void
     {
         $options = ['tags', 'tag', 'parameters', 'parameter'];
 
@@ -198,7 +198,7 @@ EOF
         $serviceIds,
         $showPrivate = false,
         $showTagAttributes = null
-    ) {
+    ): void {
         // set the label to specify public or public+private
         if ($showPrivate) {
             $label = '<comment>Public</comment> and <comment>private</comment> services';
@@ -337,7 +337,7 @@ EOF
     /**
      * Renders detailed service information about one service
      */
-    protected function outputService(OutputInterface $output, $serviceId)
+    protected function outputService(OutputInterface $output, $serviceId): void
     {
         $definition = $this->resolveServiceDefinition($serviceId);
 
@@ -392,7 +392,7 @@ EOF
         }
     }
 
-    protected function outputParameters(OutputInterface $output, $parameters)
+    protected function outputParameters(OutputInterface $output, $parameters): void
     {
         $output->writeln($this->getHelper('formatter')->formatSection('container', 'List of parameters'));
 
@@ -460,7 +460,7 @@ EOF
     /**
      * Renders list of tagged services grouped by tag
      */
-    protected function outputTags(OutputInterface $output, bool $showPrivate = false)
+    protected function outputTags(OutputInterface $output, bool $showPrivate = false): void
     {
         $tags = $this->getContainer()->findTags();
         asort($tags);

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -458,8 +458,6 @@ EOF
 
     /**
      * Renders list of tagged services grouped by tag
-     *
-     * @param bool            $showPrivate
      */
     protected function outputTags(OutputInterface $output, bool $showPrivate = false)
     {

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -28,6 +28,7 @@
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
+use InvalidArgumentException;
 use Sculpin\Core\Console\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -182,11 +183,11 @@ EOF
 
         $name = $input->getArgument('name');
         if ((null !== $name) && ($optionsCount > 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'The options tags, tag, parameters & parameter can not be combined with the service name argument.'
             );
         } elseif ((null === $name) && $optionsCount > 1) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'The options tags, tag, parameters & parameter can not be combined together.'
             );
         }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is part of the Symfony package.
@@ -50,7 +50,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
     {
         $this
             ->setName('container:debug')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
                 new InputOption(
                     'show-private',
@@ -82,7 +82,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
                     InputOption::VALUE_NONE,
                     'Displays parameters for an application'
                 )
-            ))
+            ])
             ->setDescription('Displays current services for an application')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command displays all configured <comment>public</comment> services:
@@ -171,7 +171,7 @@ EOF
 
     protected function validateInput(InputInterface $input)
     {
-        $options = array('tags', 'tag', 'parameters', 'parameter');
+        $options = ['tags', 'tag', 'parameters', 'parameter'];
 
         $optionsCount = 0;
         foreach ($options as $option) {
@@ -213,7 +213,7 @@ EOF
         // loop through to get space needed and filter private services
         $maxName = 4;
         $maxScope = 6;
-        $maxTags = array();
+        $maxTags = [];
         foreach ($serviceIds as $key => $serviceId) {
             $definition = $this->resolveServiceDefinition($serviceId);
 
@@ -260,7 +260,7 @@ EOF
         }, $maxTags));
         $format1 .= '%-'.($maxScope + 19).'s %s';
 
-        $tags = array();
+        $tags = [];
         foreach ($maxTags as $tagName => $length) {
             $tags[] = '<comment>'.$tagName.'</comment>';
         }
@@ -275,12 +275,12 @@ EOF
             $definition = $this->resolveServiceDefinition($serviceId);
 
             if ($definition instanceof Definition) {
-                $lines = array();
+                $lines = [];
                 if (null !== $showTagAttributes) {
                     foreach ($definition->getTag($showTagAttributes) as $key => $tag) {
-                        $tagValues = array();
+                        $tagValues = [];
                         foreach (array_keys($maxTags) as $tagName) {
-                            $tagValues[] = isset($tag[$tagName]) ? $tag[$tagName] : "";
+                            $tagValues[] = $tag[$tagName] ?? "";
                         }
                         if (0 === $key) {
                             $lines[] = $this->buildArgumentsArray(
@@ -306,7 +306,7 @@ EOF
                     $serviceId,
                     'n/a',
                     sprintf('<comment>alias for</comment> <info>%s</info>', (string) $alias),
-                    count($maxTags) ? array_fill(0, count($maxTags), "") : array()
+                    count($maxTags) ? array_fill(0, count($maxTags), "") : []
                 )));
             } else {
                 // we have no information (happens with "service_container")
@@ -315,15 +315,15 @@ EOF
                     $serviceId,
                     '',
                     get_class($service),
-                    count($maxTags) ? array_fill(0, count($maxTags), "") : array()
+                    count($maxTags) ? array_fill(0, count($maxTags), "") : []
                 )));
             }
         }
     }
 
-    protected function buildArgumentsArray($serviceId, $scope, $className, array $tagAttributes = array())
+    protected function buildArgumentsArray($serviceId, $scope, $className, array $tagAttributes = [])
     {
-        $arguments = array($serviceId);
+        $arguments = [$serviceId];
         foreach ($tagAttributes as $tagAttribute) {
             $arguments[] = $tagAttribute;
         }
@@ -441,7 +441,7 @@ EOF
      *
      * @return Definition|Alias
      */
-    protected function resolveServiceDefinition($serviceId)
+    protected function resolveServiceDefinition(string $serviceId)
     {
         if ($this->getContainer()->hasDefinition($serviceId)) {
             return $this->getContainer()->getDefinition($serviceId);
@@ -459,10 +459,9 @@ EOF
     /**
      * Renders list of tagged services grouped by tag
      *
-     * @param OutputInterface $output
      * @param bool            $showPrivate
      */
-    protected function outputTags(OutputInterface $output, $showPrivate = false)
+    protected function outputTags(OutputInterface $output, bool $showPrivate = false)
     {
         $tags = $this->getContainer()->findTags();
         asort($tags);

--- a/src/Sculpin/Bundle/SculpinBundle/Command/DumpAutoloadCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/DumpAutoloadCommand.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
 use Dflydev\EmbeddedComposer\Console\Command\DumpAutoloadCommand as BaseDumpAutoloadCommand;
+use Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle;
 
 /**
  * Dump Autoload Command.
@@ -25,7 +26,7 @@ class DumpAutoloadCommand extends BaseDumpAutoloadCommand
      */
     public function __construct($commandPrefix = 'sculpin:')
     {
-        $prefix = class_exists('Sculpin\\Bundle\\StandaloneBundle\\SculpinStandaloneBundle', false)
+        $prefix = class_exists(SculpinStandaloneBundle::class, false)
             ? ''
             : $commandPrefix;
 

--- a/src/Sculpin/Bundle/SculpinBundle/Command/DumpAutoloadCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/DumpAutoloadCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -36,7 +36,7 @@ class GenerateCommand extends AbstractCommand
         $this
             ->setName($prefix.'generate')
             ->setDescription('Generate a site from source.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption(
                     'clean',
                     null,
@@ -57,7 +57,7 @@ class GenerateCommand extends AbstractCommand
                 ),
                 new InputOption('url', null, InputOption::VALUE_REQUIRED, 'Override URL.'),
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Port'),
-            ))
+            ])
             ->setHelp(<<<EOT
 The <info>generate</info> command generates a site.
 
@@ -134,7 +134,7 @@ EOT
      * @param OutputInterface $output An OutputInterface instance
      * @param string          $dir    The directory to remove
      */
-    protected function clean(InputInterface $input, OutputInterface $output, $dir)
+    protected function clean(InputInterface $input, OutputInterface $output, string $dir)
     {
         $fileSystem = $this->getContainer()->get('filesystem');
         if ($fileSystem->exists($dir)) {

--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -29,7 +29,7 @@ class GenerateCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $prefix = $this->isStandaloneSculpin() ? '' : 'sculpin:';
 
@@ -68,7 +68,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         foreach ($this->getApplication()->getMissingSculpinBundlesMessages() as $message) {
             $output->writeln($message);
@@ -105,7 +105,7 @@ EOT
             );
 
             if ($watch) {
-                $httpServer->addPeriodicTimer(1, function () use ($sculpin, $dataSource, $sourceSet, $consoleIo) {
+                $httpServer->addPeriodicTimer(1, function () use ($sculpin, $dataSource, $sourceSet, $consoleIo): void {
                     clearstatcache();
                     $sourceSet->reset();
 
@@ -132,7 +132,7 @@ EOT
      *
      * @param string          $dir    The directory to remove
      */
-    protected function clean(InputInterface $input, OutputInterface $output, string $dir)
+    protected function clean(InputInterface $input, OutputInterface $output, string $dir): void
     {
         $fileSystem = $this->getContainer()->get('filesystem');
         if ($fileSystem->exists($dir)) {

--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -130,8 +130,6 @@ EOT
     /**
      * Cleanup an output directory by deleting it.
      *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
      * @param string          $dir    The directory to remove
      */
     protected function clean(InputInterface $input, OutputInterface $output, string $dir)

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InstallCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InstallCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InstallCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InstallCommand.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
 use Dflydev\EmbeddedComposer\Console\Command\InstallCommand as BaseInstallCommand;
+use Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle;
 
 /**
  * Install Command.
@@ -25,7 +26,7 @@ class InstallCommand extends BaseInstallCommand
      */
     public function __construct($commandPrefix = 'sculpin:')
     {
-        $prefix = class_exists('Sculpin\\Bundle\\StandaloneBundle\\SculpinStandaloneBundle', false)
+        $prefix = class_exists(SculpinStandaloneBundle::class, false)
             ? ''
             : $commandPrefix;
 

--- a/src/Sculpin/Bundle/SculpinBundle/Command/SelfUpdateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/SelfUpdateCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -44,7 +44,7 @@ class SelfUpdateCommand extends AbstractCommand
         $fullCommand = $this->commandPrefix.'self-update';
         $this
             ->setName($fullCommand)
-            ->setAliases(array($this->commandPrefix.'selfupdate'))
+            ->setAliases([$this->commandPrefix.'selfupdate'])
             ->setDescription('Updates sculpin to the latest version.')
             ->setHelp(<<<EOT
 The <info>self-update</info> command checks for newer versions of sculpin and if found,
@@ -83,7 +83,7 @@ EOT
             throw new FilesystemException('Sculpin update failed: the "'.$localFilename. '" file could not be written');
         }
 
-        set_error_handler(array($this, 'handleError'));
+        set_error_handler([$this, 'handleError']);
 
         $protocol = extension_loaded('openssl') ? 'https' : 'http';
 
@@ -122,7 +122,7 @@ EOT
                 // free the variable to unlock the file
                 unset($phar);
                 rename($tempFilename, $localFilename);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 @unlink($tempFilename);
                 if (!$e instanceof \UnexpectedValueException && !$e instanceof \PharException) {
                     throw $e;
@@ -144,7 +144,7 @@ EOT
      */
     protected function getStreamContext()
     {
-        $options = array('http' => array());
+        $options = ['http' => []];
 
         // Handle system proxy
         if (!empty($_SERVER['HTTP_PROXY']) || !empty($_SERVER['http_proxy'])) {
@@ -154,7 +154,7 @@ EOT
 
         if (!empty($proxy)) {
             $proxyURL = isset($proxy['scheme']) ? $proxy['scheme'] . '://' : '';
-            $proxyURL .= isset($proxy['host']) ? $proxy['host'] : '';
+            $proxyURL .= $proxy['host'] ?? '';
 
             if (isset($proxy['port'])) {
                 $proxyURL .= ":" . $proxy['port'];
@@ -165,16 +165,16 @@ EOT
             }
 
             // http(s):// is not supported in proxy
-            $proxyURL = str_replace(array('http://', 'https://'), array('tcp://', 'ssl://'), $proxyURL);
+            $proxyURL = str_replace(['http://', 'https://'], ['tcp://', 'ssl://'], $proxyURL);
 
             if (0 === strpos($proxyURL, 'ssl:') && !extension_loaded('openssl')) {
                 throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');
             }
 
-            $options['http'] = array(
+            $options['http'] = [
                 'proxy'           => $proxyURL,
                 'request_fulluri' => true,
-            );
+            ];
 
             if (isset($proxy['user'])) {
                 $auth = $proxy['user'];

--- a/src/Sculpin/Bundle/SculpinBundle/Command/SelfUpdateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/SelfUpdateCommand.php
@@ -44,7 +44,7 @@ class SelfUpdateCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $fullCommand = $this->commandPrefix.'self-update';
         $this
@@ -195,7 +195,7 @@ EOT
         return stream_context_create($options);
     }
 
-    public function handleError($code, $msg)
+    public function handleError($code, $msg): void
     {
         if ($this->message) {
             $this->message .= "\n";

--- a/src/Sculpin/Bundle/SculpinBundle/Command/SelfUpdateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/SelfUpdateCommand.php
@@ -12,9 +12,14 @@
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
 use Composer\Downloader\FilesystemException;
+use Phar;
+use PharException;
+use RuntimeException;
 use Sculpin\Core\Sculpin;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use UnexpectedValueException;
 
 /**
  * @author Igor Wiedler <igor@wiedler.ch>
@@ -118,13 +123,13 @@ EOT
             try {
                 chmod($tempFilename, 0777 & ~umask());
                 // test the phar validity
-                $phar = new \Phar($tempFilename);
+                $phar = new Phar($tempFilename);
                 // free the variable to unlock the file
                 unset($phar);
                 rename($tempFilename, $localFilename);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 @unlink($tempFilename);
-                if (!$e instanceof \UnexpectedValueException && !$e instanceof \PharException) {
+                if (!$e instanceof UnexpectedValueException && !$e instanceof PharException) {
                     throw $e;
                 }
                 $output->writeln('<error>The download is corrupted ('.$e->getMessage().').</error>');
@@ -168,7 +173,7 @@ EOT
             $proxyURL = str_replace(['http://', 'https://'], ['tcp://', 'ssl://'], $proxyURL);
 
             if (0 === strpos($proxyURL, 'ssl:') && !extension_loaded('openssl')) {
-                throw new \RuntimeException('You must enable the openssl extension to use a proxy over https');
+                throw new RuntimeException('You must enable the openssl extension to use a proxy over https');
             }
 
             $options['http'] = [

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
@@ -26,7 +26,7 @@ class ServeCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $prefix = $this->isStandaloneSculpin() ? '' : 'sculpin:';
 
@@ -46,7 +46,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $docroot = $this->getContainer()->getParameter('sculpin.output_dir');
         $kernel = $this->getContainer()->get('kernel');

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -33,14 +33,14 @@ class ServeCommand extends AbstractCommand
         $this
             ->setName($prefix.'serve')
             ->setDescription('Serve a site.')
-            ->setDefinition(array(
+            ->setDefinition([
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Port'),
-            ))
+            ])
             ->setHelp(<<<EOT
 The <info>serve</info> command serves a site.
 
 EOT
-            )->setAliases(array('server'));
+            )->setAliases(['server']);
     }
 
     /**

--- a/src/Sculpin/Bundle/SculpinBundle/Command/UpdateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/UpdateCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/Command/UpdateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/UpdateCommand.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
 use Dflydev\EmbeddedComposer\Console\Command\UpdateCommand as BaseUpdateCommand;
+use Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle;
 
 /**
  * Update Command.
@@ -25,7 +26,7 @@ class UpdateCommand extends BaseUpdateCommand
      */
     public function __construct($commandPrefix = 'sculpin:')
     {
-        $prefix = class_exists('Sculpin\\Bundle\\StandaloneBundle\\SculpinStandaloneBundle', false)
+        $prefix = class_exists(SculpinStandaloneBundle::class, false)
             ? ''
             : $commandPrefix;
 

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -13,11 +13,11 @@ namespace Sculpin\Bundle\SculpinBundle\Console;
 
 use Dflydev\EmbeddedComposer\Core\EmbeddedComposerAwareInterface;
 use Dflydev\EmbeddedComposer\Core\EmbeddedComposerInterface;
-use Sculpin\Core\Sculpin;
 use Sculpin\Bundle\SculpinBundle\Command\DumpAutoloadCommand;
 use Sculpin\Bundle\SculpinBundle\Command\InstallCommand;
 use Sculpin\Bundle\SculpinBundle\Command\SelfUpdateCommand;
 use Sculpin\Bundle\SculpinBundle\Command\UpdateCommand;
+use Sculpin\Core\Sculpin;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -107,7 +107,7 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
     /**
      * {@inheritDoc}
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null)
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null)
     {
         if (null === $output) {
             $styles = [
@@ -172,14 +172,13 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
     /**
      * Get Kernel
      *
-     * @return KernelInterface
      */
     public function getKernel(): KernelInterface
     {
         return $this->kernel;
     }
 
-    protected function registerCommands()
+    protected function registerCommands(): void
     {
         $this->kernel->boot();
 

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -111,10 +111,10 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
         if (null === $output) {
-            $styles = array(
+            $styles = [
                 'highlight' => new OutputFormatterStyle('red'),
                 'warning' => new OutputFormatterStyle('black', 'yellow'),
-            );
+            ];
             $formatter = new OutputFormatter(null, $styles);
             $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_NORMAL, null, $formatter);
         }
@@ -155,7 +155,7 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
 
     public function getMissingSculpinBundlesMessages()
     {
-        $messages = array();
+        $messages = [];
 
         // Display missing bundle to user.
         if ($missingBundles = $this->kernel->getMissingSculpinBundles()) {
@@ -175,7 +175,7 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
      *
      * @return KernelInterface
      */
-    public function getKernel()
+    public function getKernel(): KernelInterface
     {
         return $this->kernel;
     }

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -41,7 +41,6 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
     /**
      * Constructor.
      *
-     * @param KernelInterface           $kernel           A KernelInterface instance
      * @param EmbeddedComposerInterface $embeddedComposer Composer Class Loader
      */
     public function __construct(KernelInterface $kernel, EmbeddedComposerInterface $embeddedComposer)

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -171,7 +171,6 @@ class Application extends BaseApplication implements EmbeddedComposerAwareInterf
 
     /**
      * Get Kernel
-     *
      */
     public function getKernel(): KernelInterface
     {

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
@@ -25,7 +25,7 @@ class ConverterManagerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin.converter_manager')) {
             return;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -35,7 +35,7 @@ class ConverterManagerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sculpin.converter') as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
-                $definition->addMethodCall('registerConverter', array($attributes['alias'], new Reference($id)));
+                $definition->addMethodCall('registerConverter', [$attributes['alias'], new Reference($id)]);
             }
         }
     }

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
@@ -11,8 +11,8 @@
 
 namespace Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/CustomMimeTypesRepositoryPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/CustomMimeTypesRepositoryPass.php
@@ -24,7 +24,7 @@ class CustomMimeTypesRepositoryPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin.custom_mime_types_repository')) {
             return;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/CustomMimeTypesRepositoryPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/CustomMimeTypesRepositoryPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -32,7 +32,7 @@ class CustomMimeTypesRepositoryPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('sculpin.custom_mime_types_repository');
 
-        $data = array();
+        $data = [];
         foreach ($container->findTaggedServiceIds('sculpin.custom_mime_extensions') as $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
                 $type = $attributes['type'];

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataProviderManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataProviderManagerPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -35,7 +35,7 @@ class DataProviderManagerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sculpin.data_provider') as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
-                $definition->addMethodCall('registerDataProvider', array($attributes['alias'], new Reference($id)));
+                $definition->addMethodCall('registerDataProvider', [$attributes['alias'], new Reference($id)]);
             }
         }
     }

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataProviderManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataProviderManagerPass.php
@@ -25,7 +25,7 @@ class DataProviderManagerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin.data_provider_manager')) {
             return;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -34,7 +34,7 @@ class DataSourcePass implements CompilerPassInterface
         $definition = $container->getDefinition('sculpin.data_source');
 
         foreach ($container->findTaggedServiceIds('sculpin.data_source') as $id => $tagAttributes) {
-            $definition->addMethodCall('addDataSource', array(new Reference($id)));
+            $definition->addMethodCall('addDataSource', [new Reference($id)]);
         }
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
@@ -25,7 +25,7 @@ class DataSourcePass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin.data_source')) {
             return;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
@@ -11,8 +11,8 @@
 
 namespace Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
@@ -25,7 +25,7 @@ class FormatterManagerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin.formatter_manager')) {
             return;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -35,7 +35,7 @@ class FormatterManagerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sculpin.formatter') as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
-                $definition->addMethodCall('registerFormatter', array($attributes['alias'], new Reference($id)));
+                $definition->addMethodCall('registerFormatter', [$attributes['alias'], new Reference($id)]);
             }
         }
     }

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
@@ -25,7 +25,7 @@ class GeneratorManagerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin.generator_manager')) {
             return;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
@@ -11,8 +11,8 @@
 
 namespace Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -35,7 +35,7 @@ class GeneratorManagerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sculpin.generator') as $id => $tagAttributes) {
             foreach ($tagAttributes as $attributes) {
-                $definition->addMethodCall('registerGenerator', array($attributes['alias'], new Reference($id)));
+                $definition->addMethodCall('registerGenerator', [$attributes['alias'], new Reference($id)]);
             }
         }
     }

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/PathConfiguratorPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/PathConfiguratorPass.php
@@ -40,7 +40,7 @@ class PathConfiguratorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach ($container->findTaggedServiceIds('sculpin.path_configurator') as $tagAttributes) {
             foreach ($tagAttributes as $attributes) {

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/PathConfiguratorPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/PathConfiguratorPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -50,7 +50,7 @@ class PathConfiguratorPass implements CompilerPassInterface
                 if ($container->hasParameter($parameter)) {
                     $value = $container->getParameter($parameter);
                     if (! is_array($value)) {
-                        $value = array($value);
+                        $value = [$value];
                     }
 
                     if ($container->hasParameter($typeParameter)) {

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
@@ -26,7 +26,7 @@ class SculpinExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\SculpinBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -31,7 +31,7 @@ class SculpinExtension extends Extension
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         foreach ($config as $key => $value) {

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Kernel;
 abstract class AbstractKernel extends Kernel
 {
     protected $projectDir;
-    protected $missingSculpinBundles = array();
+    protected $missingSculpinBundles = [];
 
     /**
      * {@inheritdoc}
@@ -48,9 +48,9 @@ abstract class AbstractKernel extends Kernel
             $this->projectDir = dirname($this->rootDir);
         }
 
-        return array_merge(parent::getKernelParameters(), array(
+        return array_merge(parent::getKernelParameters(), [
             'sculpin.project_dir' => $this->projectDir,
-        ));
+        ]);
     }
 
     /**
@@ -58,7 +58,7 @@ abstract class AbstractKernel extends Kernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
             new \Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle,
             new \Sculpin\Bundle\MarkdownBundle\SculpinMarkdownBundle,
             new \Sculpin\Bundle\TextileBundle\SculpinTextileBundle,
@@ -69,7 +69,7 @@ abstract class AbstractKernel extends Kernel
             new \Sculpin\Bundle\TwigBundle\SculpinTwigBundle,
             new \Sculpin\Bundle\ContentTypesBundle\SculpinContentTypesBundle,
             new \Sculpin\Bundle\PostsBundle\SculpinPostsBundle,
-        );
+        ];
 
         foreach ($this->getAdditionalSculpinBundles() as $class) {
             if (class_exists($class)) {
@@ -153,7 +153,7 @@ abstract class AbstractKernel extends Kernel
      *
      * @return array
      */
-    public function getMissingSculpinBundles()
+    public function getMissingSculpinBundles(): array
     {
         return $this->missingSculpinBundles;
     }
@@ -163,5 +163,5 @@ abstract class AbstractKernel extends Kernel
      *
      * @return array
      */
-    abstract protected function getAdditionalSculpinBundles();
+    abstract protected function getAdditionalSculpinBundles(): array;
 }

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -95,7 +95,7 @@ abstract class AbstractKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         // Load defaults.
         $loader->load(__DIR__.'/../Resources/config/kernel.yml');
@@ -110,7 +110,7 @@ abstract class AbstractKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function boot()
+    public function boot(): void
     {
         if (true === $this->booted) {
             return;
@@ -145,7 +145,7 @@ abstract class AbstractKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    protected function initializeContainer()
+    protected function initializeContainer(): void
     {
         $container = $this->buildContainer();
         $container->set('kernel', $this);

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -11,6 +11,16 @@
 
 namespace Sculpin\Bundle\SculpinBundle\HttpKernel;
 
+use Sculpin\Bundle\ContentTypesBundle\SculpinContentTypesBundle;
+use Sculpin\Bundle\MarkdownBundle\SculpinMarkdownBundle;
+use Sculpin\Bundle\MarkdownTwigCompatBundle\SculpinMarkdownTwigCompatBundle;
+use Sculpin\Bundle\PaginationBundle\SculpinPaginationBundle;
+use Sculpin\Bundle\PostsBundle\SculpinPostsBundle;
+use Sculpin\Bundle\SculpinBundle\SculpinBundle;
+use Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle;
+use Sculpin\Bundle\TextileBundle\SculpinTextileBundle;
+use Sculpin\Bundle\ThemeBundle\SculpinThemeBundle;
+use Sculpin\Bundle\TwigBundle\SculpinTwigBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -59,16 +69,16 @@ abstract class AbstractKernel extends Kernel
     public function registerBundles()
     {
         $bundles = [
-            new \Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle,
-            new \Sculpin\Bundle\MarkdownBundle\SculpinMarkdownBundle,
-            new \Sculpin\Bundle\TextileBundle\SculpinTextileBundle,
-            new \Sculpin\Bundle\MarkdownTwigCompatBundle\SculpinMarkdownTwigCompatBundle,
-            new \Sculpin\Bundle\PaginationBundle\SculpinPaginationBundle,
-            new \Sculpin\Bundle\SculpinBundle\SculpinBundle,
-            new \Sculpin\Bundle\ThemeBundle\SculpinThemeBundle,
-            new \Sculpin\Bundle\TwigBundle\SculpinTwigBundle,
-            new \Sculpin\Bundle\ContentTypesBundle\SculpinContentTypesBundle,
-            new \Sculpin\Bundle\PostsBundle\SculpinPostsBundle,
+            new SculpinStandaloneBundle,
+            new SculpinMarkdownBundle,
+            new SculpinTextileBundle,
+            new SculpinMarkdownTwigCompatBundle,
+            new SculpinPaginationBundle,
+            new SculpinBundle,
+            new SculpinThemeBundle,
+            new SculpinTwigBundle,
+            new SculpinContentTypesBundle,
+            new SculpinPostsBundle,
         ];
 
         foreach ($this->getAdditionalSculpinBundles() as $class) {

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -150,8 +150,6 @@ abstract class AbstractKernel extends Kernel
      * things. This should be checked early by any Console applications to
      * ensure that proper warnings are issued if there are any missing bundles
      * detected.
-     *
-     * @return array
      */
     public function getMissingSculpinBundles(): array
     {
@@ -160,8 +158,6 @@ abstract class AbstractKernel extends Kernel
 
     /**
      * Get additional Sculpin bundles to register
-     *
-     * @return array
      */
     abstract protected function getAdditionalSculpinBundles(): array;
 }

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/DefaultKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/DefaultKernel.php
@@ -21,7 +21,7 @@ class DefaultKernel extends AbstractKernel
     /**
      * {@inheritdoc}
      */
-    protected function getAdditionalSculpinBundles()
+    protected function getAdditionalSculpinBundles(): array
     {
         return [];
     }

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/DefaultKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/DefaultKernel.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,6 +23,6 @@ class DefaultKernel extends AbstractKernel
      */
     protected function getAdditionalSculpinBundles()
     {
-        return array();
+        return [];
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -27,13 +27,13 @@ class KernelFactory
      *
      * @return \Symfony\Component\HttpKernel\Kernel
      */
-    public static function create(InputInterface $input)
+    public static function create(InputInterface $input): \Symfony\Component\HttpKernel\Kernel
     {
-        $env = $input->getParameterOption(array('--env', '-e'), getenv('SCULPIN_DEBUG') ?: 'dev');
+        $env = $input->getParameterOption(['--env', '-e'], getenv('SCULPIN_DEBUG') ?: 'dev');
         $debug = (
             $env !== 'prod'
             && getenv('SCULPIN_DEBUG') !== '0'
-            && !$input->hasParameterOption(array('--no-debug', ''))
+            && !$input->hasParameterOption(['--no-debug', ''])
         );
 
         // do something here to locate and try to create

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
@@ -24,8 +24,6 @@ class KernelFactory
      * Create a kernel.
      *
      * @param InputInterface $input Input
-     *
-     * @return \Symfony\Component\HttpKernel\Kernel
      */
     public static function create(InputInterface $input): \Symfony\Component\HttpKernel\Kernel
     {

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
@@ -11,7 +11,9 @@
 
 namespace Sculpin\Bundle\SculpinBundle\HttpKernel;
 
+use SculpinKernel;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Kernel Factory
@@ -25,7 +27,7 @@ class KernelFactory
      *
      * @param InputInterface $input Input
      */
-    public static function create(InputInterface $input): \Symfony\Component\HttpKernel\Kernel
+    public static function create(InputInterface $input): Kernel
     {
         $env = $input->getParameterOption(['--env', '-e'], getenv('SCULPIN_DEBUG') ?: 'dev');
         $debug = (
@@ -44,7 +46,7 @@ class KernelFactory
         if (file_exists($customKernel = $projectDir.'/app/SculpinKernel.php')) {
             require $customKernel;
 
-            return new \SculpinKernel($env, $debug, $projectDir);
+            return new SculpinKernel($env, $debug, $projectDir);
         }
 
         // Fallback to using the default kernel in case

--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -126,7 +126,6 @@ class HttpServer
      *
      * @param OutputInterface $output       Output
      * @param string          $responseCode Response code
-     * @param Request         $request      Request
      */
     public static function logRequest(OutputInterface $output, string $responseCode, Request $request)
     {

--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -34,7 +34,7 @@ class HttpServer
      * @param bool            $debug   Debug
      * @param int             $port    Port
      */
-    public function __construct(OutputInterface $output, $docroot, $env, $debug, $port = null)
+    public function __construct(OutputInterface $output, string $docroot, string $env, bool $debug, int $port = null)
     {
         $repository = new PhpRepository;
 
@@ -81,9 +81,9 @@ class HttpServer
 
             HttpServer::logRequest($output, 200, $request);
 
-            $response->writeHead(200, array(
+            $response->writeHead(200, [
                 "Content-Type" => $type,
-            ));
+            ]);
             $response->end(file_get_contents($path));
         });
 
@@ -96,7 +96,7 @@ class HttpServer
      * @param int      $interval Interval
      * @param callable $callback Callback
      */
-    public function addPeriodicTimer($interval, $callback)
+    public function addPeriodicTimer(int $interval, callable $callback)
     {
         $this->loop->addPeriodicTimer($interval, $callback);
     }
@@ -128,7 +128,7 @@ class HttpServer
      * @param string          $responseCode Response code
      * @param Request         $request      Request
      */
-    public static function logRequest(OutputInterface $output, $responseCode, Request $request)
+    public static function logRequest(OutputInterface $output, string $responseCode, Request $request)
     {
         $wrapOpen = '';
         $wrapClose = '';

--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -34,7 +34,7 @@ class HttpServer
      * @param bool            $debug   Debug
      * @param int             $port    Port
      */
-    public function __construct(OutputInterface $output, string $docroot, string $env, bool $debug, int $port = null)
+    public function __construct(OutputInterface $output, string $docroot, string $env, bool $debug, ?int $port = null)
     {
         $repository = new PhpRepository;
 
@@ -96,7 +96,7 @@ class HttpServer
      * @param int      $interval Interval
      * @param callable $callback Callback
      */
-    public function addPeriodicTimer(int $interval, callable $callback)
+    public function addPeriodicTimer(int $interval, callable $callback): void
     {
         $this->loop->addPeriodicTimer($interval, $callback);
     }
@@ -104,7 +104,7 @@ class HttpServer
     /**
      * Run server
      */
-    public function run()
+    public function run(): void
     {
         $this->output->writeln(sprintf(
             'Starting Sculpin server for the <info>%s</info> environment with debug <info>%s</info>',
@@ -127,7 +127,7 @@ class HttpServer
      * @param OutputInterface $output       Output
      * @param string          $responseCode Response code
      */
-    public static function logRequest(OutputInterface $output, string $responseCode, Request $request)
+    public static function logRequest(OutputInterface $output, string $responseCode, Request $request): void
     {
         $wrapOpen = '';
         $wrapClose = '';

--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -31,7 +31,7 @@ class SculpinBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConverterManagerPass);
         $container->addCompilerPass(new DataProviderManagerPass);

--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -12,12 +12,12 @@
 namespace Sculpin\Bundle\SculpinBundle;
 
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\ConverterManagerPass;
-use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\DataSourcePass;
+use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\CustomMimeTypesRepositoryPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\DataProviderManagerPass;
+use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\DataSourcePass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\FormatterManagerPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\GeneratorManagerPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\PathConfiguratorPass;
-use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\CustomMimeTypesRepositoryPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
@@ -12,6 +12,7 @@
 
 namespace Sculpin\Bundle\StandaloneBundle\Command;
 
+use RuntimeException;
 use Sculpin\Core\Console\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -56,7 +57,7 @@ EOF
 
         if ($filesystem->exists($cacheDir)) {
             if (!is_writable($cacheDir)) {
-                throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $cacheDir));
+                throw new RuntimeException(sprintf('Unable to write in the "%s" directory', $cacheDir));
             }
 
             $filesystem->remove($cacheDir);

--- a/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
@@ -30,7 +30,7 @@ class CacheClearCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:clear')
@@ -50,7 +50,7 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         $filesystem   = $this->getContainer()->get('filesystem');

--- a/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -30,7 +30,7 @@ class RegisterKernelListenersPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('event_dispatcher')) {
             return;

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -12,8 +12,11 @@
 
 namespace Sculpin\Bundle\StandaloneBundle\DependencyInjection\Compiler;
 
+use InvalidArgumentException;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Register Kernel Listener Pass
@@ -40,7 +43,7 @@ class RegisterKernelListenersPass implements CompilerPassInterface
                 $priority = $event['priority'] ?? 0;
 
                 if (!isset($event['event'])) {
-                    throw new \InvalidArgumentException(sprintf(
+                    throw new InvalidArgumentException(sprintf(
                         'Service "%s" must define the "event" attribute on "kernel.event_listener" tags.',
                         $id
                     ));
@@ -68,10 +71,10 @@ class RegisterKernelListenersPass implements CompilerPassInterface
             // even if the service is created by a factory
             $class = $container->getDefinition($id)->getClass();
 
-            $refClass = new \ReflectionClass($class);
-            $interface = 'Symfony\Component\EventDispatcher\EventSubscriberInterface';
+            $refClass = new ReflectionClass($class);
+            $interface = EventSubscriberInterface::class;
             if (!$refClass->implementsInterface($interface)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'Service "%s" must implement interface "%s".',
                     $id,
                     $interface

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -37,7 +37,7 @@ class RegisterKernelListenersPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('kernel.event_listener') as $id => $events) {
             foreach ($events as $event) {
-                $priority = isset($event['priority']) ? $event['priority'] : 0;
+                $priority = $event['priority'] ?? 0;
 
                 if (!isset($event['event'])) {
                     throw new \InvalidArgumentException(sprintf(
@@ -47,10 +47,10 @@ class RegisterKernelListenersPass implements CompilerPassInterface
                 }
 
                 if (!isset($event['method'])) {
-                    $event['method'] = 'on'.preg_replace_callback(array(
+                    $event['method'] = 'on'.preg_replace_callback([
                         '/(?<=\b)[a-z]/i',
                         '/[^a-z0-9]/i',
-                    ), function ($matches) {
+                    ], function ($matches) {
                         return strtoupper($matches[0]);
                     }, $event['event']);
                     $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);
@@ -58,7 +58,7 @@ class RegisterKernelListenersPass implements CompilerPassInterface
 
                 $definition->addMethodCall(
                     'addListenerService',
-                    array($event['event'], array($id, $event['method']), $priority)
+                    [$event['event'], [$id, $event['method']], $priority]
                 );
             }
         }
@@ -78,7 +78,7 @@ class RegisterKernelListenersPass implements CompilerPassInterface
                 ));
             }
 
-            $definition->addMethodCall('addSubscriberService', array($id, $class));
+            $definition->addMethodCall('addSubscriberService', [$id, $class]);
         }
     }
 }

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -12,8 +12,8 @@
 
 namespace Sculpin\Bundle\StandaloneBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Register Kernel Listener Pass

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
@@ -26,7 +26,7 @@ class SculpinStandaloneExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\StandaloneBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -28,7 +28,7 @@ class SculpinStandaloneExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
     }
 }

--- a/src/Sculpin/Bundle/StandaloneBundle/SculpinStandaloneBundle.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/SculpinStandaloneBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SculpinStandaloneBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RegisterKernelListenersPass, PassConfig::TYPE_AFTER_REMOVING);
     }

--- a/src/Sculpin/Bundle/StandaloneBundle/SculpinStandaloneBundle.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/SculpinStandaloneBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Bundle\TextileBundle\DependencyInjection;
 
+use Netcarver\Textile\Parser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -32,7 +33,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('parser_class')->defaultValue('Netcarver\Textile\Parser')->end()
+                ->scalarNode('parser_class')->defaultValue(Parser::class)->end()
                 ->arrayNode('extensions')
                     ->defaultValue(['textile'])
                     ->prototype('scalar')->end()

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('parser_class')->defaultValue('Netcarver\Textile\Parser')->end()
                 ->arrayNode('extensions')
-                    ->defaultValue(array('textile'))
+                    ->defaultValue(['textile'])
                     ->prototype('scalar')->end()
                 ->end()
             ->end();

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
@@ -26,7 +26,7 @@ class SculpinTextileExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\TextileBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -31,7 +31,7 @@ class SculpinTextileExtension extends Extension
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('sculpin_textile.parser.class', $config['parser_class']);

--- a/src/Sculpin/Bundle/TextileBundle/SculpinTextileBundle.php
+++ b/src/Sculpin/Bundle/TextileBundle/SculpinTextileBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/TextileBundle/SculpinTextileBundle.php
+++ b/src/Sculpin/Bundle/TextileBundle/SculpinTextileBundle.php
@@ -20,5 +20,5 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SculpinTextileBundle extends Bundle
 {
-    const CONVERTER_NAME = 'textile';
+    public const CONVERTER_NAME = 'textile';
 }

--- a/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
+++ b/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
@@ -53,7 +53,7 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(ConverterContextInterface $converterContext)
+    public function convert(ConverterContextInterface $converterContext): void
     {
         $converterContext->setContent($this->parser->textileThis($converterContext->content()));
     }
@@ -73,7 +73,7 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
      *
      * @param SourceSetEvent $sourceSetEvent Source Set Event
      */
-    public function beforeRun(SourceSetEvent $sourceSetEvent)
+    public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
         foreach ($sourceSetEvent->updatedSources() as $source) {
             foreach ($this->extensions as $extension) {

--- a/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
+++ b/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -37,7 +37,7 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
      *
      * @var array
      */
-    protected $extensions = array();
+    protected $extensions = [];
 
     /**
      * Constructor.
@@ -45,7 +45,7 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
      * @param Parser $parser     Parser
      * @param array  $extensions Extensions
      */
-    public function __construct(Parser $parser, array $extensions = array())
+    public function __construct(Parser $parser, array $extensions = [])
     {
         $this->parser = $parser;
         $this->extensions = $extensions;
@@ -64,9 +64,9 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             Sculpin::EVENT_BEFORE_RUN => 'beforeRun',
-        );
+        ];
     }
 
     /**

--- a/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
+++ b/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
@@ -42,7 +42,6 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
     /**
      * Constructor.
      *
-     * @param Parser $parser     Parser
      * @param array  $extensions Extensions
      */
     public function __construct(Parser $parser, array $extensions = [])

--- a/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
+++ b/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
@@ -25,7 +25,7 @@ class ListCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('theme:list')
@@ -40,7 +40,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $themeRegistry = $this->getContainer()->get('sculpin_theme.theme_registry');
         $activeTheme = $themeRegistry->findActiveTheme();

--- a/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
+++ b/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
@@ -26,7 +26,7 @@ class SculpinThemeExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\ThemeBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -31,7 +31,7 @@ class SculpinThemeExtension extends Extension
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('sculpin_theme.directory', $config['directory']);

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/ThemeBundle/SculpinThemeBundle.php
+++ b/src/Sculpin/Bundle/ThemeBundle/SculpinThemeBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -30,7 +30,7 @@ class ThemeRegistry
     public function listThemes()
     {
         if (! file_exists($this->directory)) {
-            return array();
+            return [];
         }
 
         $directories = $this
@@ -40,11 +40,11 @@ class ThemeRegistry
             ->depth('== 1')
             ->in($this->directory);
 
-        $themes = array();
+        $themes = [];
 
         foreach ($directories as $directory) {
             $name = basename(dirname($directory)).'/'.basename($directory);
-            $theme = array('name' => $name, 'path' => $directory);
+            $theme = ['name' => $name, 'path' => $directory];
             if (file_exists($directory.'/theme.yml')) {
                 $theme = array_merge(Yaml::parse(file_get_contents($directory.'/theme.yml')), $theme);
             }
@@ -58,7 +58,7 @@ class ThemeRegistry
     {
         $themes = $this->listThemes();
 
-        foreach (array($this->activeTheme.'-dev', $this->activeTheme) as $activeTheme) {
+        foreach ([$this->activeTheme.'-dev', $this->activeTheme] as $activeTheme) {
             if (! isset($themes[$activeTheme])) {
                 continue;
             }

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Bundle\ThemeBundle;
 
 use Dflydev\Symfony\FinderFactory\FinderFactoryInterface;
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
 class ThemeRegistry
@@ -66,7 +67,7 @@ class ThemeRegistry
             $theme = $themes[$activeTheme];
             if (isset($theme['parent'])) {
                 if (! isset($themes[$theme['parent']])) {
-                    throw new \RuntimeException(sprintf(
+                    throw new RuntimeException(sprintf(
                         "Theme %s is a child of nonexistent parent theme %s",
                         $this->activeTheme,
                         $theme['parent']

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
@@ -2,7 +2,9 @@
 
 namespace Sculpin\Bundle\ThemeBundle;
 
-class ThemeTwigExtension extends \Twig_Extension
+use Twig_Extension;
+use Twig_Function_Method;
+class ThemeTwigExtension extends Twig_Extension
 {
     private $theme;
     private $sourceDir;
@@ -21,9 +23,9 @@ class ThemeTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            'theme_path' => new \Twig_Function_Method($this, 'themePath'),
-            'theme_path_exists' => new \Twig_Function_Method($this, 'themePathExists'),
-            'theme_paths' => new \Twig_Function_Method($this, 'themePaths'),
+            'theme_path' => new Twig_Function_Method($this, 'themePath'),
+            'theme_path_exists' => new Twig_Function_Method($this, 'themePathExists'),
+            'theme_paths' => new Twig_Function_Method($this, 'themePaths'),
         ];
     }
 

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
@@ -4,6 +4,7 @@ namespace Sculpin\Bundle\ThemeBundle;
 
 use Twig_Extension;
 use Twig_Function_Method;
+
 class ThemeTwigExtension extends Twig_Extension
 {
     private $theme;

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
@@ -40,10 +40,6 @@ class ThemeTwigExtension extends \Twig_Extension
      *
      * Will always return a value. Default return value is the input unless the
      * file actually exists at a theme location.
-     *
-     * @param string $resource
-     *
-     * @return string
      */
     public function themePath(string $resource): string
     {
@@ -72,10 +68,6 @@ class ThemeTwigExtension extends \Twig_Extension
 
     /**
      * Check to see if a given Theme resource exists anywhere on disk
-     *
-     * @param string $resource
-     *
-     * @return bool
      */
     public function themePathExists(string $resource): bool
     {
@@ -106,10 +98,6 @@ class ThemeTwigExtension extends \Twig_Extension
      * Generate a collection of URLs for a Theme's resource
      *
      * May end up returning an empty array.
-     *
-     * @param string $resource
-     *
-     * @return array
      */
     public function themePaths(string $resource): array
     {

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Bundle\ThemeBundle;
 
@@ -20,11 +20,11 @@ class ThemeTwigExtension extends \Twig_Extension
      */
     public function getFunctions()
     {
-        return array(
+        return [
             'theme_path' => new \Twig_Function_Method($this, 'themePath'),
             'theme_path_exists' => new \Twig_Function_Method($this, 'themePathExists'),
             'theme_paths' => new \Twig_Function_Method($this, 'themePaths'),
-        );
+        ];
     }
 
     /**
@@ -45,7 +45,7 @@ class ThemeTwigExtension extends \Twig_Extension
      *
      * @return string
      */
-    public function themePath($resource)
+    public function themePath(string $resource): string
     {
         if (null === $this->theme) {
             return $resource;
@@ -77,7 +77,7 @@ class ThemeTwigExtension extends \Twig_Extension
      *
      * @return bool
      */
-    public function themePathExists($resource)
+    public function themePathExists(string $resource): bool
     {
         if (file_exists($this->sourceDir.'/'.$resource)) {
             return true;
@@ -111,9 +111,9 @@ class ThemeTwigExtension extends \Twig_Extension
      *
      * @return array
      */
-    public function themePaths($resource)
+    public function themePaths(string $resource): array
     {
-        $paths = array();
+        $paths = [];
 
         if (file_exists($this->sourceDir.'/'.$resource)) {
             $paths[] = $resource;

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
@@ -12,8 +12,11 @@
 namespace Sculpin\Bundle\ThemeBundle;
 
 use Sculpin\Bundle\TwigBundle\FlexibleExtensionFilesystemLoader;
+use Twig_ExistsLoaderInterface;
+use Twig_Loader_Chain;
+use Twig_LoaderInterface;
 
-class ThemeTwigLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
+class ThemeTwigLoader implements Twig_LoaderInterface, Twig_ExistsLoaderInterface
 {
     /** @var \Twig_Loader_Chain */
     private $chainLoader;
@@ -34,7 +37,7 @@ class ThemeTwigLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterf
             }
         }
 
-        $this->chainLoader = new \Twig_Loader_Chain($loaders);
+        $this->chainLoader = new Twig_Loader_Chain($loaders);
     }
 
     private function findPaths($theme, array $paths = [])

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -20,7 +20,7 @@ class ThemeTwigLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterf
 
     public function __construct(ThemeRegistry $themeRegistry, array $extensions)
     {
-        $loaders = array();
+        $loaders = [];
 
         $theme = $themeRegistry->findActiveTheme();
         if (null !== $theme) {
@@ -30,16 +30,16 @@ class ThemeTwigLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterf
             }
 
             if ($paths) {
-                $loaders[] = new FlexibleExtensionFilesystemLoader('', array(), $paths, $extensions);
+                $loaders[] = new FlexibleExtensionFilesystemLoader('', [], $paths, $extensions);
             }
         }
 
         $this->chainLoader = new \Twig_Loader_Chain($loaders);
     }
 
-    private function findPaths($theme, array $paths = array())
+    private function findPaths($theme, array $paths = [])
     {
-        foreach (array('_views', '_layouts', '_includes', '_partials') as $type) {
+        foreach (['_views', '_layouts', '_includes', '_partials'] as $type) {
             if (is_dir($viewPath = $theme['path'].'/'.$type)) {
                 $paths[] = $viewPath;
             }

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -39,9 +39,9 @@ class TwigEnvironmentPass implements CompilerPassInterface
         // afterward. If not, the globals from the extensions will never
         // be registered.
         $calls = $definition->getMethodCalls();
-        $definition->setMethodCalls(array());
+        $definition->setMethodCalls([]);
         foreach ($container->findTaggedServiceIds('twig.extension') as $id => $attributes) {
-            $definition->addMethodCall('addExtension', array(new Reference($id)));
+            $definition->addMethodCall('addExtension', [new Reference($id)]);
         }
         $definition->setMethodCalls(array_merge($definition->getMethodCalls(), $calls));
     }

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -11,9 +11,9 @@
 
 namespace Sculpin\Bundle\TwigBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Adds tagged twig.extension services to twig service

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -26,7 +26,7 @@ class TwigEnvironmentPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin_twig.twig')) {
             return;

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Bundle\TwigBundle\DependencyInjection\Compiler;
 
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -49,7 +50,7 @@ class TwigLoaderPass implements CompilerPassInterface
 
         $sourceViewPaths = $container->getParameter('sculpin_twig.source_view_paths');
         foreach ($container->getParameter('kernel.bundles') as $class) {
-            $reflection = new \ReflectionClass($class);
+            $reflection = new ReflectionClass($class);
             foreach ($sourceViewPaths as $sourceViewPath) {
                 if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/'.$sourceViewPath)) {
                     $appendedLoaders[] = $dir;

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -36,8 +36,8 @@ class TwigLoaderPass implements CompilerPassInterface
         $arguments = $definition->getArguments();
         $loaders = $arguments[0];
 
-        $prependedLoaders = array();
-        $appendedLoaders = array();
+        $prependedLoaders = [];
+        $appendedLoaders = [];
 
         foreach ($container->findTaggedServiceIds('twig.loaders.prepend') as $id => $attributes) {
             $prependedLoaders[] = new Reference($id);

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -27,7 +27,7 @@ class TwigLoaderPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition('sculpin_twig.loader')) {
             return;

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -11,9 +11,9 @@
 
 namespace Sculpin\Bundle\TwigBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Adds tagged twig.loaders services to twig loader service

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder;

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -36,11 +36,11 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('source_view_paths')
-                    ->defaultValue(array('_views', '_layouts', '_includes', '_partials'))
+                    ->defaultValue(['_views', '_layouts', '_includes', '_partials'])
                     ->prototype('scalar')->end()
                 ->end()
                 ->arrayNode('extensions')
-                    ->defaultValue(array('', 'twig', 'html', 'html.twig', 'twig.html'))
+                    ->defaultValue(['', 'twig', 'html', 'html.twig', 'twig.html'])
                     ->prototype('scalar')->end()
                 ->end()
             ->end();

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
@@ -26,7 +26,7 @@ class SculpinTwigExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
@@ -13,7 +13,7 @@ namespace Sculpin\Bundle\TwigBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -31,7 +31,7 @@ class SculpinTwigExtension extends Extension
         $configuration = new Configuration;
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('sculpin_twig.source_view_paths', $config['source_view_paths']);

--- a/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
@@ -11,12 +11,13 @@
 
 namespace Sculpin\Bundle\TwigBundle;
 
+use Twig_Loader_Filesystem;
 /**
  * Filesystem Loader.
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class FilesystemLoader extends \Twig_Loader_Filesystem
+class FilesystemLoader extends Twig_Loader_Filesystem
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Bundle\TwigBundle;
 
 use Twig_Loader_Filesystem;
+
 /**
  * Filesystem Loader.
  *

--- a/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -14,13 +14,15 @@ namespace Sculpin\Bundle\TwigBundle;
 use Sculpin\Core\Event\SourceSetEvent;
 use Sculpin\Core\Sculpin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Twig_Error_Loader;
+use Twig_LoaderInterface;
 
 /**
  * Flexible Extension Filesystem Loader.
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventSubscriberInterface
+class FlexibleExtensionFilesystemLoader implements Twig_LoaderInterface, EventSubscriberInterface
 {
     /**
      * Filesystem loader
@@ -94,11 +96,11 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
                 $this->cachedCacheKeyExtension[$name] = $extension;
 
                 return $this->cachedCacheKey[$name];
-            } catch (\Twig_Error_Loader $e) {
+            } catch (Twig_Error_Loader $e) {
             }
         }
 
-        throw $this->cachedCacheKeyException[$name] = new \Twig_Error_Loader(
+        throw $this->cachedCacheKeyException[$name] = new Twig_Error_Loader(
             sprintf('Template "%s" is not defined.', $name)
         );
     }

--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -29,9 +29,9 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
      */
     protected $filesystemLoader;
 
-    protected $cachedCacheKey = array();
-    protected $cachedCacheKeyExtension = array();
-    protected $cachedCacheKeyException = array();
+    protected $cachedCacheKey = [];
+    protected $cachedCacheKeyExtension = [];
+    protected $cachedCacheKeyException = [];
 
     /**
      * Constructor.
@@ -41,7 +41,7 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
      * @param string[] $paths
      * @param string[] $extensions
      */
-    public function __construct($sourceDir, array $sourcePaths, array $paths, array $extensions)
+    public function __construct(string $sourceDir, array $sourcePaths, array $paths, array $extensions)
     {
         $mappedSourcePaths = array_map(function ($path) use ($sourceDir) {
             return $sourceDir.'/'.$path;
@@ -121,17 +121,17 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             Sculpin::EVENT_BEFORE_RUN => 'beforeRun',
-        );
+        ];
     }
 
     public function beforeRun(SourceSetEvent $sourceSetEvent)
     {
         if ($sourceSetEvent->sourceSet()->newSources()) {
-            $this->cachedCacheKey = array();
-            $this->cachedCacheKeyExtension = array();
-            $this->cachedCacheKeyException = array();
+            $this->cachedCacheKey = [];
+            $this->cachedCacheKeyExtension = [];
+            $this->cachedCacheKeyException = [];
         }
     }
 }

--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -127,7 +127,7 @@ class FlexibleExtensionFilesystemLoader implements Twig_LoaderInterface, EventSu
         ];
     }
 
-    public function beforeRun(SourceSetEvent $sourceSetEvent)
+    public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
         if ($sourceSetEvent->sourceSet()->newSources()) {
             $this->cachedCacheKey = [];

--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -36,7 +36,6 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
     /**
      * Constructor.
      *
-     * @param string   $sourceDir
      * @param string[] $sourcePaths
      * @param string[] $paths
      * @param string[] $extensions

--- a/src/Sculpin/Bundle/TwigBundle/SculpinTwigBundle.php
+++ b/src/Sculpin/Bundle/TwigBundle/SculpinTwigBundle.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Bundle/TwigBundle/SculpinTwigBundle.php
+++ b/src/Sculpin/Bundle/TwigBundle/SculpinTwigBundle.php
@@ -23,12 +23,12 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SculpinTwigBundle extends Bundle
 {
-    const FORMATTER_NAME = 'twig';
+    public const FORMATTER_NAME = 'twig';
 
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new TwigEnvironmentPass);
         $container->addCompilerPass(new TwigLoaderPass);

--- a/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -25,7 +25,6 @@ class TemplateResetter implements EventSubscriberInterface
     /**
      * Constructor.
      *
-     * @param \Twig_Environment $twig
      */
     public function __construct(\Twig_Environment $twig)
     {
@@ -37,9 +36,9 @@ class TemplateResetter implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             Sculpin::EVENT_BEFORE_RUN => 'beforeRun',
-        );
+        ];
     }
 
     /**

--- a/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
@@ -24,7 +24,6 @@ class TemplateResetter implements EventSubscriberInterface
 {
     /**
      * Constructor.
-     *
      */
     public function __construct(\Twig_Environment $twig)
     {

--- a/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
@@ -14,6 +14,7 @@ namespace Sculpin\Bundle\TwigBundle;
 use Sculpin\Core\Event\SourceSetEvent;
 use Sculpin\Core\Sculpin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Twig_Environment;
 
 /**
  * Template Resetter.
@@ -25,7 +26,7 @@ class TemplateResetter implements EventSubscriberInterface
     /**
      * Constructor.
      */
-    public function __construct(\Twig_Environment $twig)
+    public function __construct(Twig_Environment $twig)
     {
         $this->twig = $twig;
     }

--- a/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
@@ -46,7 +46,7 @@ class TemplateResetter implements EventSubscriberInterface
      *
      * @param SourceSetEvent $sourceSetEvent Source Set Event
      */
-    public function beforeRun(SourceSetEvent $sourceSetEvent)
+    public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
         if ($sourceSetEvent->updatedSources()) {
             $this->twig->clearTemplateCache();

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -58,15 +58,15 @@ class TwigFormatter implements FormatterInterface
             $template = $this->twig->loadTemplate($formatContext->templateId());
 
             if (!count($blockNames = $this->findAllBlocks($template, $data))) {
-                return array('content' => $template->render($data));
+                return ['content' => $template->render($data)];
             }
-            $blocks = array();
+            $blocks = [];
             foreach ($blockNames as $blockName) {
                 $blocks[$blockName] = $template->renderBlock($blockName, $data);
             }
 
             return $blocks;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
         }
     }
@@ -94,7 +94,7 @@ class TwigFormatter implements FormatterInterface
             $data = $formatContext->data()->export();
 
             return $this->twig->render($formatContext->templateId(), $data);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
         }
     }

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -47,7 +47,7 @@ class TwigFormatter implements FormatterInterface
         $this->arrayLoader = $arrayLoader;
     }
 
-     /**
+    /**
      * {@inheritdoc}
      */
     public function formatBlocks(FormatContext $formatContext)

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -50,7 +50,7 @@ class TwigFormatter implements FormatterInterface
      /**
      * {@inheritdoc}
      */
-    public function formatBlocks(FormatContext $formatContext): array
+    public function formatBlocks(FormatContext $formatContext)
     {
         try {
             $this->arrayLoader->setTemplate($formatContext->templateId(), $this->massageTemplate($formatContext));
@@ -83,7 +83,7 @@ class TwigFormatter implements FormatterInterface
     /**
      * {@inheritdoc}
      */
-    public function formatPage(FormatContext $formatContext): string
+    public function formatPage(FormatContext $formatContext)
     {
         try {
             $this->arrayLoader->setTemplate(

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -50,7 +50,7 @@ class TwigFormatter implements FormatterInterface
      /**
      * {@inheritdoc}
      */
-    public function formatBlocks(FormatContext $formatContext)
+    public function formatBlocks(FormatContext $formatContext): array
     {
         try {
             $this->arrayLoader->setTemplate($formatContext->templateId(), $this->massageTemplate($formatContext));
@@ -83,7 +83,7 @@ class TwigFormatter implements FormatterInterface
     /**
      * {@inheritdoc}
      */
-    public function formatPage(FormatContext $formatContext)
+    public function formatPage(FormatContext $formatContext): string
     {
         try {
             $this->arrayLoader->setTemplate(

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -13,6 +13,10 @@ namespace Sculpin\Bundle\TwigBundle;
 
 use Sculpin\Core\Formatter\FormatContext;
 use Sculpin\Core\Formatter\FormatterInterface;
+use Throwable;
+use Twig_Environment;
+use Twig_Loader_Array;
+use Twig_Template;
 
 /**
  * Twig Formatter.
@@ -41,7 +45,7 @@ class TwigFormatter implements FormatterInterface
      * @param \Twig_Environment  $twig        Twig
      * @param \Twig_Loader_Array $arrayLoader Array Loader
      */
-    public function __construct(\Twig_Environment $twig, \Twig_Loader_Array $arrayLoader)
+    public function __construct(Twig_Environment $twig, Twig_Loader_Array $arrayLoader)
     {
         $this->twig = $twig;
         $this->arrayLoader = $arrayLoader;
@@ -66,12 +70,12 @@ class TwigFormatter implements FormatterInterface
             }
 
             return $blocks;
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
         }
     }
 
-    public function findAllBlocks(\Twig_Template $template, array $context)
+    public function findAllBlocks(Twig_Template $template, array $context)
     {
         if (false !== $parent = $template->getParent($context)) {
             return array_unique(array_merge($this->findAllBlocks($parent, $context), $template->getBlockNames()));
@@ -94,7 +98,7 @@ class TwigFormatter implements FormatterInterface
             $data = $formatContext->data()->export();
 
             return $this->twig->render($formatContext->templateId(), $data);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
         }
     }

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -106,7 +106,7 @@ class TwigFormatter implements FormatterInterface
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->twig->clearCacheFiles();
         $this->twig->clearTemplateCache();

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -19,7 +19,7 @@ class ProxySourceCollection implements \ArrayAccess, \Iterator, \Countable
     protected $items;
     protected $sorter;
 
-    public function __construct(array $items = array(), SorterInterface $sorter = null)
+    public function __construct(array $items = [], SorterInterface $sorter = null)
     {
         $this->items = $items;
         $this->sorter = $sorter ?: new DefaultSorter;
@@ -108,6 +108,6 @@ class ProxySourceCollection implements \ArrayAccess, \Iterator, \Countable
 
     public function sort()
     {
-        uasort($this->items, array($this->sorter, 'sort'));
+        uasort($this->items, [$this->sorter, 'sort']);
     }
 }

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
@@ -11,10 +11,13 @@
 
 namespace Sculpin\Contrib\ProxySourceCollection;
 
+use ArrayAccess;
+use Countable;
+use Iterator;
 use Sculpin\Contrib\ProxySourceCollection\Sorter\DefaultSorter;
 use Sculpin\Contrib\ProxySourceCollection\Sorter\SorterInterface;
 
-class ProxySourceCollection implements \ArrayAccess, \Iterator, \Countable
+class ProxySourceCollection implements ArrayAccess, Iterator, Countable
 {
     protected $items;
     protected $sorter;

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
@@ -22,13 +22,13 @@ class ProxySourceCollection implements ArrayAccess, Iterator, Countable
     protected $items;
     protected $sorter;
 
-    public function __construct(array $items = [], SorterInterface $sorter = null)
+    public function __construct(array $items = [], ?SorterInterface $sorter = null)
     {
         $this->items = $items;
         $this->sorter = $sorter ?: new DefaultSorter;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->items[] = $value;
@@ -42,7 +42,7 @@ class ProxySourceCollection implements ArrayAccess, Iterator, Countable
         return isset($this->items[$offset]);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->items[$offset]);
     }
@@ -52,7 +52,7 @@ class ProxySourceCollection implements ArrayAccess, Iterator, Countable
         return isset($this->items[$offset]) ? $this->items[$offset] : null;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->items);
     }
@@ -82,7 +82,7 @@ class ProxySourceCollection implements ArrayAccess, Iterator, Countable
         return count($this->items);
     }
 
-    public function init()
+    public function init(): void
     {
         $this->sort();
 
@@ -109,7 +109,7 @@ class ProxySourceCollection implements ArrayAccess, Iterator, Countable
         return $this->items[$keys[0]];
     }
 
-    public function sort()
+    public function sort(): void
     {
         uasort($this->items, [$this->sorter, 'sort']);
     }

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -37,10 +37,10 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         FormatterManager $formatterManager,
         $dataProviderName,
         $dataSingularName = null,
-        ProxySourceCollection $collection = null,
+        ?ProxySourceCollection $collection = null,
         FilterInterface $filter,
         MapInterface $map,
-        ProxySourceItemFactoryInterface $factory = null
+        ?ProxySourceItemFactoryInterface $factory = null
     ) {
         $this->formatterManager = $formatterManager;
         $this->dataProviderName = $dataProviderName;
@@ -67,7 +67,7 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         ];
     }
 
-    public function beforeRun(SourceSetEvent $sourceSetEvent)
+    public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
         foreach ($sourceSetEvent->updatedSources() as $source) {
             if ($source->isGenerated()) {
@@ -101,7 +101,7 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         $this->collection->init();
     }
 
-    public function beforeRunPost(SourceSetEvent $sourceSetEvent)
+    public function beforeRunPost(SourceSetEvent $sourceSetEvent): void
     {
         $anItemHasChanged = false;
         foreach ($this->collection as $item) {
@@ -124,7 +124,7 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         }
     }
 
-    public function afterConvert(ConvertEvent $convertEvent)
+    public function afterConvert(ConvertEvent $convertEvent): void
     {
         $sourceId = $convertEvent->source()->sourceId();
         if (isset($this->collection[$sourceId])) {

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -58,13 +58,13 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
 
     public static function getSubscribedEvents()
     {
-        return array(
-            Sculpin::EVENT_BEFORE_RUN => array(
-                array('beforeRun', 0),
-                array('beforeRunPost', -100),
-            ),
+        return [
+            Sculpin::EVENT_BEFORE_RUN => [
+                ['beforeRun', 0],
+                ['beforeRunPost', -100],
+            ],
             Sculpin::EVENT_AFTER_CONVERT => 'afterConvert',
-        );
+        ];
     }
 
     public function beforeRun(SourceSetEvent $sourceSetEvent)

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -51,7 +51,7 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         $this->factory = $factory ?: new SimpleProxySourceItemFactory;
     }
 
-    public function provideData()
+    public function provideData(): ProxySourceCollection
     {
         return $this->collection;
     }

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -52,7 +52,7 @@ class ProxySourceItem extends ProxySource implements ArrayAccess
         return $this->data()->get('blocks');
     }
 
-    public function setBlocks(array $blocks = null)
+    public function setBlocks(?array $blocks = null): void
     {
         $this->data()->set('blocks', $blocks ?: []);
     }
@@ -62,7 +62,7 @@ class ProxySourceItem extends ProxySource implements ArrayAccess
         return $this->previousItem;
     }
 
-    public function setPreviousItem(self $item = null)
+    public function setPreviousItem(?self $item = null): void
     {
         $lastPreviousItem = $this->previousItem;
         $this->previousItem = $item;
@@ -85,7 +85,7 @@ class ProxySourceItem extends ProxySource implements ArrayAccess
         return $this->nextItem;
     }
 
-    public function setNextItem(self $item = null)
+    public function setNextItem(?self $item = null): void
     {
         $lastNextItem = $this->nextItem;
         $this->nextItem = $item;
@@ -103,7 +103,7 @@ class ProxySourceItem extends ProxySource implements ArrayAccess
         }
     }
 
-    public function reprocess()
+    public function reprocess(): void
     {
         $this->setHasChanged();
     }
@@ -131,7 +131,7 @@ class ProxySourceItem extends ProxySource implements ArrayAccess
         return ! method_exists($this, $offset) && null !== $this->data()->get($offset);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (! method_exists($this, $offset)) {
             $this->data()->remove($offset);

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -28,7 +28,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         return $this->data()->export();
     }
 
-    public function url()
+    public function url(): string
     {
         return $this->permalink()->relativeUrlPath();
     }

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -11,9 +11,11 @@
 
 namespace Sculpin\Contrib\ProxySourceCollection;
 
+use ArrayAccess;
+use InvalidArgumentException;
 use Sculpin\Core\Source\ProxySource;
 
-class ProxySourceItem extends ProxySource implements \ArrayAccess
+class ProxySourceItem extends ProxySource implements ArrayAccess
 {
     private $previousItem;
     private $nextItem;
@@ -109,7 +111,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
-            throw new \InvalidArgumentException('Proxy source items cannot have values pushed onto them');
+            throw new InvalidArgumentException('Proxy source items cannot have values pushed onto them');
         } else {
             if (method_exists($this, $offset)) {
                 return call_user_func([$this, $offset, $value]);

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -52,7 +52,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
 
     public function setBlocks(array $blocks = null)
     {
-        $this->data()->set('blocks', $blocks ?: array());
+        $this->data()->set('blocks', $blocks ?: []);
     }
 
     public function previousItem()
@@ -60,7 +60,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         return $this->previousItem;
     }
 
-    public function setPreviousItem(ProxySourceItem $item = null)
+    public function setPreviousItem(self $item = null)
     {
         $lastPreviousItem = $this->previousItem;
         $this->previousItem = $item;
@@ -83,7 +83,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         return $this->nextItem;
     }
 
-    public function setNextItem(ProxySourceItem $item = null)
+    public function setNextItem(self $item = null)
     {
         $lastNextItem = $this->nextItem;
         $this->nextItem = $item;
@@ -112,12 +112,12 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
             throw new \InvalidArgumentException('Proxy source items cannot have values pushed onto them');
         } else {
             if (method_exists($this, $offset)) {
-                return call_user_func(array($this, $offset, $value));
+                return call_user_func([$this, $offset, $value]);
             }
 
             $setMethod = 'set'.ucfirst($offset);
             if (method_exists($this, $setMethod)) {
-                return call_user_func(array($this, $setMethod, $value));
+                return call_user_func([$this, $setMethod, $value]);
             }
 
             $this->data()->set($offset, $value);
@@ -139,7 +139,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
     public function offsetGet($offset)
     {
         if (method_exists($this, $offset)) {
-            return call_user_func(array($this, $offset));
+            return call_user_func([$this, $offset]);
         }
 
         return $this->data()->get($offset);

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItemFactoryInterface.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItemFactoryInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItemFactoryInterface.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItemFactoryInterface.php
@@ -15,5 +15,5 @@ use Sculpin\Core\Source\SourceInterface;
 
 interface ProxySourceItemFactoryInterface
 {
-    public function createProxySourceItem(SourceInterface $source);
+    public function createProxySourceItem(SourceInterface $source): ProxySourceItem;
 }

--- a/src/Sculpin/Contrib/ProxySourceCollection/SimpleProxySourceItemFactory.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/SimpleProxySourceItemFactory.php
@@ -25,7 +25,7 @@ class SimpleProxySourceItemFactory implements ProxySourceItemFactoryInterface
         );
     }
 
-    public function createProxySourceItem(SourceInterface $source)
+    public function createProxySourceItem(SourceInterface $source): ProxySourceItem
     {
         return $this->reflectionClass->newInstance($source);
     }

--- a/src/Sculpin/Contrib/ProxySourceCollection/SimpleProxySourceItemFactory.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/SimpleProxySourceItemFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/ProxySourceCollection/SimpleProxySourceItemFactory.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/SimpleProxySourceItemFactory.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Contrib\ProxySourceCollection;
 
+use ReflectionClass;
 use Sculpin\Core\Source\SourceInterface;
 
 class SimpleProxySourceItemFactory implements ProxySourceItemFactoryInterface
@@ -19,8 +20,8 @@ class SimpleProxySourceItemFactory implements ProxySourceItemFactoryInterface
 
     public function __construct($class = null)
     {
-        $this->reflectionClass = new \ReflectionClass(
-            $class ?: 'Sculpin\Contrib\ProxySourceCollection\ProxySourceItem'
+        $this->reflectionClass = new ReflectionClass(
+            $class ?: ProxySourceItem::class
         );
     }
 

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/DefaultSorter.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/DefaultSorter.php
@@ -15,7 +15,7 @@ use Sculpin\Contrib\ProxySourceCollection\ProxySourceItem;
 
 class DefaultSorter implements SorterInterface
 {
-    public function sort(ProxySourceItem $a, ProxySourceItem $b)
+    public function sort(ProxySourceItem $a, ProxySourceItem $b): int
     {
         if ($a->date() && $a->title() && $b->date() && $b->title()) {
             return strnatcmp($b->date().' '.$b->title(), $a->date().' '.$a->title());

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/DefaultSorter.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/DefaultSorter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/MetaSorter.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/MetaSorter.php
@@ -25,7 +25,7 @@ class MetaSorter implements SorterInterface
         $this->setReversed($direction);
     }
 
-    private function setKey($key = null)
+    private function setKey($key = null): void
     {
         if (null === $key) {
             throw new InvalidArgumentException('Key must be specified');
@@ -33,7 +33,7 @@ class MetaSorter implements SorterInterface
 
         $this->key = $key;
     }
-    private function setReversed($direction)
+    private function setReversed($direction): void
     {
         switch (strtolower($direction)) {
             case 'asc':

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/MetaSorter.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/MetaSorter.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Contrib\ProxySourceCollection\Sorter;
 
+use InvalidArgumentException;
 use Sculpin\Contrib\ProxySourceCollection\ProxySourceItem;
 
 class MetaSorter implements SorterInterface
@@ -27,7 +28,7 @@ class MetaSorter implements SorterInterface
     private function setKey($key = null)
     {
         if (null === $key) {
-            throw new \InvalidArgumentException('Key must be specified');
+            throw new InvalidArgumentException('Key must be specified');
         }
 
         $this->key = $key;
@@ -44,7 +45,7 @@ class MetaSorter implements SorterInterface
                 $this->reversed = false;
                 break;
             default:
-                throw new \InvalidArgumentException(
+                throw new InvalidArgumentException(
                     'Invalid value passed for direction, must be one of: asc, ascending, desc, descending'
                 );
         }

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/MetaSorter.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/MetaSorter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/SorterInterface.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/SorterInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/ProxySourceCollection/Sorter/SorterInterface.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/Sorter/SorterInterface.php
@@ -15,5 +15,5 @@ use Sculpin\Contrib\ProxySourceCollection\ProxySourceItem;
 
 interface SorterInterface
 {
-    public function sort(ProxySourceItem $a, ProxySourceItem $b);
+    public function sort(ProxySourceItem $a, ProxySourceItem $b): int;
 }

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ConvertToLowercaseStrategy.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ConvertToLowercaseStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/PermalinkStrategyInterface.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/PermalinkStrategyInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/PermalinkStrategyInterface.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/PermalinkStrategyInterface.php
@@ -13,5 +13,5 @@ namespace Sculpin\Contrib\Taxonomy\PermalinkStrategy;
 
 interface PermalinkStrategyInterface
 {
-    public function process($str);
+    public function process($str): void;
 }

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ToyRocketStrategy.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/ToyRocketStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/TranslateSpacesToDashesStrategy.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategy/TranslateSpacesToDashesStrategy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
@@ -23,7 +23,7 @@ class PermalinkStrategyCollection
         $this->strategies = new SplObjectStorage();
     }
 
-    public function push(PermalinkStrategyInterface $strategy)
+    public function push(PermalinkStrategyInterface $strategy): void
     {
         $this->strategies->attach($strategy);
     }

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollection.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Contrib\Taxonomy;
 
 use Sculpin\Contrib\Taxonomy\PermalinkStrategy\PermalinkStrategyInterface;
+use SplObjectStorage;
 
 class PermalinkStrategyCollection
 {
@@ -19,7 +20,7 @@ class PermalinkStrategyCollection
 
     public function __construct()
     {
-        $this->strategies = new \SplObjectStorage();
+        $this->strategies = new SplObjectStorage();
     }
 
     public function push(PermalinkStrategyInterface $strategy)

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
@@ -46,7 +46,7 @@ class ProxySourceTaxonomyDataProvider implements DataProviderInterface, EventSub
         ];
     }
 
-    public function beforeRun(SourceSetEvent $sourceSetEvent)
+    public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
         $taxons = [];
         $dataProvider = $this->dataProviderManager->dataProvider($this->dataProviderName);

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
@@ -34,7 +34,7 @@ class ProxySourceTaxonomyDataProvider implements DataProviderInterface, EventSub
         $this->taxonomyKey = $taxonomyKey;
     }
 
-    public function provideData()
+    public function provideData(): array
     {
         return $this->taxons;
     }

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyDataProvider.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ProxySourceTaxonomyDataProvider implements DataProviderInterface, EventSubscriberInterface
 {
-    private $taxons = array();
+    private $taxons = [];
     private $dataProviderManager;
     private $dataProviderName;
     private $taxonomyKey;
@@ -41,19 +41,19 @@ class ProxySourceTaxonomyDataProvider implements DataProviderInterface, EventSub
 
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             Sculpin::EVENT_BEFORE_RUN => 'beforeRun',
-        );
+        ];
     }
 
     public function beforeRun(SourceSetEvent $sourceSetEvent)
     {
-        $taxons = array();
+        $taxons = [];
         $dataProvider = $this->dataProviderManager->dataProvider($this->dataProviderName);
 
         foreach ($dataProvider->provideData() as $item) {
             if ($itemTaxons = $item->data()->get($this->taxonomyKey)) {
-                $normalizedItemTaxons = array();
+                $normalizedItemTaxons = [];
                 foreach ((array) $itemTaxons as $itemTaxon) {
                     $normalizedItemTaxon = trim($itemTaxon);
                     $taxons[$normalizedItemTaxon][] = $item;

--- a/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
+++ b/src/Sculpin/Contrib/Taxonomy/ProxySourceTaxonomyIndexGenerator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -42,7 +42,7 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
         $dataProvider = $this->dataProviderManager->dataProvider($this->dataProviderName);
         $taxons = $dataProvider->provideData();
 
-        $generatedSources = array();
+        $generatedSources = [];
         foreach ($taxons as $taxon => $items) {
             $generatedSource = $source->duplicate(
                 $source->sourceId().':'.$this->injectedTaxonKey.'='.$taxon
@@ -58,7 +58,7 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
             if (preg_match('/^(.+?)\.(.+)$/', $basename, $matches)) {
                 $urlTaxon = $this->permalinkStrategyCollection->process($taxon);
                 $indexType = $matches[2];
-                $suffix = in_array($indexType, array('xml', 'rss', 'json')) ? '.'.$indexType : '/';
+                $suffix = in_array($indexType, ['xml', 'rss', 'json']) ? '.'.$indexType : '/';
                 $permalink = $permalink.'/'.$urlTaxon.$suffix;
             } else {
                 // not sure what case this is?
@@ -83,7 +83,7 @@ class ProxySourceTaxonomyIndexGenerator implements GeneratorInterface
             if ($indexType) {
                 foreach ($items as $item) {
                     $key = $this->injectedTaxonKey.'_'.$indexType.'_index_permalinks';
-                    $taxonIndexPermalinks = $item->data()->get($key) ?: array();
+                    $taxonIndexPermalinks = $item->data()->get($key) ?: [];
 
                     $taxonIndexPermalinks[$taxon] = $permalink;
 

--- a/src/Sculpin/Core/Configuration/Configuration.php
+++ b/src/Sculpin/Core/Configuration/Configuration.php
@@ -75,7 +75,6 @@ class Configuration extends BaseConfiguration
      * NOTE: Does not clear existing values first.
      *
      * @param array $excludes Excludes.
-     *
      */
     public function setExcludes(array $excludes = []): Configuration
     {
@@ -88,8 +87,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Add an exclude pattern
-     *
-     *
      */
     public function addExclude(string $pattern): Configuration
     {
@@ -118,7 +115,6 @@ class Configuration extends BaseConfiguration
      * NOTE: Does not clear existing values first.
      *
      * @param array $ignores Ignores.
-     *
      */
     public function setIgnores(array $ignores = []): Configuration
     {
@@ -131,8 +127,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Add an ignore pattern
-     *
-     *
      */
     public function addIgnore(string $pattern): Configuration
     {
@@ -161,7 +155,6 @@ class Configuration extends BaseConfiguration
      * NOTE: Does not clear existing values first.
      *
      * @param array $raws Raws.
-     *
      */
     public function setRaws(array $raws = []): Configuration
     {
@@ -174,8 +167,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Add a raw pattern
-     *
-     *
      */
     public function addRaw(string $pattern): Configuration
     {
@@ -201,7 +192,6 @@ class Configuration extends BaseConfiguration
      * Set source directory
      *
      * @param string $sourceDir Source directory
-     *
      */
     public function setSourceDir(string $sourceDir): Configuration
     {
@@ -266,7 +256,6 @@ class Configuration extends BaseConfiguration
      * Set default formatter
      *
      * @param string $defaultFormatter Default formatter
-     *
      */
     public function setDefaultFormatter(string $defaultFormatter): Configuration
     {

--- a/src/Sculpin/Core/Configuration/Configuration.php
+++ b/src/Sculpin/Core/Configuration/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -25,21 +25,21 @@ class Configuration extends BaseConfiguration
      *
      * @var array
      */
-    private $excludes = array();
+    private $excludes = [];
 
     /**
      * Ignore patterns
      *
      * @var array
      */
-    private $ignores = array();
+    private $ignores = [];
 
     /**
      * Raw patterns
      *
      * @var array
      */
-    private $raws = array();
+    private $raws = [];
 
     /**
      * Source directory
@@ -78,7 +78,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function setExcludes(array $excludes = array())
+    public function setExcludes(array $excludes = []): Configuration
     {
         foreach ($excludes as $exclude) {
             $this->addExclude($exclude);
@@ -94,7 +94,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function addExclude($pattern)
+    public function addExclude(string $pattern): Configuration
     {
         if (substr($pattern, 0, 2)=='./') {
             $pattern = substr($pattern, 2);
@@ -112,7 +112,7 @@ class Configuration extends BaseConfiguration
      *
      * @return array
      */
-    public function excludes()
+    public function excludes(): array
     {
         return $this->excludes;
     }
@@ -126,7 +126,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function setIgnores(array $ignores = array())
+    public function setIgnores(array $ignores = []): Configuration
     {
         foreach ($ignores as $ignore) {
             $this->addIgnore($ignore);
@@ -142,7 +142,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function addIgnore($pattern)
+    public function addIgnore(string $pattern): Configuration
     {
         if (substr($pattern, 0, 2)=='./') {
             $pattern = substr($pattern, 2);
@@ -160,7 +160,7 @@ class Configuration extends BaseConfiguration
      *
      * @return array
      */
-    public function ignores()
+    public function ignores(): array
     {
         return $this->ignores;
     }
@@ -174,7 +174,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function setRaws(array $raws = array())
+    public function setRaws(array $raws = []): Configuration
     {
         foreach ($raws as $raw) {
             $this->addRaw($raw);
@@ -190,7 +190,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function addRaw($pattern)
+    public function addRaw(string $pattern): Configuration
     {
         if (substr($pattern, 0, 2)=='./') {
             $pattern = substr($pattern, 2);
@@ -207,7 +207,7 @@ class Configuration extends BaseConfiguration
      *
      * @return array
      */
-    public function raws()
+    public function raws(): array
     {
         return $this->raws;
     }
@@ -219,7 +219,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function setSourceDir($sourceDir)
+    public function setSourceDir(string $sourceDir): Configuration
     {
         $this->sourceDir = $sourceDir;
 
@@ -231,7 +231,7 @@ class Configuration extends BaseConfiguration
      *
      * @return string
      */
-    public function sourceDir()
+    public function sourceDir(): string
     {
         return $this->sourceDir;
     }
@@ -243,7 +243,7 @@ class Configuration extends BaseConfiguration
      *
      * @return $this
      */
-    public function setOutputDir($outputDir)
+    public function setOutputDir(string $outputDir)
     {
         $this->outputDir = $outputDir;
 
@@ -255,7 +255,7 @@ class Configuration extends BaseConfiguration
      *
      * @return string
      */
-    public function outputDir()
+    public function outputDir(): string
     {
         return $this->outputDir;
     }
@@ -267,7 +267,7 @@ class Configuration extends BaseConfiguration
      *
      * @return $this
      */
-    public function setPermalink($permalink)
+    public function setPermalink(string $permalink)
     {
         $this->permalink = $permalink;
 
@@ -279,7 +279,7 @@ class Configuration extends BaseConfiguration
      *
      * @return string
      */
-    public function permalink()
+    public function permalink(): string
     {
         return $this->permalink;
     }
@@ -291,7 +291,7 @@ class Configuration extends BaseConfiguration
      *
      * @return Configuration
      */
-    public function setDefaultFormatter($defaultFormatter)
+    public function setDefaultFormatter(string $defaultFormatter): Configuration
     {
         $this->defaultFormatter = $defaultFormatter;
 
@@ -303,7 +303,7 @@ class Configuration extends BaseConfiguration
      *
      * @return string
      */
-    public function defaultFormatter()
+    public function defaultFormatter(): string
     {
         return $this->defaultFormatter;
     }

--- a/src/Sculpin/Core/Configuration/Configuration.php
+++ b/src/Sculpin/Core/Configuration/Configuration.php
@@ -76,7 +76,6 @@ class Configuration extends BaseConfiguration
      *
      * @param array $excludes Excludes.
      *
-     * @return Configuration
      */
     public function setExcludes(array $excludes = []): Configuration
     {
@@ -91,7 +90,6 @@ class Configuration extends BaseConfiguration
      * Add an exclude pattern
      *
      *
-     * @return Configuration
      */
     public function addExclude(string $pattern): Configuration
     {
@@ -121,7 +119,6 @@ class Configuration extends BaseConfiguration
      *
      * @param array $ignores Ignores.
      *
-     * @return Configuration
      */
     public function setIgnores(array $ignores = []): Configuration
     {
@@ -136,7 +133,6 @@ class Configuration extends BaseConfiguration
      * Add an ignore pattern
      *
      *
-     * @return Configuration
      */
     public function addIgnore(string $pattern): Configuration
     {
@@ -166,7 +162,6 @@ class Configuration extends BaseConfiguration
      *
      * @param array $raws Raws.
      *
-     * @return Configuration
      */
     public function setRaws(array $raws = []): Configuration
     {
@@ -181,7 +176,6 @@ class Configuration extends BaseConfiguration
      * Add a raw pattern
      *
      *
-     * @return Configuration
      */
     public function addRaw(string $pattern): Configuration
     {
@@ -208,7 +202,6 @@ class Configuration extends BaseConfiguration
      *
      * @param string $sourceDir Source directory
      *
-     * @return Configuration
      */
     public function setSourceDir(string $sourceDir): Configuration
     {
@@ -274,7 +267,6 @@ class Configuration extends BaseConfiguration
      *
      * @param string $defaultFormatter Default formatter
      *
-     * @return Configuration
      */
     public function setDefaultFormatter(string $defaultFormatter): Configuration
     {

--- a/src/Sculpin/Core/Configuration/Configuration.php
+++ b/src/Sculpin/Core/Configuration/Configuration.php
@@ -90,7 +90,6 @@ class Configuration extends BaseConfiguration
     /**
      * Add an exclude pattern
      *
-     * @param string $pattern
      *
      * @return Configuration
      */
@@ -109,8 +108,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Excludes
-     *
-     * @return array
      */
     public function excludes(): array
     {
@@ -138,7 +135,6 @@ class Configuration extends BaseConfiguration
     /**
      * Add an ignore pattern
      *
-     * @param string $pattern
      *
      * @return Configuration
      */
@@ -157,8 +153,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Ignores
-     *
-     * @return array
      */
     public function ignores(): array
     {
@@ -186,7 +180,6 @@ class Configuration extends BaseConfiguration
     /**
      * Add a raw pattern
      *
-     * @param string $pattern
      *
      * @return Configuration
      */
@@ -204,8 +197,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Raws
-     *
-     * @return array
      */
     public function raws(): array
     {
@@ -228,8 +219,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Source directory
-     *
-     * @return string
      */
     public function sourceDir(): string
     {
@@ -252,8 +241,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Output directory
-     *
-     * @return string
      */
     public function outputDir(): string
     {
@@ -276,8 +263,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Permalink
-     *
-     * @return string
      */
     public function permalink(): string
     {
@@ -300,8 +285,6 @@ class Configuration extends BaseConfiguration
 
     /**
      * Default formatter
-     *
-     * @return string
      */
     public function defaultFormatter(): string
     {

--- a/src/Sculpin/Core/Console/Command/ContainerAwareCommand.php
+++ b/src/Sculpin/Core/Console/Command/ContainerAwareCommand.php
@@ -46,7 +46,7 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
      *
      * @see ContainerAwareInterface::setContainer()
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(?ContainerInterface $container = null): void
     {
         $this->container = $container;
     }

--- a/src/Sculpin/Core/Console/Command/ContainerAwareCommand.php
+++ b/src/Sculpin/Core/Console/Command/ContainerAwareCommand.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is part of the Symfony package.
@@ -30,7 +30,7 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
     /**
      * @return ContainerInterface
      */
-    protected function getContainer()
+    protected function getContainer(): ContainerInterface
     {
         if (null === $this->container) {
             $this->container = $this->getApplication()->getKernel()->getContainer();

--- a/src/Sculpin/Core/Converter/ConverterContextInterface.php
+++ b/src/Sculpin/Core/Converter/ConverterContextInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,12 +23,12 @@ interface ConverterContextInterface
      *
      * @return string
      */
-    public function content();
+    public function content(): string;
 
     /**
      * Set content
      *
      * @param string $content Content
      */
-    public function setContent($content);
+    public function setContent(string $content);
 }

--- a/src/Sculpin/Core/Converter/ConverterContextInterface.php
+++ b/src/Sculpin/Core/Converter/ConverterContextInterface.php
@@ -20,7 +20,6 @@ interface ConverterContextInterface
 {
     /**
      * Content
-     *
      */
     public function content(): string;
 

--- a/src/Sculpin/Core/Converter/ConverterContextInterface.php
+++ b/src/Sculpin/Core/Converter/ConverterContextInterface.php
@@ -21,7 +21,6 @@ interface ConverterContextInterface
     /**
      * Content
      *
-     * @return string
      */
     public function content(): string;
 
@@ -30,5 +29,5 @@ interface ConverterContextInterface
      *
      * @param string $content Content
      */
-    public function setContent(string $content);
+    public function setContent(string $content): void;
 }

--- a/src/Sculpin/Core/Converter/ConverterInterface.php
+++ b/src/Sculpin/Core/Converter/ConverterInterface.php
@@ -20,7 +20,6 @@ interface ConverterInterface
 {
     /**
      * Convert content.
-     *
      */
     public function convert(ConverterContextInterface $converterContext);
 }

--- a/src/Sculpin/Core/Converter/ConverterInterface.php
+++ b/src/Sculpin/Core/Converter/ConverterInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -21,7 +21,6 @@ interface ConverterInterface
     /**
      * Convert content.
      *
-     * @param ConverterContextInterface $converterContext
      */
     public function convert(ConverterContextInterface $converterContext);
 }

--- a/src/Sculpin/Core/Converter/ConverterInterface.php
+++ b/src/Sculpin/Core/Converter/ConverterInterface.php
@@ -21,5 +21,5 @@ interface ConverterInterface
     /**
      * Convert content.
      */
-    public function convert(ConverterContextInterface $converterContext);
+    public function convert(ConverterContextInterface $converterContext): void;
 }

--- a/src/Sculpin/Core/Converter/ConverterManager.php
+++ b/src/Sculpin/Core/Converter/ConverterManager.php
@@ -64,7 +64,7 @@ class ConverterManager
      * @param string             $name      Name
      * @param ConverterInterface $converter Converter
      */
-    public function registerConverter(string $name, ConverterInterface $converter)
+    public function registerConverter(string $name, ConverterInterface $converter): void
     {
         $this->converters[$name] = $converter;
     }
@@ -74,7 +74,6 @@ class ConverterManager
      *
      * @param string $name Name
      *
-     * @return ConverterInterface
      */
     public function converter(string $name): ConverterInterface
     {
@@ -86,7 +85,7 @@ class ConverterManager
      *
      * @param SourceInterface $source Source
      */
-    public function convertSource(SourceInterface $source)
+    public function convertSource(SourceInterface $source): void
     {
         $converters = $source->data()->get('converters');
         if (!$converters || !is_array($converters)) {

--- a/src/Sculpin/Core/Converter/ConverterManager.php
+++ b/src/Sculpin/Core/Converter/ConverterManager.php
@@ -73,7 +73,6 @@ class ConverterManager
      * Converter
      *
      * @param string $name Name
-     *
      */
     public function converter(string $name): ConverterInterface
     {

--- a/src/Sculpin/Core/Converter/ConverterManager.php
+++ b/src/Sculpin/Core/Converter/ConverterManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -43,7 +43,7 @@ class ConverterManager
      *
      * @var array
      */
-    protected $converters = array();
+    protected $converters = [];
 
     /**
      * Constructor.
@@ -64,7 +64,7 @@ class ConverterManager
      * @param string             $name      Name
      * @param ConverterInterface $converter Converter
      */
-    public function registerConverter($name, ConverterInterface $converter)
+    public function registerConverter(string $name, ConverterInterface $converter)
     {
         $this->converters[$name] = $converter;
     }
@@ -76,7 +76,7 @@ class ConverterManager
      *
      * @return ConverterInterface
      */
-    public function converter($name)
+    public function converter(string $name): ConverterInterface
     {
         return $this->converters[$name];
     }
@@ -90,7 +90,7 @@ class ConverterManager
     {
         $converters = $source->data()->get('converters');
         if (!$converters || !is_array($converters)) {
-            $converters = array('null');
+            $converters = ['null'];
         }
 
         foreach ($converters as $converter) {

--- a/src/Sculpin/Core/Converter/NullConverter.php
+++ b/src/Sculpin/Core/Converter/NullConverter.php
@@ -21,7 +21,7 @@ class NullConverter implements ConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(ConverterContextInterface $converterContext)
+    public function convert(ConverterContextInterface $converterContext): void
     {
     }
 }

--- a/src/Sculpin/Core/Converter/NullConverter.php
+++ b/src/Sculpin/Core/Converter/NullConverter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Converter/ParserInterface.php
+++ b/src/Sculpin/Core/Converter/ParserInterface.php
@@ -12,5 +12,5 @@ interface ParserInterface
      *
      * @return string
      */
-    public function transform(string $content): string;
+    public function transform($content): string;
 }

--- a/src/Sculpin/Core/Converter/ParserInterface.php
+++ b/src/Sculpin/Core/Converter/ParserInterface.php
@@ -8,9 +8,7 @@ namespace Sculpin\Core\Converter;
 interface ParserInterface
 {
     /**
-     * @param string $content
-     *
-     * @return string
+     * @param string|mixed $content
      */
     public function transform($content): string;
 }

--- a/src/Sculpin/Core/Converter/ParserInterface.php
+++ b/src/Sculpin/Core/Converter/ParserInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Core\Converter;
 
@@ -12,5 +12,5 @@ interface ParserInterface
      *
      * @return string
      */
-    public function transform($content);
+    public function transform(string $content): string;
 }

--- a/src/Sculpin/Core/Converter/SourceConverterContext.php
+++ b/src/Sculpin/Core/Converter/SourceConverterContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -40,7 +40,7 @@ class SourceConverterContext implements ConverterContextInterface
     /**
      * {@inheritdoc}
      */
-    public function content()
+    public function content(): string
     {
         return $this->source->content();
     }
@@ -48,7 +48,7 @@ class SourceConverterContext implements ConverterContextInterface
     /**
      * {@inheritdoc}
      */
-    public function setContent($content)
+    public function setContent(string $content)
     {
         $this->source->setContent($content);
     }

--- a/src/Sculpin/Core/Converter/SourceConverterContext.php
+++ b/src/Sculpin/Core/Converter/SourceConverterContext.php
@@ -48,7 +48,7 @@ class SourceConverterContext implements ConverterContextInterface
     /**
      * {@inheritdoc}
      */
-    public function setContent(string $content)
+    public function setContent(string $content): void
     {
         $this->source->setContent($content);
     }

--- a/src/Sculpin/Core/DataProvider/DataProviderInterface.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderInterface.php
@@ -21,7 +21,7 @@ interface DataProviderInterface
     /**
      * Provide data.
      *
-     * @return array
+     * @return array|mixed
      */
-    public function provideData(): array;
+    public function provideData();
 }

--- a/src/Sculpin/Core/DataProvider/DataProviderInterface.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,5 +23,5 @@ interface DataProviderInterface
      *
      * @return array
      */
-    public function provideData();
+    public function provideData(): array;
 }

--- a/src/Sculpin/Core/DataProvider/DataProviderManager.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,7 +23,7 @@ class DataProviderManager
      *
      * @var array
      */
-    protected $dataProviders = array();
+    protected $dataProviders = [];
 
     /**
      * Register data provider
@@ -31,7 +31,7 @@ class DataProviderManager
      * @param string                $name         Name
      * @param DataProviderInterface $dataProvider Data provider
      */
-    public function registerDataProvider($name, DataProviderInterface $dataProvider)
+    public function registerDataProvider(string $name, DataProviderInterface $dataProvider)
     {
         $this->dataProviders[$name] = $dataProvider;
     }
@@ -41,7 +41,7 @@ class DataProviderManager
      *
      * @return array
      */
-    public function dataProviders()
+    public function dataProviders(): array
     {
         return array_keys($this->dataProviders);
     }
@@ -53,7 +53,7 @@ class DataProviderManager
      *
      * @return DataProviderInterface
      */
-    public function dataProvider($name)
+    public function dataProvider(string $name): DataProviderInterface
     {
         return $this->dataProviders[$name];
     }

--- a/src/Sculpin/Core/DataProvider/DataProviderManager.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderManager.php
@@ -48,7 +48,6 @@ class DataProviderManager
      * Data provider
      *
      * @param string $name Name
-     *
      */
     public function dataProvider(string $name): DataProviderInterface
     {

--- a/src/Sculpin/Core/DataProvider/DataProviderManager.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderManager.php
@@ -38,8 +38,6 @@ class DataProviderManager
 
     /**
      * List of registered ata provider names
-     *
-     * @return array
      */
     public function dataProviders(): array
     {

--- a/src/Sculpin/Core/DataProvider/DataProviderManager.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderManager.php
@@ -31,7 +31,7 @@ class DataProviderManager
      * @param string                $name         Name
      * @param DataProviderInterface $dataProvider Data provider
      */
-    public function registerDataProvider(string $name, DataProviderInterface $dataProvider)
+    public function registerDataProvider(string $name, DataProviderInterface $dataProvider): void
     {
         $this->dataProviders[$name] = $dataProvider;
     }
@@ -49,7 +49,6 @@ class DataProviderManager
      *
      * @param string $name Name
      *
-     * @return DataProviderInterface
      */
     public function dataProvider(string $name): DataProviderInterface
     {

--- a/src/Sculpin/Core/Event/ConvertEvent.php
+++ b/src/Sculpin/Core/Event/ConvertEvent.php
@@ -67,8 +67,6 @@ class ConvertEvent extends Event
 
     /**
      * Converter
-     *
-     * @return string
      */
     public function converter(): string
     {
@@ -78,7 +76,6 @@ class ConvertEvent extends Event
     /**
      * Test if Source is converted by requested converter
      *
-     * @param string $requestedConverter
      *
      * @return boolean
      */
@@ -89,8 +86,6 @@ class ConvertEvent extends Event
 
     /**
      * Test if Source is formatted by requested formatter
-     *
-     * @param string $requestedFormatter
      */
     public function isFormattedBy(string $requestedFormatter): string
     {

--- a/src/Sculpin/Core/Event/ConvertEvent.php
+++ b/src/Sculpin/Core/Event/ConvertEvent.php
@@ -84,7 +84,9 @@ class ConvertEvent extends Event
      */
     public function isFormattedBy(string $requestedFormatter): string
     {
-        return $requestedFormatter === $this->source->data()->get('formatter') ? $requestedFormatter : $this->defaultFormatter;
+        return $requestedFormatter === $this->source->data()->get('formatter')
+            ? $requestedFormatter
+            : $this->defaultFormatter;
     }
 
     /**

--- a/src/Sculpin/Core/Event/ConvertEvent.php
+++ b/src/Sculpin/Core/Event/ConvertEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -48,7 +48,7 @@ class ConvertEvent extends Event
      * @param string          $converter        Converter
      * @param string          $defaultFormatter Default formatter
      */
-    public function __construct(SourceInterface $source, $converter, $defaultFormatter)
+    public function __construct(SourceInterface $source, string $converter, string $defaultFormatter)
     {
         $this->source = $source;
         $this->converter = $converter;
@@ -60,7 +60,7 @@ class ConvertEvent extends Event
      *
      * @return SourceInterface
      */
-    public function source()
+    public function source(): SourceInterface
     {
         return $this->source;
     }
@@ -70,7 +70,7 @@ class ConvertEvent extends Event
      *
      * @return string
      */
-    public function converter()
+    public function converter(): string
     {
         return $this->converter;
     }
@@ -82,7 +82,7 @@ class ConvertEvent extends Event
      *
      * @return boolean
      */
-    public function isConvertedBy($requestedConverter)
+    public function isConvertedBy(string $requestedConverter): bool
     {
         return $requestedConverter === $this->converter;
     }
@@ -94,7 +94,7 @@ class ConvertEvent extends Event
      *
      * @return boolean
      */
-    public function isFormattedBy($requestedFormatter)
+    public function isFormattedBy(string $requestedFormatter): bool
     {
         return $requestedFormatter == $this->source->data()->get('formatter') ?: $this->defaultFormatter;
     }
@@ -107,7 +107,7 @@ class ConvertEvent extends Event
      *
      * @return boolean
      */
-    public function isHandledBy($requestedConverter, $requestedFormatter)
+    public function isHandledBy(string $requestedConverter, string $requestedFormatter): bool
     {
         return $this->isConvertedBy($requestedConverter) and $this->isFormattedBy($requestedFormatter);
     }

--- a/src/Sculpin/Core/Event/ConvertEvent.php
+++ b/src/Sculpin/Core/Event/ConvertEvent.php
@@ -57,7 +57,6 @@ class ConvertEvent extends Event
 
     /**
      * Source
-     *
      */
     public function source(): SourceInterface
     {
@@ -74,8 +73,6 @@ class ConvertEvent extends Event
 
     /**
      * Test if Source is converted by requested converter
-     *
-     *
      */
     public function isConvertedBy(string $requestedConverter): bool
     {
@@ -95,7 +92,6 @@ class ConvertEvent extends Event
      *
      * @param string $requestedConverter Converter
      * @param string $requestedFormatter Formatter
-     *
      */
     public function isHandledBy(string $requestedConverter, string $requestedFormatter): bool
     {

--- a/src/Sculpin/Core/Event/ConvertEvent.php
+++ b/src/Sculpin/Core/Event/ConvertEvent.php
@@ -58,7 +58,6 @@ class ConvertEvent extends Event
     /**
      * Source
      *
-     * @return SourceInterface
      */
     public function source(): SourceInterface
     {
@@ -77,7 +76,6 @@ class ConvertEvent extends Event
      * Test if Source is converted by requested converter
      *
      *
-     * @return boolean
      */
     public function isConvertedBy(string $requestedConverter): bool
     {
@@ -98,7 +96,6 @@ class ConvertEvent extends Event
      * @param string $requestedConverter Converter
      * @param string $requestedFormatter Formatter
      *
-     * @return boolean
      */
     public function isHandledBy(string $requestedConverter, string $requestedFormatter): bool
     {

--- a/src/Sculpin/Core/Event/ConvertEvent.php
+++ b/src/Sculpin/Core/Event/ConvertEvent.php
@@ -91,12 +91,10 @@ class ConvertEvent extends Event
      * Test if Source is formatted by requested formatter
      *
      * @param string $requestedFormatter
-     *
-     * @return boolean
      */
-    public function isFormattedBy(string $requestedFormatter): bool
+    public function isFormattedBy(string $requestedFormatter): string
     {
-        return $requestedFormatter == $this->source->data()->get('formatter') ?: $this->defaultFormatter;
+        return $requestedFormatter === $this->source->data()->get('formatter') ? $requestedFormatter : $this->defaultFormatter;
     }
 
     /**

--- a/src/Sculpin/Core/Event/Event.php
+++ b/src/Sculpin/Core/Event/Event.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Event/FormatEvent.php
+++ b/src/Sculpin/Core/Event/FormatEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -42,7 +42,7 @@ class FormatEvent extends Event
      *
      * @return FormatContext
      */
-    public function formatContext()
+    public function formatContext(): FormatContext
     {
         return $this->formatContext;
     }

--- a/src/Sculpin/Core/Event/FormatEvent.php
+++ b/src/Sculpin/Core/Event/FormatEvent.php
@@ -39,7 +39,6 @@ class FormatEvent extends Event
 
     /**
      * Format Context
-     *
      */
     public function formatContext(): FormatContext
     {

--- a/src/Sculpin/Core/Event/FormatEvent.php
+++ b/src/Sculpin/Core/Event/FormatEvent.php
@@ -40,7 +40,6 @@ class FormatEvent extends Event
     /**
      * Format Context
      *
-     * @return FormatContext
      */
     public function formatContext(): FormatContext
     {

--- a/src/Sculpin/Core/Event/SourceSetEvent.php
+++ b/src/Sculpin/Core/Event/SourceSetEvent.php
@@ -39,8 +39,6 @@ class SourceSetEvent extends Event
 
     /**
      * All sources
-     *
-     * @return array
      */
     public function allSources(): array
     {
@@ -49,8 +47,6 @@ class SourceSetEvent extends Event
 
     /**
      * Updated sources
-     *
-     * @return array
      */
     public function updatedSources(): array
     {

--- a/src/Sculpin/Core/Event/SourceSetEvent.php
+++ b/src/Sculpin/Core/Event/SourceSetEvent.php
@@ -56,7 +56,6 @@ class SourceSetEvent extends Event
     /**
      * Current source set
      *
-     * @return SourceSet
      */
     public function sourceSet(): SourceSet
     {

--- a/src/Sculpin/Core/Event/SourceSetEvent.php
+++ b/src/Sculpin/Core/Event/SourceSetEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -42,7 +42,7 @@ class SourceSetEvent extends Event
      *
      * @return array
      */
-    public function allSources()
+    public function allSources(): array
     {
         return $this->sourceSet->allSources();
     }
@@ -52,7 +52,7 @@ class SourceSetEvent extends Event
      *
      * @return array
      */
-    public function updatedSources()
+    public function updatedSources(): array
     {
         return $this->sourceSet->updatedSources();
     }
@@ -62,7 +62,7 @@ class SourceSetEvent extends Event
      *
      * @return SourceSet
      */
-    public function sourceSet()
+    public function sourceSet(): SourceSet
     {
         return $this->sourceSet;
     }

--- a/src/Sculpin/Core/Event/SourceSetEvent.php
+++ b/src/Sculpin/Core/Event/SourceSetEvent.php
@@ -55,7 +55,6 @@ class SourceSetEvent extends Event
 
     /**
      * Current source set
-     *
      */
     public function sourceSet(): SourceSet
     {

--- a/src/Sculpin/Core/Formatter/FormatContext.php
+++ b/src/Sculpin/Core/Formatter/FormatContext.php
@@ -73,7 +73,6 @@ class FormatContext
 
     /**
      * Data
-     *
      */
     public function data(): Data
     {

--- a/src/Sculpin/Core/Formatter/FormatContext.php
+++ b/src/Sculpin/Core/Formatter/FormatContext.php
@@ -74,7 +74,6 @@ class FormatContext
     /**
      * Data
      *
-     * @return Data
      */
     public function data(): Data
     {

--- a/src/Sculpin/Core/Formatter/FormatContext.php
+++ b/src/Sculpin/Core/Formatter/FormatContext.php
@@ -57,8 +57,6 @@ class FormatContext
 
     /**
      * Template ID
-     *
-     * @return string
      */
     public function templateId(): string
     {
@@ -67,8 +65,6 @@ class FormatContext
 
     /**
      * Template
-     *
-     * @return string
      */
     public function template(): string
     {
@@ -87,8 +83,6 @@ class FormatContext
 
     /**
      * Formatter
-     *
-     * @return string
      */
     public function formatter(): string
     {

--- a/src/Sculpin/Core/Formatter/FormatContext.php
+++ b/src/Sculpin/Core/Formatter/FormatContext.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -48,7 +48,7 @@ class FormatContext
      * @param string $template   Template
      * @param array  $data       Data
      */
-    public function __construct($templateId, $template, $data)
+    public function __construct(string $templateId, string $template, array $data)
     {
         $this->templateId = $templateId;
         $this->template = $template;
@@ -60,7 +60,7 @@ class FormatContext
      *
      * @return string
      */
-    public function templateId()
+    public function templateId(): string
     {
         return $this->templateId;
     }
@@ -70,7 +70,7 @@ class FormatContext
      *
      * @return string
      */
-    public function template()
+    public function template(): string
     {
         return $this->template;
     }
@@ -80,7 +80,7 @@ class FormatContext
      *
      * @return Data
      */
-    public function data()
+    public function data(): Data
     {
         return $this->data;
     }
@@ -90,7 +90,7 @@ class FormatContext
      *
      * @return string
      */
-    public function formatter()
+    public function formatter(): string
     {
         return $this->data->get('formatter');
     }

--- a/src/Sculpin/Core/Formatter/FormatterInterface.php
+++ b/src/Sculpin/Core/Formatter/FormatterInterface.php
@@ -43,5 +43,5 @@ interface FormatterInterface
      * (if applicable) or do anything else they need to do after having
      * run once.
      */
-    public function reset();
+    public function reset(): void;
 }

--- a/src/Sculpin/Core/Formatter/FormatterInterface.php
+++ b/src/Sculpin/Core/Formatter/FormatterInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -25,7 +25,7 @@ interface FormatterInterface
      *
      * @return array
      */
-    public function formatBlocks(FormatContext $formatContext);
+    public function formatBlocks(FormatContext $formatContext): array;
 
     /**
      * Format an entire page
@@ -34,7 +34,7 @@ interface FormatterInterface
      *
      * @return string
      */
-    public function formatPage(FormatContext $formatContext);
+    public function formatPage(FormatContext $formatContext): string;
 
     /**
      * Reset

--- a/src/Sculpin/Core/Formatter/FormatterInterface.php
+++ b/src/Sculpin/Core/Formatter/FormatterInterface.php
@@ -23,18 +23,18 @@ interface FormatterInterface
      *
      * @param FormatContext $formatContext Format context
      *
-     * @return array
+     * @return array|void
      */
-    public function formatBlocks(FormatContext $formatContext): array;
+    public function formatBlocks(FormatContext $formatContext);
 
     /**
      * Format an entire page
      *
      * @param FormatContext $formatContext Format context
      *
-     * @return string
+     * @return string|void
      */
-    public function formatPage(FormatContext $formatContext): string;
+    public function formatPage(FormatContext $formatContext);
 
     /**
      * Reset

--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -81,7 +81,6 @@ class FormatterManager
      * Build base format context
      *
      * @param mixed $context
-     *
      */
     protected function buildBaseFormatContext($context): Configuration
     {
@@ -117,7 +116,6 @@ class FormatterManager
      * @param string $templateId Template ID
      * @param string $template   Template
      * @param array  $context    Context
-     *
      */
     public function buildFormatContext(string $templateId, string $template, array $context): FormatContext
     {
@@ -151,7 +149,6 @@ class FormatterManager
      * Formatter
      *
      * @param string $name Name
-     *
      */
     public function formatter(string $name): FormatterInterface
     {
@@ -164,8 +161,6 @@ class FormatterManager
      * @param string $templateId Template ID
      * @param string $template   Template
      * @param array  $context    Context
-     *
-     * @return string|null
      */
     public function formatPage(string $templateId, string $template, array $context): ?string
     {
@@ -185,8 +180,6 @@ class FormatterManager
      * Format a page for a Source
      *
      * @param SourceInterface $source Source
-     *
-     * @return string|null
      */
     public function formatSourcePage(SourceInterface $source): ?string
     {
@@ -203,8 +196,6 @@ class FormatterManager
      * @param string $templateId Template ID
      * @param string $template   Template
      * @param array  $context    Context
-     *
-     * @return array|null
      */
     public function formatBlocks(string $templateId, string $template, array $context): ?array
     {
@@ -224,8 +215,6 @@ class FormatterManager
      * Format blocks for a Source
      *
      * @param SourceInterface $source Source
-     *
-     * @return array|null
      */
     public function formatSourceBlocks(SourceInterface $source): ?array
     {

--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -70,7 +70,7 @@ class FormatterManager
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         Configuration $siteConfiguration,
-        DataProviderManager $dataProviderManager = null
+        ?DataProviderManager $dataProviderManager = null
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->siteConfiguration = $siteConfiguration;
@@ -82,7 +82,6 @@ class FormatterManager
      *
      * @param mixed $context
      *
-     * @return Configuration
      */
     protected function buildBaseFormatContext($context): Configuration
     {
@@ -119,7 +118,6 @@ class FormatterManager
      * @param string $template   Template
      * @param array  $context    Context
      *
-     * @return FormatContext
      */
     public function buildFormatContext(string $templateId, string $template, array $context): FormatContext
     {
@@ -140,7 +138,7 @@ class FormatterManager
      * @param string             $name      Name
      * @param FormatterInterface $formatter Formatter
      */
-    public function registerFormatter(string $name, FormatterInterface $formatter)
+    public function registerFormatter(string $name, FormatterInterface $formatter): void
     {
         $this->formatters[$name] = $formatter;
 
@@ -154,7 +152,6 @@ class FormatterManager
      *
      * @param string $name Name
      *
-     * @return FormatterInterface
      */
     public function formatter(string $name): FormatterInterface
     {
@@ -170,7 +167,7 @@ class FormatterManager
      *
      * @return string|null
      */
-    public function formatPage(string $templateId, string $template, array $context)
+    public function formatPage(string $templateId, string $template, array $context): ?string
     {
         $formatContext = $this->buildFormatContext($templateId, $template, $context);
 
@@ -191,7 +188,7 @@ class FormatterManager
      *
      * @return string|null
      */
-    public function formatSourcePage(SourceInterface $source)
+    public function formatSourcePage(SourceInterface $source): ?string
     {
         return $this->formatPage(
             $source->sourceId(),
@@ -209,7 +206,7 @@ class FormatterManager
      *
      * @return array|null
      */
-    public function formatBlocks(string $templateId, string $template, array $context)
+    public function formatBlocks(string $templateId, string $template, array $context): ?array
     {
         $formatContext = $this->buildFormatContext($templateId, $template, $context);
 
@@ -230,7 +227,7 @@ class FormatterManager
      *
      * @return array|null
      */
-    public function formatSourceBlocks(SourceInterface $source)
+    public function formatSourceBlocks(SourceInterface $source): ?array
     {
         return $this->formatBlocks(
             $source->sourceId(),
@@ -256,7 +253,7 @@ class FormatterManager
      *
      * @param DataProviderManager $dataProviderManager Data Provider Manager
      */
-    public function setDataProviderManager(DataProviderManager $dataProviderManager = null)
+    public function setDataProviderManager(?DataProviderManager $dataProviderManager = null): void
     {
         $this->dataProviderManager = $dataProviderManager;
     }

--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -51,7 +51,7 @@ class FormatterManager
      *
      * @var array
      */
-    protected $formatters = array();
+    protected $formatters = [];
 
     /**
      * Default formatter
@@ -84,14 +84,14 @@ class FormatterManager
      *
      * @return Configuration
      */
-    protected function buildBaseFormatContext($context)
+    protected function buildBaseFormatContext($context): Configuration
     {
-        $baseContext = new Configuration(array(
+        $baseContext = new Configuration([
             'site' => $this->siteConfiguration->export(),
             'page' => $context,
             'formatter' => $this->defaultFormatter,
-            'converters' => array(),
-        ));
+            'converters' => [],
+        ]);
 
         if (isset($context['url'])) {
             if ('/' === $context['url']) {
@@ -121,11 +121,11 @@ class FormatterManager
      *
      * @return FormatContext
      */
-    public function buildFormatContext($templateId, $template, $context)
+    public function buildFormatContext(string $templateId, string $template, array $context): FormatContext
     {
         $baseContext = $this->buildBaseFormatContext($context);
 
-        foreach (array('layout', 'formatter', 'converters') as $key) {
+        foreach (['layout', 'formatter', 'converters'] as $key) {
             if (isset($context[$key])) {
                 $baseContext->set($key, $context[$key]);
             }
@@ -140,7 +140,7 @@ class FormatterManager
      * @param string             $name      Name
      * @param FormatterInterface $formatter Formatter
      */
-    public function registerFormatter($name, FormatterInterface $formatter)
+    public function registerFormatter(string $name, FormatterInterface $formatter)
     {
         $this->formatters[$name] = $formatter;
 
@@ -156,7 +156,7 @@ class FormatterManager
      *
      * @return FormatterInterface
      */
-    public function formatter($name)
+    public function formatter(string $name): FormatterInterface
     {
         return $this->formatters[$name];
     }
@@ -170,7 +170,7 @@ class FormatterManager
      *
      * @return string
      */
-    public function formatPage($templateId, $template, $context)
+    public function formatPage(string $templateId, string $template, array $context): string
     {
         $formatContext = $this->buildFormatContext($templateId, $template, $context);
 
@@ -191,7 +191,7 @@ class FormatterManager
      *
      * @return string
      */
-    public function formatSourcePage(SourceInterface $source)
+    public function formatSourcePage(SourceInterface $source): string
     {
         return $this->formatPage(
             $source->sourceId(),
@@ -209,12 +209,12 @@ class FormatterManager
      *
      * @return array
      */
-    public function formatBlocks($templateId, $template, $context)
+    public function formatBlocks(string $templateId, string $template, array $context): array
     {
         $formatContext = $this->buildFormatContext($templateId, $template, $context);
 
         if (!$formatContext->formatter()) {
-            return array('content' => $template);
+            return ['content' => $template];
         }
 
         $this->eventDispatcher->dispatch(Sculpin::EVENT_BEFORE_FORMAT, new FormatEvent($formatContext));
@@ -230,7 +230,7 @@ class FormatterManager
      *
      * @return array
      */
-    public function formatSourceBlocks(SourceInterface $source)
+    public function formatSourceBlocks(SourceInterface $source): array
     {
         return $this->formatBlocks(
             $source->sourceId(),
@@ -244,7 +244,7 @@ class FormatterManager
      *
      * @return string
      */
-    public function defaultFormatter()
+    public function defaultFormatter(): string
     {
         return $this->defaultFormatter;
     }

--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -241,8 +241,6 @@ class FormatterManager
 
     /**
      * Default Formatter.
-     *
-     * @return string
      */
     public function defaultFormatter(): string
     {

--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -168,9 +168,9 @@ class FormatterManager
      * @param string $template   Template
      * @param array  $context    Context
      *
-     * @return string
+     * @return string|null
      */
-    public function formatPage(string $templateId, string $template, array $context): string
+    public function formatPage(string $templateId, string $template, array $context)
     {
         $formatContext = $this->buildFormatContext($templateId, $template, $context);
 
@@ -189,9 +189,9 @@ class FormatterManager
      *
      * @param SourceInterface $source Source
      *
-     * @return string
+     * @return string|null
      */
-    public function formatSourcePage(SourceInterface $source): string
+    public function formatSourcePage(SourceInterface $source)
     {
         return $this->formatPage(
             $source->sourceId(),
@@ -207,9 +207,9 @@ class FormatterManager
      * @param string $template   Template
      * @param array  $context    Context
      *
-     * @return array
+     * @return array|null
      */
-    public function formatBlocks(string $templateId, string $template, array $context): array
+    public function formatBlocks(string $templateId, string $template, array $context)
     {
         $formatContext = $this->buildFormatContext($templateId, $template, $context);
 
@@ -228,9 +228,9 @@ class FormatterManager
      *
      * @param SourceInterface $source Source
      *
-     * @return array
+     * @return array|null
      */
-    public function formatSourceBlocks(SourceInterface $source): array
+    public function formatSourceBlocks(SourceInterface $source)
     {
         return $this->formatBlocks(
             $source->sourceId(),

--- a/src/Sculpin/Core/Generator/GeneratorInterface.php
+++ b/src/Sculpin/Core/Generator/GeneratorInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Generator/GeneratorManager.php
+++ b/src/Sculpin/Core/Generator/GeneratorManager.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Core\Generator;
 
 use Dflydev\DotAccessConfiguration\Configuration;
+use InvalidArgumentException;
 use Sculpin\Core\DataProvider\DataProviderManager;
 use Sculpin\Core\Source\SourceInterface;
 use Sculpin\Core\Source\SourceSet;
@@ -102,7 +103,7 @@ class GeneratorManager
 
             foreach ($generatorNames as $generatorName) {
                 if (!isset($this->generators[$generatorName])) {
-                    throw new \InvalidArgumentException(
+                    throw new InvalidArgumentException(
                         "Requested generator '$generatorName' could not be found; was it registered?"
                     );
                 }

--- a/src/Sculpin/Core/Generator/GeneratorManager.php
+++ b/src/Sculpin/Core/Generator/GeneratorManager.php
@@ -86,7 +86,6 @@ class GeneratorManager
      * @param  SourceInterface           $source    Source
      * @param  SourceSet                 $sourceSet Source set
      * @throws \InvalidArgumentException
-     *
      */
     public function generate(SourceInterface $source, SourceSet $sourceSet)
     {

--- a/src/Sculpin/Core/Generator/GeneratorManager.php
+++ b/src/Sculpin/Core/Generator/GeneratorManager.php
@@ -63,7 +63,7 @@ class GeneratorManager
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         Configuration $siteConfiguration,
-        DataProviderManager $dataProviderManager = null
+        ?DataProviderManager $dataProviderManager = null
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->siteConfiguration = $siteConfiguration;
@@ -76,7 +76,7 @@ class GeneratorManager
      * @param string             $name      Name
      * @param GeneratorInterface $generator Generator
      */
-    public function registerGenerator(string $name, GeneratorInterface $generator)
+    public function registerGenerator(string $name, GeneratorInterface $generator): void
     {
         $this->generators[$name] = $generator;
     }
@@ -88,7 +88,7 @@ class GeneratorManager
      * @param  SourceSet                 $sourceSet Source set
      * @throws \InvalidArgumentException
      */
-    public function generate(SourceInterface $source, SourceSet $sourceSet)
+    public function generate(SourceInterface $source, SourceSet $sourceSet): void
     {
         $data = $source->data();
 
@@ -145,7 +145,7 @@ class GeneratorManager
      *
      * @param DataProviderManager $dataProviderManager Data Provider Manager
      */
-    public function setDataProviderManager(DataProviderManager $dataProviderManager = null)
+    public function setDataProviderManager(?DataProviderManager $dataProviderManager = null): void
     {
         $this->dataProviderManager = $dataProviderManager;
     }

--- a/src/Sculpin/Core/Generator/GeneratorManager.php
+++ b/src/Sculpin/Core/Generator/GeneratorManager.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -50,7 +50,7 @@ class GeneratorManager
      *
      * @var array
      */
-    protected $generators = array();
+    protected $generators = [];
 
     /**
      * Constructor.
@@ -75,7 +75,7 @@ class GeneratorManager
      * @param string             $name      Name
      * @param GeneratorInterface $generator Generator
      */
-    public function registerGenerator($name, GeneratorInterface $generator)
+    public function registerGenerator(string $name, GeneratorInterface $generator)
     {
         $this->generators[$name] = $generator;
     }
@@ -87,13 +87,12 @@ class GeneratorManager
      * @param  SourceSet                 $sourceSet Source set
      * @throws \InvalidArgumentException
      *
-     * @return string
      */
     public function generate(SourceInterface $source, SourceSet $sourceSet)
     {
         $data = $source->data();
 
-        $generators = array();
+        $generators = [];
         $isGenerator = $source->isGenerator();
         if ($generatorNames = $data->get('generator')) {
             if (!$isGenerator) {
@@ -119,10 +118,10 @@ class GeneratorManager
             return;
         }
 
-        $targetSources = array($source);
+        $targetSources = [$source];
 
         foreach ($generators as $generator) {
-            $newTargetSources = array();
+            $newTargetSources = [];
             foreach ($targetSources as $targetSource) {
                 foreach ((array) $generator->generate($targetSource) as $generatedSource) {
                     $generatedSource->setIsGenerated();

--- a/src/Sculpin/Core/Io/ConsoleIo.php
+++ b/src/Sculpin/Core/Io/ConsoleIo.php
@@ -11,9 +11,9 @@
 
 namespace Sculpin\Core\Io;
 
+use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\HelperSet;
 
 /**
  * The Input/Output helper.

--- a/src/Sculpin/Core/Io/ConsoleIo.php
+++ b/src/Sculpin/Core/Io/ConsoleIo.php
@@ -51,7 +51,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function isInteractive()
+    public function isInteractive(): bool
     {
         return $this->input->isInteractive();
     }
@@ -59,7 +59,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function isDecorated()
+    public function isDecorated(): bool
     {
         return $this->output->isDecorated();
     }
@@ -67,7 +67,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function isVerbose()
+    public function isVerbose(): bool
     {
         return $this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;
     }
@@ -75,7 +75,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function isVeryVerbose()
+    public function isVeryVerbose(): bool
     {
         return $this->output->getVerbosity() >= 3; // OutputInterface::VERBOSITY_VERY_VERBOSE
     }
@@ -83,7 +83,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function isDebug()
+    public function isDebug(): bool
     {
         return $this->output->getVerbosity() >= 4; // OutputInterface::VERBOSITY_DEBUG
     }

--- a/src/Sculpin/Core/Io/ConsoleIo.php
+++ b/src/Sculpin/Core/Io/ConsoleIo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Io/ConsoleIo.php
+++ b/src/Sculpin/Core/Io/ConsoleIo.php
@@ -39,7 +39,7 @@ class ConsoleIo implements IoInterface
         $this->helperSet = $helperSet;
     }
 
-    public function enableDebugging($startTime)
+    public function enableDebugging($startTime): void
     {
         $this->startTime = $startTime;
     }
@@ -87,7 +87,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function write($messages, $newline = true)
+    public function write($messages, $newline = true): void
     {
         if (null !== $this->startTime) {
             $messages = (array) $messages;
@@ -105,7 +105,7 @@ class ConsoleIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function overwrite($messages, $newline = true, $size = null)
+    public function overwrite($messages, $newline = true, $size = null): void
     {
         // messages can be an array, let's convert it to string anyway
         $messages = join($newline ? "\n" : '', (array) $messages);

--- a/src/Sculpin/Core/Io/ConsoleIo.php
+++ b/src/Sculpin/Core/Io/ConsoleIo.php
@@ -31,10 +31,6 @@ class ConsoleIo implements IoInterface
 
     /**
      * Constructor.
-     *
-     * @param InputInterface  $input     The input instance
-     * @param OutputInterface $output    The output instance
-     * @param HelperSet       $helperSet The helperSet instance
      */
     public function __construct(InputInterface $input, OutputInterface $output, HelperSet $helperSet)
     {

--- a/src/Sculpin/Core/Io/IoInterface.php
+++ b/src/Sculpin/Core/Io/IoInterface.php
@@ -21,35 +21,30 @@ interface IoInterface
     /**
      * Is this input means interactive?
      *
-     * @return bool
      */
     public function isInteractive(): bool;
 
     /**
      * Is this output verbose?
      *
-     * @return bool
      */
     public function isVerbose(): bool;
 
     /**
      * Is the output very verbose?
      *
-     * @return bool
      */
     public function isVeryVerbose(): bool;
 
     /**
      * Is the output in debug verbosity?
      *
-     * @return bool
      */
     public function isDebug(): bool;
 
     /**
      * Is this output decorated?
      *
-     * @return bool
      */
     public function isDecorated(): bool;
 
@@ -59,7 +54,7 @@ interface IoInterface
      * @param string|array $messages The message as an array of lines or a single string
      * @param bool         $newline  Whether to add a newline or not
      */
-    public function write($messages, $newline = true);
+    public function write($messages, $newline = true): void;
 
     /**
      * Overwrites a previous message to the output.
@@ -68,5 +63,5 @@ interface IoInterface
      * @param bool         $newline  Whether to add a newline or not
      * @param integer      $size     The size of line
      */
-    public function overwrite($messages, $newline = true, $size = null);
+    public function overwrite($messages, $newline = true, $size = null): void;
 }

--- a/src/Sculpin/Core/Io/IoInterface.php
+++ b/src/Sculpin/Core/Io/IoInterface.php
@@ -20,31 +20,26 @@ interface IoInterface
 {
     /**
      * Is this input means interactive?
-     *
      */
     public function isInteractive(): bool;
 
     /**
      * Is this output verbose?
-     *
      */
     public function isVerbose(): bool;
 
     /**
      * Is the output very verbose?
-     *
      */
     public function isVeryVerbose(): bool;
 
     /**
      * Is the output in debug verbosity?
-     *
      */
     public function isDebug(): bool;
 
     /**
      * Is this output decorated?
-     *
      */
     public function isDecorated(): bool;
 

--- a/src/Sculpin/Core/Io/IoInterface.php
+++ b/src/Sculpin/Core/Io/IoInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,35 +23,35 @@ interface IoInterface
      *
      * @return bool
      */
-    public function isInteractive();
+    public function isInteractive(): bool;
 
     /**
      * Is this output verbose?
      *
      * @return bool
      */
-    public function isVerbose();
+    public function isVerbose(): bool;
 
     /**
      * Is the output very verbose?
      *
      * @return bool
      */
-    public function isVeryVerbose();
+    public function isVeryVerbose(): bool;
 
     /**
      * Is the output in debug verbosity?
      *
      * @return bool
      */
-    public function isDebug();
+    public function isDebug(): bool;
 
     /**
      * Is this output decorated?
      *
      * @return bool
      */
-    public function isDecorated();
+    public function isDecorated(): bool;
 
     /**
      * Writes a message to the output.

--- a/src/Sculpin/Core/Io/NullIo.php
+++ b/src/Sculpin/Core/Io/NullIo.php
@@ -61,14 +61,14 @@ class NullIo implements IoInterface
     /**
      * {@inheritDoc}
      */
-    public function write($messages, $newline = true)
+    public function write($messages, $newline = true): void
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function overwrite($messages, $newline = true, $size = 80)
+    public function overwrite($messages, $newline = true, $size = 80): void
     {
     }
 }

--- a/src/Sculpin/Core/Io/NullIo.php
+++ b/src/Sculpin/Core/Io/NullIo.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Output/FilesystemWriter.php
+++ b/src/Sculpin/Core/Output/FilesystemWriter.php
@@ -47,7 +47,7 @@ class FilesystemWriter implements WriterInterface
     /**
      * {@inheritdoc}
      */
-    public function write(OutputInterface $output)
+    public function write(OutputInterface $output): void
     {
         $outputPath = $this->outputDir.'/'.$output->permalink()->relativeFilePath();
         if ($output->hasFileReference()) {

--- a/src/Sculpin/Core/Output/FilesystemWriter.php
+++ b/src/Sculpin/Core/Output/FilesystemWriter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -40,7 +40,7 @@ class FilesystemWriter implements WriterInterface
      * @param Filesystem $filesystem Filesystem
      * @param string     $outputDir  Output directory
      */
-    public function __construct(Filesystem $filesystem, $outputDir)
+    public function __construct(Filesystem $filesystem, string $outputDir)
     {
         $this->filesystem = $filesystem;
         $this->outputDir = $outputDir;

--- a/src/Sculpin/Core/Output/FilesystemWriter.php
+++ b/src/Sculpin/Core/Output/FilesystemWriter.php
@@ -37,7 +37,6 @@ class FilesystemWriter implements WriterInterface
     /**
      * Constructor.
      *
-     * @param Filesystem $filesystem Filesystem
      * @param string     $outputDir  Output directory
      */
     public function __construct(Filesystem $filesystem, string $outputDir)

--- a/src/Sculpin/Core/Output/OutputInterface.php
+++ b/src/Sculpin/Core/Output/OutputInterface.php
@@ -23,25 +23,21 @@ interface OutputInterface
 {
     /**
      * Unique ID
-     *
      */
     public function outputId(): string;
 
     /**
      * Pathname (relative)
-     *
      */
     public function pathname(): string;
 
     /**
      * Suggested permalink
-     *
      */
     public function permalink(): PermalinkInterface;
 
     /**
      * Has a file reference?
-     *
      */
     public function hasFileReference(): bool;
 

--- a/src/Sculpin/Core/Output/OutputInterface.php
+++ b/src/Sculpin/Core/Output/OutputInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -25,40 +25,40 @@ interface OutputInterface
      *
      * @return string
      */
-    public function outputId();
+    public function outputId(): string;
 
     /**
      * Pathname (relative)
      *
      * @return string
      */
-    public function pathname();
+    public function pathname(): string;
 
     /**
      * Suggested permalink
      *
      * @return PermalinkInterface
      */
-    public function permalink();
+    public function permalink(): PermalinkInterface;
 
     /**
      * Has a file reference?
      *
      * @return boolean
      */
-    public function hasFileReference();
+    public function hasFileReference(): bool;
 
     /**
      * File reference. (if hasFileReference)
      *
      * @return \Symfony\Component\Finder\SplFileInfo
      */
-    public function file();
+    public function file(): \Symfony\Component\Finder\SplFileInfo;
 
     /**
      * Formatted content (if not hasFileReference)
      *
      * @return string
      */
-    public function formattedContent();
+    public function formattedContent(): string;
 }

--- a/src/Sculpin/Core/Output/OutputInterface.php
+++ b/src/Sculpin/Core/Output/OutputInterface.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Core\Output;
 
 use Sculpin\Core\Permalink\PermalinkInterface;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Output Interface
@@ -51,14 +52,14 @@ interface OutputInterface
     /**
      * File reference. (if hasFileReference)
      *
-     * @return \Symfony\Component\Finder\SplFileInfo
+     * @return SplFileInfo|null
      */
-    public function file(): \Symfony\Component\Finder\SplFileInfo;
+    public function file();
 
     /**
      * Formatted content (if not hasFileReference)
      *
-     * @return string
+     * @return string|null
      */
-    public function formattedContent(): string;
+    public function formattedContent();
 }

--- a/src/Sculpin/Core/Output/OutputInterface.php
+++ b/src/Sculpin/Core/Output/OutputInterface.php
@@ -24,28 +24,24 @@ interface OutputInterface
     /**
      * Unique ID
      *
-     * @return string
      */
     public function outputId(): string;
 
     /**
      * Pathname (relative)
      *
-     * @return string
      */
     public function pathname(): string;
 
     /**
      * Suggested permalink
      *
-     * @return PermalinkInterface
      */
     public function permalink(): PermalinkInterface;
 
     /**
      * Has a file reference?
      *
-     * @return boolean
      */
     public function hasFileReference(): bool;
 
@@ -54,12 +50,12 @@ interface OutputInterface
      *
      * @return SplFileInfo|null
      */
-    public function file();
+    public function file(): ?SplFileInfo;
 
     /**
      * Formatted content (if not hasFileReference)
      *
      * @return string|null
      */
-    public function formattedContent();
+    public function formattedContent(): ?string;
 }

--- a/src/Sculpin/Core/Output/SourceOutput.php
+++ b/src/Sculpin/Core/Output/SourceOutput.php
@@ -11,6 +11,7 @@
 
 namespace Sculpin\Core\Output;
 
+use Sculpin\Core\Permalink\PermalinkInterface;
 use Sculpin\Core\Source\SourceInterface;
 
 /**
@@ -40,7 +41,7 @@ class SourceOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function outputId()
+    public function outputId(): string
     {
         return $this->source->sourceId();
     }
@@ -48,7 +49,7 @@ class SourceOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function pathname()
+    public function pathname(): string
     {
         return $this->source->relativePathname();
     }
@@ -56,7 +57,7 @@ class SourceOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function permalink()
+    public function permalink(): PermalinkInterface
     {
         return $this->source->permalink();
     }
@@ -64,7 +65,7 @@ class SourceOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function hasFileReference()
+    public function hasFileReference(): bool
     {
         return $this->source->useFileReference();
     }

--- a/src/Sculpin/Core/Output/SourceOutput.php
+++ b/src/Sculpin/Core/Output/SourceOutput.php
@@ -13,6 +13,7 @@ namespace Sculpin\Core\Output;
 
 use Sculpin\Core\Permalink\PermalinkInterface;
 use Sculpin\Core\Source\SourceInterface;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Source Output.
@@ -73,7 +74,7 @@ class SourceOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function file()
+    public function file(): ?SplFileInfo
     {
         return $this->source->useFileReference() ? $this->source->file() : null;
     }
@@ -81,7 +82,7 @@ class SourceOutput implements OutputInterface
     /**
      * {@inheritdoc}
      */
-    public function formattedContent()
+    public function formattedContent(): ?string
     {
         return $this->source->useFileReference() ? null : $this->source->formattedContent();
     }

--- a/src/Sculpin/Core/Output/SourceOutput.php
+++ b/src/Sculpin/Core/Output/SourceOutput.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Output/WriterInterface.php
+++ b/src/Sculpin/Core/Output/WriterInterface.php
@@ -23,5 +23,5 @@ interface WriterInterface
      *
      * @param OutputInterface $output Output
      */
-    public function write(OutputInterface $output);
+    public function write(OutputInterface $output): void;
 }

--- a/src/Sculpin/Core/Output/WriterInterface.php
+++ b/src/Sculpin/Core/Output/WriterInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Permalink/Permalink.php
+++ b/src/Sculpin/Core/Permalink/Permalink.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -38,7 +38,7 @@ class Permalink implements PermalinkInterface
      * @param string $relativeFilePath Relative file path
      * @param string $relativeUrlPath  Relative URL path
      */
-    public function __construct($relativeFilePath, $relativeUrlPath)
+    public function __construct(string $relativeFilePath, string $relativeUrlPath)
     {
         $this->relativeFilePath = $relativeFilePath;
         $this->relativeUrlPath = $relativeUrlPath;
@@ -47,7 +47,7 @@ class Permalink implements PermalinkInterface
     /**
      * {@inheritdoc}
      */
-    public function relativeFilePath()
+    public function relativeFilePath(): string
     {
         return $this->relativeFilePath;
     }
@@ -55,7 +55,7 @@ class Permalink implements PermalinkInterface
     /**
      * {@inheritdoc}
      */
-    public function relativeUrlPath()
+    public function relativeUrlPath(): string
     {
         return $this->relativeUrlPath;
     }

--- a/src/Sculpin/Core/Permalink/PermalinkInterface.php
+++ b/src/Sculpin/Core/Permalink/PermalinkInterface.php
@@ -20,13 +20,11 @@ interface PermalinkInterface
 {
     /**
      * Relative file path
-     *
      */
     public function relativeFilePath(): string;
 
     /**
      * Relative URL path
-     *
      */
     public function relativeUrlPath(): string;
 }

--- a/src/Sculpin/Core/Permalink/PermalinkInterface.php
+++ b/src/Sculpin/Core/Permalink/PermalinkInterface.php
@@ -21,14 +21,12 @@ interface PermalinkInterface
     /**
      * Relative file path
      *
-     * @return string
      */
     public function relativeFilePath(): string;
 
     /**
      * Relative URL path
      *
-     * @return string
      */
     public function relativeUrlPath(): string;
 }

--- a/src/Sculpin/Core/Permalink/PermalinkInterface.php
+++ b/src/Sculpin/Core/Permalink/PermalinkInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,12 +23,12 @@ interface PermalinkInterface
      *
      * @return string
      */
-    public function relativeFilePath();
+    public function relativeFilePath(): string;
 
     /**
      * Relative URL path
      *
      * @return string
      */
-    public function relativeUrlPath();
+    public function relativeUrlPath(): string;
 }

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -107,7 +107,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
                 return preg_replace('/(\.[^\.]+|\.[^\.]+\.[^\.]+)$/', '', $pathname).'.html';
                 break;
             default:
-                list($year, $yr, $month, $mo, $day, $dy) = explode('-', date('Y-y-m-n-d-j', (int) $date));
+                [$year, $yr, $month, $mo, $day, $dy] = explode('-', date('Y-y-m-n-d-j', (int) $date));
                 $permalink = preg_replace('/:year/', $year, $permalink);
                 $permalink = preg_replace('/:yr/', $yr, $permalink);
                 $permalink = preg_replace('/:month/', $month, $permalink);

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -171,7 +171,6 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
     /**
      * Does the specified path represent a date?
      *
-     * @param string $path
      *
      * @return mixed
      */
@@ -195,8 +194,6 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
      *
      * @param string $param Parameter to normalize
      * @param string $space What to use as space separator
-     *
-     * @return string
      */
     private function normalize(string $param, string $space = '-'): string
     {

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -32,7 +32,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
      *
      * @param string $defaultPermalink Default permalink
      */
-    public function __construct($defaultPermalink)
+    public function __construct(string $defaultPermalink)
     {
         $this->defaultPermalink = $defaultPermalink;
     }
@@ -40,7 +40,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(SourceInterface $source)
+    public function create(SourceInterface $source): PermalinkInterface
     {
         if ($source->canBeFormatted()) {
             $relativeFilePath = $this->generatePermalinkPathname($source);
@@ -89,7 +89,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
                 break;
             case 'pretty':
                 if ($response = $this->isDatePath($pathname)) {
-                    return implode('/', array_merge($response, array('index.html')));
+                    return implode('/', array_merge($response, ['index.html']));
                 } else {
                     $pretty = preg_replace('/(\.[^\.\/]+|\.[^\.\/]+\.[^\.\/]+)$/', '', $pathname);
                     if (basename($pretty) == 'index') {
@@ -157,7 +157,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
      *
      * @return string Template for permalink
      */
-    private function getPermaLinkTemplate(SourceInterface $source)
+    private function getPermaLinkTemplate(SourceInterface $source): string
     {
         $permalink = $source->data()->get('permalink');
 
@@ -175,14 +175,14 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
      *
      * @return mixed
      */
-    private function isDatePath($path)
+    private function isDatePath(string $path)
     {
         if (preg_match(
             '/(\d{4})[\/\-]*(\d{2})[\/\-]*(\d{2})[\/\-]*(.+?)(\.[^\.]+|\.[^\.]+\.[^\.]+)$/',
             $path,
             $matches
         )) {
-            return array($matches[1], $matches[2], $matches[3], $matches[4]);
+            return [$matches[1], $matches[2], $matches[3], $matches[4]];
         }
 
         return null;
@@ -198,7 +198,7 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
      *
      * @return string
      */
-    private function normalize($param, $space = '-')
+    private function normalize(string $param, string $space = '-'): string
     {
         $param = trim($param);
         if (function_exists('iconv')) {

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactoryInterface.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactoryInterface.php
@@ -24,7 +24,6 @@ interface SourcePermalinkFactoryInterface
      * Create a Permalink for a Source.
      *
      * @param SourceInterface $source Source
-     *
      */
     public function create(SourceInterface $source): PermalinkInterface;
 }

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactoryInterface.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactoryInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -27,5 +27,5 @@ interface SourcePermalinkFactoryInterface
      *
      * @return PermalinkInterface
      */
-    public function create(SourceInterface $source);
+    public function create(SourceInterface $source): PermalinkInterface;
 }

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactoryInterface.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactoryInterface.php
@@ -25,7 +25,6 @@ interface SourcePermalinkFactoryInterface
      *
      * @param SourceInterface $source Source
      *
-     * @return PermalinkInterface
      */
     public function create(SourceInterface $source): PermalinkInterface;
 }

--- a/src/Sculpin/Core/Sculpin.php
+++ b/src/Sculpin/Core/Sculpin.php
@@ -32,16 +32,16 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class Sculpin
 {
-    const GIT_VERSION = '@git_version@';
+    public const GIT_VERSION = '@git_version@';
 
-    const EVENT_BEFORE_RUN = 'sculpin.core.before_run';
-    const EVENT_AFTER_RUN = 'sculpin.core.after_run';
+    public const EVENT_BEFORE_RUN = 'sculpin.core.before_run';
+    public const EVENT_AFTER_RUN = 'sculpin.core.after_run';
 
-    const EVENT_BEFORE_CONVERT = 'sculpin.core.before_convert';
-    const EVENT_AFTER_CONVERT = 'sculpin.core.after_convert';
+    public const EVENT_BEFORE_CONVERT = 'sculpin.core.before_convert';
+    public const EVENT_AFTER_CONVERT = 'sculpin.core.after_convert';
 
-    const EVENT_BEFORE_FORMAT = 'sculpin.core.before_format';
-    const EVENT_AFTER_FORMAT = 'sculpin.core.after_format';
+    public const EVENT_BEFORE_FORMAT = 'sculpin.core.before_format';
+    public const EVENT_AFTER_FORMAT = 'sculpin.core.after_format';
 
     /**
      * Site Configuration
@@ -135,7 +135,7 @@ class Sculpin
      * @param SourceSet           $sourceSet  Source set
      * @param IoInterface         $io         IO Interface
      */
-    public function run(DataSourceInterface $dataSource, SourceSet $sourceSet, IoInterface $io = null)
+    public function run(DataSourceInterface $dataSource, SourceSet $sourceSet, ?IoInterface $io = null): void
     {
         if (null === $io) {
             $io = new NullIo();

--- a/src/Sculpin/Core/Sculpin.php
+++ b/src/Sculpin/Core/Sculpin.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
+++ b/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
@@ -35,7 +35,6 @@ class SiteConfigurationFactory
 
     /**
      * Get an instance of the Configuration() class from the given file.
-     *
      */
     private function getConfigFile(string $configFile): YamlFileConfigurationBuilder
     {
@@ -46,7 +45,6 @@ class SiteConfigurationFactory
 
     /**
      * Create Site Configuration
-     *
      */
     public function create(): Configuration
     {
@@ -57,7 +55,6 @@ class SiteConfigurationFactory
     }
     /**
      * Detect configuration file and create Site Configuration from it
-     *
      */
     public function detectConfig(): Configuration
     {

--- a/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
+++ b/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -27,7 +27,7 @@ class SiteConfigurationFactory
      * @param string $rootDir     Root directory
      * @param string $environment Environment
      */
-    public function __construct($rootDir, $environment)
+    public function __construct(string $rootDir, string $environment)
     {
         $this->rootDir = $rootDir;
         $this->environment = $environment;
@@ -39,9 +39,9 @@ class SiteConfigurationFactory
      * @param  string $configFile
      * @return YamlFileConfigurationBuilder
      */
-    private function getConfigFile($configFile)
+    private function getConfigFile(string $configFile): YamlFileConfigurationBuilder
     {
-        $builder = new YamlFileConfigurationBuilder(array($configFile));
+        $builder = new YamlFileConfigurationBuilder([$configFile]);
 
         return $builder->build();
     }
@@ -51,7 +51,7 @@ class SiteConfigurationFactory
      *
      * @return Configuration
      */
-    public function create()
+    public function create(): Configuration
     {
         $config = $this->detectConfig();
         $config->set('env', $this->environment);
@@ -63,7 +63,7 @@ class SiteConfigurationFactory
      *
      * @return Configuration
      */
-    public function detectConfig()
+    public function detectConfig(): Configuration
     {
         if (file_exists($file = $this->rootDir.'/config/sculpin_site_'.$this->environment.'.yml')) {
             return $this->getConfigFile($file);

--- a/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
+++ b/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
@@ -36,7 +36,6 @@ class SiteConfigurationFactory
     /**
      * Get an instance of the Configuration() class from the given file.
      *
-     * @param  string $configFile
      * @return YamlFileConfigurationBuilder
      */
     private function getConfigFile(string $configFile): YamlFileConfigurationBuilder

--- a/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
+++ b/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
@@ -36,7 +36,6 @@ class SiteConfigurationFactory
     /**
      * Get an instance of the Configuration() class from the given file.
      *
-     * @return YamlFileConfigurationBuilder
      */
     private function getConfigFile(string $configFile): YamlFileConfigurationBuilder
     {
@@ -48,7 +47,6 @@ class SiteConfigurationFactory
     /**
      * Create Site Configuration
      *
-     * @return Configuration
      */
     public function create(): Configuration
     {
@@ -60,7 +58,6 @@ class SiteConfigurationFactory
     /**
      * Detect configuration file and create Site Configuration from it
      *
-     * @return Configuration
      */
     public function detectConfig(): Configuration
     {

--- a/src/Sculpin/Core/Source/AbstractSource.php
+++ b/src/Sculpin/Core/Source/AbstractSource.php
@@ -11,8 +11,8 @@
 
 namespace Sculpin\Core\Source;
 
-use Sculpin\Core\Permalink\PermalinkInterface;
 use Dflydev\DotAccessConfiguration\Configuration as Data;
+use Sculpin\Core\Permalink\PermalinkInterface;
 use SplFileInfo;
 
 /**

--- a/src/Sculpin/Core/Source/AbstractSource.php
+++ b/src/Sculpin/Core/Source/AbstractSource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -11,8 +11,10 @@
 
 namespace Sculpin\Core\Source;
 
+use Sculpin\Core\Configuration\Configuration;
 use Sculpin\Core\Permalink\PermalinkInterface;
 use Dflydev\DotAccessConfiguration\Configuration as Data;
+use SplFileInfo;
 
 /**
  * Abstract Source.
@@ -73,7 +75,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * File
      *
-     * @var \SplFileInfo
+     * @var SplFileInfo
      */
     protected $file;
 
@@ -131,7 +133,7 @@ abstract class AbstractSource implements SourceInterface
      *
      * @param bool $hasChanged Has the Source changed?
      */
-    protected function init($hasChanged = null)
+    protected function init(bool $hasChanged = null)
     {
         if (null !== $hasChanged) {
             $this->hasChanged = $hasChanged;
@@ -142,7 +144,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function sourceId()
+    public function sourceId(): string
     {
         return $this->sourceId;
     }
@@ -150,7 +152,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function isRaw()
+    public function isRaw(): bool
     {
         return $this->isRaw;
     }
@@ -158,7 +160,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function content()
+    public function content(): string
     {
         return $this->content;
     }
@@ -166,7 +168,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setContent($content = null)
+    public function setContent(string $content = null)
     {
         $this->content = $content;
 
@@ -178,7 +180,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function formattedContent()
+    public function formattedContent(): string
     {
         return $this->formattedContent;
     }
@@ -186,7 +188,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setFormattedContent($formattedContent = null)
+    public function setFormattedContent(string $formattedContent = null)
     {
         $this->formattedContent = $formattedContent;
     }
@@ -194,7 +196,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function data()
+    public function data(): Configuration
     {
         return $this->data;
     }
@@ -202,7 +204,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function hasChanged()
+    public function hasChanged(): bool
     {
         return $this->hasChanged;
     }
@@ -226,7 +228,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function permalink()
+    public function permalink(): PermalinkInterface
     {
         return $this->permalink;
     }
@@ -242,7 +244,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function useFileReference()
+    public function useFileReference(): bool
     {
         return $this->useFileReference;
     }
@@ -250,7 +252,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function canBeFormatted()
+    public function canBeFormatted(): bool
     {
         return $this->canBeFormatted;
     }
@@ -258,7 +260,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function isGenerator()
+    public function isGenerator(): bool
     {
         return $this->isGenerator;
     }
@@ -282,7 +284,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function isGenerated()
+    public function isGenerated(): bool
     {
         return $this->isGenerated;
     }
@@ -306,7 +308,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function shouldBeSkipped()
+    public function shouldBeSkipped(): bool
     {
         return $this->shouldBeSkipped;
     }
@@ -338,7 +340,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function relativePathname()
+    public function relativePathname(): string
     {
         return $this->relativePathname;
     }
@@ -346,7 +348,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function filename()
+    public function filename(): string
     {
         return $this->filename;
     }
@@ -354,7 +356,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function file()
+    public function file(): SplFileInfo
     {
         return $this->file;
     }
@@ -362,7 +364,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function url()
+    public function url(): string
     {
         return $this->permalink()->relativeUrlPath();
     }
@@ -370,19 +372,19 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function duplicate($newSourceId, array $options = array())
+    public function duplicate(string $newSourceId, array $options = []): SourceInterface
     {
         return new MemorySource(
             $newSourceId,
             new Data($this->data->exportRaw()),
-            isset($options['content']) ? $options['content'] : $this->content,
-            isset($options['formattedContent']) ? $options['formattedContent'] : $this->formattedContent,
-            isset($options['relativePathname']) ? $options['relativePathname'] : $this->relativePathname,
-            isset($options['filename']) ? $options['filename'] : $this->filename,
-            isset($options['file']) ? $options['file'] : $this->file,
-            isset($options['isRaw']) ? $options['isRaw'] : $this->isRaw,
-            isset($options['canBeFormatted']) ? $options['canBeFormatted'] : $this->canBeFormatted,
-            isset($options['hasChanged']) ? $options['hasChanged'] : $this->hasChanged
+            $options['content'] ?? $this->content,
+            $options['formattedContent'] ?? $this->formattedContent,
+            $options['relativePathname'] ?? $this->relativePathname,
+            $options['filename'] ?? $this->filename,
+            $options['file'] ?? $this->file,
+            $options['isRaw'] ?? $this->isRaw,
+            $options['canBeFormatted'] ?? $this->canBeFormatted,
+            $options['hasChanged'] ?? $this->hasChanged
         );
     }
 }

--- a/src/Sculpin/Core/Source/AbstractSource.php
+++ b/src/Sculpin/Core/Source/AbstractSource.php
@@ -11,7 +11,6 @@
 
 namespace Sculpin\Core\Source;
 
-use Sculpin\Core\Configuration\Configuration;
 use Sculpin\Core\Permalink\PermalinkInterface;
 use Dflydev\DotAccessConfiguration\Configuration as Data;
 use SplFileInfo;
@@ -196,7 +195,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function data(): Configuration
+    public function data(): Data
     {
         return $this->data;
     }

--- a/src/Sculpin/Core/Source/AbstractSource.php
+++ b/src/Sculpin/Core/Source/AbstractSource.php
@@ -132,7 +132,7 @@ abstract class AbstractSource implements SourceInterface
      *
      * @param bool $hasChanged Has the Source changed?
      */
-    protected function init(bool $hasChanged = null)
+    protected function init(?bool $hasChanged = null): void
     {
         if (null !== $hasChanged) {
             $this->hasChanged = $hasChanged;
@@ -167,7 +167,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setContent(string $content = null)
+    public function setContent(?string $content = null): void
     {
         $this->content = $content;
 
@@ -179,7 +179,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function formattedContent()
+    public function formattedContent(): ?string
     {
         return $this->formattedContent;
     }
@@ -187,7 +187,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setFormattedContent(string $formattedContent = null)
+    public function setFormattedContent(?string $formattedContent = null): void
     {
         $this->formattedContent = $formattedContent;
     }
@@ -211,7 +211,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setHasChanged()
+    public function setHasChanged(): void
     {
         $this->hasChanged = true;
     }
@@ -219,7 +219,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setHasNotChanged()
+    public function setHasNotChanged(): void
     {
         $this->hasChanged = false;
     }
@@ -235,7 +235,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setPermalink(PermalinkInterface $permalink)
+    public function setPermalink(PermalinkInterface $permalink): void
     {
         $this->permalink = $permalink;
     }
@@ -267,7 +267,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsGenerator()
+    public function setIsGenerator(): void
     {
         $this->isGenerator = true;
     }
@@ -275,7 +275,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsNotGenerator()
+    public function setIsNotGenerator(): void
     {
         $this->isGenerator = false;
     }
@@ -291,7 +291,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsGenerated()
+    public function setIsGenerated(): void
     {
         $this->isGenerated = true;
     }
@@ -299,7 +299,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsNotGenerated()
+    public function setIsNotGenerated(): void
     {
         $this->isGenerated = false;
     }
@@ -315,7 +315,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setShouldBeSkipped()
+    public function setShouldBeSkipped(): void
     {
         $this->shouldBeSkipped = true;
     }
@@ -323,7 +323,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setShouldNotBeSkipped()
+    public function setShouldNotBeSkipped(): void
     {
         $this->shouldBeSkipped = false;
     }
@@ -331,7 +331,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function forceReprocess()
+    public function forceReprocess(): void
     {
         $this->init(true);
     }

--- a/src/Sculpin/Core/Source/AbstractSource.php
+++ b/src/Sculpin/Core/Source/AbstractSource.php
@@ -179,7 +179,7 @@ abstract class AbstractSource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function formattedContent(): string
+    public function formattedContent()
     {
         return $this->formattedContent;
     }

--- a/src/Sculpin/Core/Source/CompositeDataSource.php
+++ b/src/Sculpin/Core/Source/CompositeDataSource.php
@@ -49,8 +49,6 @@ class CompositeDataSource implements DataSourceInterface
 
     /**
      * Backing Data Sources
-     *
-     * @return array
      */
     public function dataSources(): array
     {

--- a/src/Sculpin/Core/Source/CompositeDataSource.php
+++ b/src/Sculpin/Core/Source/CompositeDataSource.php
@@ -42,7 +42,7 @@ class CompositeDataSource implements DataSourceInterface
      *
      * @param DataSourceInterface $dataSource Data Source
      */
-    public function addDataSource(DataSourceInterface $dataSource)
+    public function addDataSource(DataSourceInterface $dataSource): void
     {
         $this->dataSources[$dataSource->dataSourceId()] = $dataSource;
     }
@@ -68,7 +68,7 @@ class CompositeDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function refresh(SourceSet $sourceSet)
+    public function refresh(SourceSet $sourceSet): void
     {
         foreach ($this->dataSources as $dataSource) {
             $dataSource->refresh($sourceSet);

--- a/src/Sculpin/Core/Source/CompositeDataSource.php
+++ b/src/Sculpin/Core/Source/CompositeDataSource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,14 +23,14 @@ class CompositeDataSource implements DataSourceInterface
      *
      * @var array
      */
-    private $dataSources = array();
+    private $dataSources = [];
 
     /**
      * Constructor.
      *
      * @param array $dataSources Data sources
      */
-    public function __construct(array $dataSources = array())
+    public function __construct(array $dataSources = [])
     {
         foreach ($dataSources as $dataSource) {
             $this->dataSources[$dataSource->dataSourceId()] = $dataSource;
@@ -52,7 +52,7 @@ class CompositeDataSource implements DataSourceInterface
      *
      * @return array
      */
-    public function dataSources()
+    public function dataSources(): array
     {
         return $this->dataSources;
     }
@@ -60,7 +60,7 @@ class CompositeDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function dataSourceId()
+    public function dataSourceId(): string
     {
         return 'CompositeDataSource('.implode(',', array_map(function ($dataSource) {
             return $dataSource->dataSourceId();

--- a/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
@@ -79,8 +79,8 @@ class ConfigFilesystemDataSource implements DataSourceInterface
         string $sourceDir,
         ConfigurationInterface $siteConfiguration,
         SiteConfigurationFactory $siteConfigurationFactory,
-        FinderFactoryInterface $finderFactory = null,
-        AntPathMatcher $matcher = null
+        ?FinderFactoryInterface $finderFactory = null,
+        ?AntPathMatcher $matcher = null
     ) {
         $this->sourceDir = $sourceDir;
         $this->siteConfiguration = $siteConfiguration;
@@ -103,7 +103,7 @@ class ConfigFilesystemDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function refresh(SourceSet $sourceSet)
+    public function refresh(SourceSet $sourceSet): void
     {
         if (! is_dir($this->sourceDir)) {
             return;

--- a/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
@@ -93,7 +93,7 @@ class ConfigFilesystemDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function dataSourceId()
+    public function dataSourceId(): string
     {
         // This is not really needed since we are not going to
         // ever create actual sources.

--- a/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -76,7 +76,7 @@ class ConfigFilesystemDataSource implements DataSourceInterface
      * @param AntPathMatcher           $matcher                  Matcher
      */
     public function __construct(
-        $sourceDir,
+        string $sourceDir,
         ConfigurationInterface $siteConfiguration,
         SiteConfigurationFactory $siteConfigurationFactory,
         FinderFactoryInterface $finderFactory = null,

--- a/src/Sculpin/Core/Source/DataSourceInterface.php
+++ b/src/Sculpin/Core/Source/DataSourceInterface.php
@@ -20,7 +20,6 @@ interface DataSourceInterface
 {
     /**
      * Data Source ID
-     *
      */
     public function dataSourceId(): string;
 

--- a/src/Sculpin/Core/Source/DataSourceInterface.php
+++ b/src/Sculpin/Core/Source/DataSourceInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,7 +23,7 @@ interface DataSourceInterface
      *
      * @return string
      */
-    public function dataSourceId();
+    public function dataSourceId(): string;
 
     /**
      * Refresh the Source Set with updated Sources.

--- a/src/Sculpin/Core/Source/DataSourceInterface.php
+++ b/src/Sculpin/Core/Source/DataSourceInterface.php
@@ -21,7 +21,6 @@ interface DataSourceInterface
     /**
      * Data Source ID
      *
-     * @return string
      */
     public function dataSourceId(): string;
 
@@ -30,5 +29,5 @@ interface DataSourceInterface
      *
      * @param SourceSet $sourceSet Source set to be updated
      */
-    public function refresh(SourceSet $sourceSet);
+    public function refresh(SourceSet $sourceSet): void;
 }

--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -11,10 +11,10 @@
 
 namespace Sculpin\Core\Source;
 
-use Symfony\Component\Finder\SplFileInfo;
 use Dflydev\Canal\Analyzer\Analyzer;
 use Dflydev\DotAccessConfiguration\Configuration as Data;
 use Dflydev\DotAccessConfiguration\YamlConfigurationBuilder as YamlDataBuilder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * File Source.

--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -14,6 +14,7 @@ namespace Sculpin\Core\Source;
 use Dflydev\Canal\Analyzer\Analyzer;
 use Dflydev\DotAccessConfiguration\Configuration as Data;
 use Dflydev\DotAccessConfiguration\YamlConfigurationBuilder as YamlDataBuilder;
+use InvalidArgumentException;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
@@ -93,7 +94,7 @@ class FileSource extends AbstractSource
                         try {
                             $builder = new YamlDataBuilder($matches[1]);
                             $this->data = $builder->build();
-                        } catch (\InvalidArgumentException $e) {
+                        } catch (InvalidArgumentException $e) {
                             // Likely not actually YAML front matter available,
                             // treat the entire file as pure content.
                             echo ' ! ' . $this->sourceId() . ' ' . $e->getMessage() . ' !' . PHP_EOL;

--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -26,7 +26,6 @@ class FileSource extends AbstractSource
     /**
      * Constructor
      *
-     * @param Analyzer            $analyzer   Analyzer
      * @param DataSourceInterface $dataSource Data Source
      * @param SplFileInfo         $file       File
      * @param bool                $isRaw      Should be treated as raw

--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -36,8 +36,8 @@ class FileSource extends AbstractSource
         Analyzer $analyzer,
         DataSourceInterface $dataSource,
         SplFileInfo $file,
-        $isRaw,
-        $hasChanged = false
+        bool $isRaw,
+        bool $hasChanged = false
     ) {
         $this->analyzer = $analyzer;
         $this->sourceId = 'FileSource:'.$dataSource->dataSourceId().':'.$file->getRelativePathname();
@@ -58,7 +58,7 @@ class FileSource extends AbstractSource
      *
      * @param bool $hasChanged Has the file changed?
      */
-    protected function init($hasChanged = null)
+    protected function init(bool $hasChanged = null)
     {
         parent::init($hasChanged);
 

--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -82,7 +82,7 @@ class FileSource extends AbstractSource
                 // Additionally, any text file is a candidate for formatting.
                 $this->canBeFormatted = true;
 
-                $content = file_get_contents($this->file);
+                $content = file_get_contents($this->file->getRealPath());
 
                 if (preg_match('/^\s*(?:---[\s]*[\r\n]+)(.*?)(?:---[\s]*[\r\n]+)(.*?)$/s', $content, $matches)) {
                     $this->content = $matches[2];

--- a/src/Sculpin/Core/Source/FileSource.php
+++ b/src/Sculpin/Core/Source/FileSource.php
@@ -58,7 +58,7 @@ class FileSource extends AbstractSource
      *
      * @param bool $hasChanged Has the file changed?
      */
-    protected function init(bool $hasChanged = null)
+    protected function init(?bool $hasChanged = null): void
     {
         parent::init($hasChanged);
 

--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -100,10 +100,10 @@ class FilesystemDataSource implements DataSourceInterface
      * @param DirectorySeparatorNormalizer $directorySeparatorNormalizer Directory Separator Normalizer
      */
     public function __construct(
-        $sourceDir,
-        $excludes,
-        $ignores,
-        $raws,
+        string $sourceDir,
+        array $excludes,
+        array $ignores,
+        array $raws,
         FinderFactoryInterface $finderFactory = null,
         AntPathMatcher $matcher = null,
         Analyzer $analyzer = null,

--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -96,7 +96,6 @@ class FilesystemDataSource implements DataSourceInterface
      * @param array                        $raws                         Raw paths
      * @param FinderFactoryInterface       $finderFactory                Finder Factory
      * @param AntPathMatcher               $matcher                      Matcher
-     * @param Analyzer                     $analyzer                     Analyzer
      * @param DirectorySeparatorNormalizer $directorySeparatorNormalizer Directory Separator Normalizer
      */
     public function __construct(

--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -103,10 +103,10 @@ class FilesystemDataSource implements DataSourceInterface
         array $excludes,
         array $ignores,
         array $raws,
-        FinderFactoryInterface $finderFactory = null,
-        AntPathMatcher $matcher = null,
-        Analyzer $analyzer = null,
-        DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
+        ?FinderFactoryInterface $finderFactory = null,
+        ?AntPathMatcher $matcher = null,
+        ?Analyzer $analyzer = null,
+        ?DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
     ) {
         $this->sourceDir = $sourceDir;
         $this->excludes = $excludes;
@@ -130,7 +130,7 @@ class FilesystemDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function refresh(SourceSet $sourceSet)
+    public function refresh(SourceSet $sourceSet): void
     {
         $sinceTimeLast = $this->sinceTime;
 

--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -123,7 +123,7 @@ class FilesystemDataSource implements DataSourceInterface
     /**
      * {@inheritdoc}
      */
-    public function dataSourceId()
+    public function dataSourceId(): string
     {
         return 'FilesystemDataSource:'.$this->sourceDir;
     }

--- a/src/Sculpin/Core/Source/Filter/AntPathFilter.php
+++ b/src/Sculpin/Core/Source/Filter/AntPathFilter.php
@@ -22,8 +22,8 @@ class AntPathFilter implements FilterInterface
 
     public function __construct(
         array $paths,
-        AntPathMatcher $antPathMatcher = null,
-        DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
+        ?AntPathMatcher $antPathMatcher = null,
+        ?DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
     ) {
         if (null === $antPathMatcher) {
             $antPathMatcher = new AntPathMatcher;
@@ -35,7 +35,7 @@ class AntPathFilter implements FilterInterface
         $this->directorySeparatorNormalizer = $directorySeparatorNormalizer ?: new DirectorySeparatorNormalizer;
     }
 
-    public function match(SourceInterface $source)
+    public function match(SourceInterface $source): bool
     {
         $normalizedPath = $this->directorySeparatorNormalizer->normalize($source->relativePathname());
 

--- a/src/Sculpin/Core/Source/Filter/AntPathFilter.php
+++ b/src/Sculpin/Core/Source/Filter/AntPathFilter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/Filter/ChainFilter.php
+++ b/src/Sculpin/Core/Source/Filter/ChainFilter.php
@@ -24,7 +24,7 @@ class ChainFilter implements FilterInterface
         $this->or = $or;
     }
 
-    public function match(SourceInterface $source)
+    public function match(SourceInterface $source): bool
     {
         $matched = false;
 
@@ -53,7 +53,7 @@ class ChainFilter implements FilterInterface
         return $matched;
     }
 
-    public function addFilter(FilterInterface $filter)
+    public function addFilter(FilterInterface $filter): void
     {
         $this->filters[] = $filter;
     }

--- a/src/Sculpin/Core/Source/Filter/ChainFilter.php
+++ b/src/Sculpin/Core/Source/Filter/ChainFilter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -15,10 +15,10 @@ use Sculpin\Core\Source\SourceInterface;
 
 class ChainFilter implements FilterInterface
 {
-    private $filters = array();
+    private $filters = [];
     private $or;
 
-    public function __construct(array $filters = array(), $or = false)
+    public function __construct(array $filters = [], $or = false)
     {
         $this->filters = $filters;
         $this->or = $or;

--- a/src/Sculpin/Core/Source/Filter/DraftsFilter.php
+++ b/src/Sculpin/Core/Source/Filter/DraftsFilter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/Filter/DraftsFilter.php
+++ b/src/Sculpin/Core/Source/Filter/DraftsFilter.php
@@ -22,7 +22,7 @@ class DraftsFilter implements FilterInterface
         $this->publishDrafts = $publishDrafts;
     }
 
-    public function match(SourceInterface $source)
+    public function match(SourceInterface $source): bool
     {
         if ($source->data()->get('draft')) {
             if (!$this->publishDrafts) {

--- a/src/Sculpin/Core/Source/Filter/FilterInterface.php
+++ b/src/Sculpin/Core/Source/Filter/FilterInterface.php
@@ -15,5 +15,5 @@ use Sculpin\Core\Source\SourceInterface;
 
 interface FilterInterface
 {
-    public function match(SourceInterface $source);
+    public function match(SourceInterface $source): bool;
 }

--- a/src/Sculpin/Core/Source/Filter/FilterInterface.php
+++ b/src/Sculpin/Core/Source/Filter/FilterInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/Filter/MetaFilter.php
+++ b/src/Sculpin/Core/Source/Filter/MetaFilter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/Filter/NullFilter.php
+++ b/src/Sculpin/Core/Source/Filter/NullFilter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/Map/CalculatedDateFromFilenameMap.php
+++ b/src/Sculpin/Core/Source/Map/CalculatedDateFromFilenameMap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -24,7 +24,7 @@ class CalculatedDateFromFilenameMap implements MapInterface
                 $matches
             )) {
                 list($dummy, $year, $month, $day, $time) = $matches;
-                $parts = array(implode('-', array($year, $month, $day)));
+                $parts = [implode('-', [$year, $month, $day])];
                 if ($time && false !== strtotime($time)) {
                     $parts[] = $time;
                 }

--- a/src/Sculpin/Core/Source/Map/CalculatedDateFromFilenameMap.php
+++ b/src/Sculpin/Core/Source/Map/CalculatedDateFromFilenameMap.php
@@ -15,7 +15,7 @@ use Sculpin\Core\Source\SourceInterface;
 
 class CalculatedDateFromFilenameMap implements MapInterface
 {
-    public function process(SourceInterface $source)
+    public function process(SourceInterface $source): void
     {
         if (!$source->data()->get('calculated_date')) {
             if (preg_match(
@@ -23,7 +23,7 @@ class CalculatedDateFromFilenameMap implements MapInterface
                 $source->relativePathname(),
                 $matches
             )) {
-                list($dummy, $year, $month, $day, $time) = $matches;
+                [$dummy, $year, $month, $day, $time] = $matches;
                 $parts = [implode('-', [$year, $month, $day])];
                 if ($time && false !== strtotime($time)) {
                     $parts[] = $time;

--- a/src/Sculpin/Core/Source/Map/ChainMap.php
+++ b/src/Sculpin/Core/Source/Map/ChainMap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -15,9 +15,9 @@ use Sculpin\Core\Source\SourceInterface;
 
 class ChainMap implements MapInterface
 {
-    private $maps = array();
+    private $maps = [];
 
-    public function __construct(array $maps = array())
+    public function __construct(array $maps = [])
     {
         $this->maps = $maps;
     }

--- a/src/Sculpin/Core/Source/Map/ChainMap.php
+++ b/src/Sculpin/Core/Source/Map/ChainMap.php
@@ -22,14 +22,14 @@ class ChainMap implements MapInterface
         $this->maps = $maps;
     }
 
-    public function process(SourceInterface $source)
+    public function process(SourceInterface $source): void
     {
         foreach ($this->maps as $map) {
             $map->process($source);
         }
     }
 
-    public function addMap(MapInterface $map)
+    public function addMap(MapInterface $map): void
     {
         $this->maps[] = $map;
     }

--- a/src/Sculpin/Core/Source/Map/DefaultDataMap.php
+++ b/src/Sculpin/Core/Source/Map/DefaultDataMap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -17,7 +17,7 @@ class DefaultDataMap implements MapInterface
 {
     private $defaults;
 
-    public function __construct(array $defaults = array())
+    public function __construct(array $defaults = [])
     {
         $this->defaults = $defaults;
     }

--- a/src/Sculpin/Core/Source/Map/DefaultDataMap.php
+++ b/src/Sculpin/Core/Source/Map/DefaultDataMap.php
@@ -22,7 +22,7 @@ class DefaultDataMap implements MapInterface
         $this->defaults = $defaults;
     }
 
-    public function process(SourceInterface $source)
+    public function process(SourceInterface $source): void
     {
         foreach ($this->defaults as $name => $value) {
             if (!$source->data()->get($name) && $value) {

--- a/src/Sculpin/Core/Source/Map/DraftsMap.php
+++ b/src/Sculpin/Core/Source/Map/DraftsMap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -20,12 +20,12 @@ class DraftsMap implements MapInterface
         if ($source->data()->get('draft')) {
             $tags = $source->data()->get('tags');
             if (null === $tags) {
-                $tags = array('drafts');
+                $tags = ['drafts'];
             } else {
                 if (!is_array($tags)) {
-                    $tags = array();
+                    $tags = [];
                     if ($tags) {
-                        $tags = array($tags);
+                        $tags = [$tags];
                     }
                 }
 

--- a/src/Sculpin/Core/Source/Map/DraftsMap.php
+++ b/src/Sculpin/Core/Source/Map/DraftsMap.php
@@ -15,7 +15,7 @@ use Sculpin\Core\Source\SourceInterface;
 
 class DraftsMap implements MapInterface
 {
-    public function process(SourceInterface $source)
+    public function process(SourceInterface $source): void
     {
         if ($source->data()->get('draft')) {
             $tags = $source->data()->get('tags');

--- a/src/Sculpin/Core/Source/Map/MapInterface.php
+++ b/src/Sculpin/Core/Source/Map/MapInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/Map/MapInterface.php
+++ b/src/Sculpin/Core/Source/Map/MapInterface.php
@@ -15,5 +15,5 @@ use Sculpin\Core\Source\SourceInterface;
 
 interface MapInterface
 {
-    public function process(SourceInterface $source);
+    public function process(SourceInterface $source): void;
 }

--- a/src/Sculpin/Core/Source/Map/NullMap.php
+++ b/src/Sculpin/Core/Source/Map/NullMap.php
@@ -15,7 +15,7 @@ use Sculpin\Core\Source\SourceInterface;
 
 class NullMap implements MapInterface
 {
-    public function process(SourceInterface $source)
+    public function process(SourceInterface $source): void
     {
         // NOOP
     }

--- a/src/Sculpin/Core/Source/Map/NullMap.php
+++ b/src/Sculpin/Core/Source/Map/NullMap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Source/MemorySource.php
+++ b/src/Sculpin/Core/Source/MemorySource.php
@@ -12,6 +12,7 @@
 namespace Sculpin\Core\Source;
 
 use Dflydev\DotAccessConfiguration\Configuration as Data;
+use SplFileInfo;
 
 /**
  * Memory Source.
@@ -40,7 +41,7 @@ class MemorySource extends AbstractSource
         $formattedContent,
         string $relativePathname,
         string $filename,
-        \SplFileInfo $file,
+        SplFileInfo $file,
         bool $isRaw,
         bool $canBeFormatted,
         bool $hasChanged

--- a/src/Sculpin/Core/Source/MemorySource.php
+++ b/src/Sculpin/Core/Source/MemorySource.php
@@ -38,7 +38,7 @@ class MemorySource extends AbstractSource
         string $sourceId,
         Data $data,
         string $content,
-        $formattedContent,
+        ?string $formattedContent,
         string $relativePathname,
         string $filename,
         SplFileInfo $file,

--- a/src/Sculpin/Core/Source/MemorySource.php
+++ b/src/Sculpin/Core/Source/MemorySource.php
@@ -26,7 +26,7 @@ class MemorySource extends AbstractSource
      * @param string       $sourceId         Source ID
      * @param Data         $data             Data
      * @param string       $content          Content
-     * @param string       $formattedContent Formatted content
+     * @param string|null       $formattedContent Formatted content
      * @param string       $relativePathname Relative Pathname
      * @param string       $filename         Filename
      * @param \SplFileInfo $file             File
@@ -38,7 +38,7 @@ class MemorySource extends AbstractSource
         string $sourceId,
         Data $data,
         string $content,
-        string $formattedContent,
+        $formattedContent,
         string $relativePathname,
         string $filename,
         \SplFileInfo $file,

--- a/src/Sculpin/Core/Source/MemorySource.php
+++ b/src/Sculpin/Core/Source/MemorySource.php
@@ -24,7 +24,6 @@ class MemorySource extends AbstractSource
      * Constructor
      *
      * @param string       $sourceId         Source ID
-     * @param Data         $data             Data
      * @param string       $content          Content
      * @param string|null       $formattedContent Formatted content
      * @param string       $relativePathname Relative Pathname

--- a/src/Sculpin/Core/Source/MemorySource.php
+++ b/src/Sculpin/Core/Source/MemorySource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -35,16 +35,16 @@ class MemorySource extends AbstractSource
      * @param bool         $hasChanged       Has changed?
      */
     public function __construct(
-        $sourceId,
+        string $sourceId,
         Data $data,
-        $content,
-        $formattedContent,
-        $relativePathname,
-        $filename,
-        $file,
-        $isRaw,
-        $canBeFormatted,
-        $hasChanged
+        string $content,
+        string $formattedContent,
+        string $relativePathname,
+        string $filename,
+        \SplFileInfo $file,
+        bool $isRaw,
+        bool $canBeFormatted,
+        bool $hasChanged
     ) {
         $this->sourceId = $sourceId;
         $this->data = $data;

--- a/src/Sculpin/Core/Source/ProxySource.php
+++ b/src/Sculpin/Core/Source/ProxySource.php
@@ -72,7 +72,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setHasChanged(): bool
+    public function setHasChanged(): void
     {
         $this->source->setHasChanged();
     }
@@ -80,7 +80,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setHasNotChanged(): bool
+    public function setHasNotChanged(): void
     {
         $this->source->setHasNotChanged();
     }
@@ -96,7 +96,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setPermalink(PermalinkInterface $permalink)
+    public function setPermalink(PermalinkInterface $permalink): void
     {
         $this->source->setPermalink($permalink);
     }
@@ -128,7 +128,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setContent(string $content = null)
+    public function setContent(?string $content = null): void
     {
         $this->source->setContent($content);
     }
@@ -144,7 +144,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setFormattedContent(string $formattedContent = null)
+    public function setFormattedContent(?string $formattedContent = null): void
     {
         $this->source->setFormattedContent($formattedContent);
     }
@@ -184,7 +184,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsGenerator()
+    public function setIsGenerator(): void
     {
         $this->source->setIsGenerator();
     }
@@ -192,7 +192,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsNotGenerator()
+    public function setIsNotGenerator(): void
     {
         $this->source->setIsNotGenerator();
     }
@@ -208,7 +208,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsGenerated()
+    public function setIsGenerated(): void
     {
         $this->source->setIsGenerated();
     }
@@ -216,7 +216,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setIsNotGenerated()
+    public function setIsNotGenerated(): void
     {
         $this->source->setIsNotGenerated();
     }
@@ -232,7 +232,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setShouldBeSkipped()
+    public function setShouldBeSkipped(): void
     {
         $this->source->setShouldBeSkipped();
     }
@@ -240,7 +240,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setShouldNotBeSkipped()
+    public function setShouldNotBeSkipped(): void
     {
         $this->source->setShouldNotBeSkipped();
     }
@@ -248,7 +248,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function forceReprocess()
+    public function forceReprocess(): void
     {
         $this->source->forceReprocess();
     }

--- a/src/Sculpin/Core/Source/ProxySource.php
+++ b/src/Sculpin/Core/Source/ProxySource.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -11,7 +11,9 @@
 
 namespace Sculpin\Core\Source;
 
+use Sculpin\Core\Configuration\Configuration;
 use Sculpin\Core\Permalink\PermalinkInterface;
+use SplFileInfo;
 
 /**
  * Proxy source
@@ -30,7 +32,6 @@ class ProxySource implements SourceInterface
     /**
      * Constructor
      *
-     * @param SourceInterface $source
      */
     public function __construct(SourceInterface $source)
     {
@@ -40,7 +41,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function sourceId()
+    public function sourceId(): string
     {
         return $this->source->sourceId();
     }
@@ -48,7 +49,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function isRaw()
+    public function isRaw(): bool
     {
         return $this->source->isRaw();
     }
@@ -56,7 +57,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function canBeFormatted()
+    public function canBeFormatted(): bool
     {
         return $this->source->isRaw();
     }
@@ -64,7 +65,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function hasChanged()
+    public function hasChanged(): bool
     {
         return $this->source->hasChanged();
     }
@@ -72,23 +73,23 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setHasChanged()
+    public function setHasChanged(): bool
     {
-        return $this->source->setHasChanged();
+        $this->source->setHasChanged();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setHasNotChanged()
+    public function setHasNotChanged(): bool
     {
-        return $this->source->setHasNotChanged();
+        $this->source->setHasNotChanged();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function permalink()
+    public function permalink(): PermalinkInterface
     {
         return $this->source->permalink();
     }
@@ -98,13 +99,13 @@ class ProxySource implements SourceInterface
      */
     public function setPermalink(PermalinkInterface $permalink)
     {
-        return $this->source->setPermalink($permalink);
+        $this->source->setPermalink($permalink);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function useFileReference()
+    public function useFileReference(): bool
     {
         return $this->source->useFileReference();
     }
@@ -112,7 +113,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function file()
+    public function file(): SplFileInfo
     {
         return $this->source->file();
     }
@@ -120,7 +121,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function content()
+    public function content(): string
     {
         return $this->source->content();
     }
@@ -128,15 +129,15 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setContent($content = null)
+    public function setContent(string $content = null)
     {
-        return $this->source->setContent($content);
+        $this->source->setContent($content);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function formattedContent()
+    public function formattedContent(): string
     {
         return $this->source->formattedContent();
     }
@@ -144,15 +145,15 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function setFormattedContent($formattedContent = null)
+    public function setFormattedContent(string $formattedContent = null)
     {
-        return $this->source->setFormattedContent($formattedContent);
+        $this->source->setFormattedContent($formattedContent);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function relativePathname()
+    public function relativePathname(): string
     {
         return $this->source->relativePathname();
     }
@@ -160,7 +161,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function filename()
+    public function filename(): string
     {
         return $this->source->filename();
     }
@@ -168,7 +169,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function data()
+    public function data(): Configuration
     {
         return $this->source->data();
     }
@@ -176,9 +177,9 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function isGenerator()
+    public function isGenerator(): bool
     {
-        return $this->source->data();
+        return $this->source->isGenerator();
     }
 
     /**
@@ -186,7 +187,7 @@ class ProxySource implements SourceInterface
      */
     public function setIsGenerator()
     {
-        return $this->source->setIsGenerator();
+        $this->source->setIsGenerator();
     }
 
     /**
@@ -194,13 +195,13 @@ class ProxySource implements SourceInterface
      */
     public function setIsNotGenerator()
     {
-        return $this->source->setIsNotGenerator();
+        $this->source->setIsNotGenerator();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isGenerated()
+    public function isGenerated(): bool
     {
         return $this->source->isGenerated();
     }
@@ -210,7 +211,7 @@ class ProxySource implements SourceInterface
      */
     public function setIsGenerated()
     {
-        return $this->source->setIsGenerated();
+        $this->source->setIsGenerated();
     }
 
     /**
@@ -218,13 +219,13 @@ class ProxySource implements SourceInterface
      */
     public function setIsNotGenerated()
     {
-        return $this->source->setIsNotGenerated();
+        $this->source->setIsNotGenerated();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function shouldBeSkipped()
+    public function shouldBeSkipped(): bool
     {
         $this->source->shouldBeSkipped();
     }
@@ -250,13 +251,13 @@ class ProxySource implements SourceInterface
      */
     public function forceReprocess()
     {
-        return $this->source->forceReprocess();
+        $this->source->forceReprocess();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function url()
+    public function url(): string
     {
         return $this->source->url();
     }
@@ -264,7 +265,7 @@ class ProxySource implements SourceInterface
     /**
      * {@inheritdoc}
      */
-    public function duplicate($newSourceId)
+    public function duplicate(string $newSourceId): SourceInterface
     {
         return $this->source->duplicate($newSourceId);
     }

--- a/src/Sculpin/Core/Source/ProxySource.php
+++ b/src/Sculpin/Core/Source/ProxySource.php
@@ -11,7 +11,7 @@
 
 namespace Sculpin\Core\Source;
 
-use Sculpin\Core\Configuration\Configuration;
+use Dflydev\DotAccessConfiguration\Configuration;
 use Sculpin\Core\Permalink\PermalinkInterface;
 use SplFileInfo;
 

--- a/src/Sculpin/Core/Source/ProxySource.php
+++ b/src/Sculpin/Core/Source/ProxySource.php
@@ -31,7 +31,6 @@ class ProxySource implements SourceInterface
 
     /**
      * Constructor
-     *
      */
     public function __construct(SourceInterface $source)
     {

--- a/src/Sculpin/Core/Source/SourceInterface.php
+++ b/src/Sculpin/Core/Source/SourceInterface.php
@@ -103,9 +103,9 @@ interface SourceInterface
     /**
      * Formatted content (if not use file reference)
      *
-     * @return string
+     * @return string|null
      */
-    public function formattedContent(): string;
+    public function formattedContent();
 
     /**
      * Set formatted content

--- a/src/Sculpin/Core/Source/SourceInterface.php
+++ b/src/Sculpin/Core/Source/SourceInterface.php
@@ -24,7 +24,7 @@ interface SourceInterface
     /**
      * Source ID
      *
-     * @return String
+     * @return string
      */
     public function sourceId(): String;
 
@@ -68,7 +68,6 @@ interface SourceInterface
 
     /**
      * Set permalink
-     *
      */
     public function setPermalink(PermalinkInterface $permalink);
 

--- a/src/Sculpin/Core/Source/SourceInterface.php
+++ b/src/Sculpin/Core/Source/SourceInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sculpin\Core\Source;
 
-use Sculpin\Core\Configuration\Configuration;
+use Dflydev\DotAccessConfiguration\Configuration;
 use Sculpin\Core\Permalink\PermalinkInterface;
 
 /**

--- a/src/Sculpin/Core/Source/SourceInterface.php
+++ b/src/Sculpin/Core/Source/SourceInterface.php
@@ -31,180 +31,162 @@ interface SourceInterface
     /**
      * Represents a raw source
      *
-     * @return boolean
      */
     public function isRaw(): bool;
 
     /**
      * Represents a source that can be formatted
      *
-     * @return boolean
      */
     public function canBeFormatted(): bool;
 
     /**
      * Has changed
      *
-     * @return boolean
      */
     public function hasChanged(): bool;
 
     /**
      * Mark source as changed
      */
-    public function setHasChanged();
+    public function setHasChanged(): void;
 
     /**
      * Mark source as not changed
      */
-    public function setHasNotChanged();
+    public function setHasNotChanged(): void;
 
     /**
      * Permalink
      *
-     * @return PermalinkInterface
      */
     public function permalink(): PermalinkInterface;
 
     /**
      * Set permalink
      */
-    public function setPermalink(PermalinkInterface $permalink);
+    public function setPermalink(PermalinkInterface $permalink): void;
 
     /**
      * Use file reference reference instead of string content
      *
-     * @return bool
      */
     public function useFileReference(): bool;
 
     /**
      * File reference. (if uses file reference)
      *
-     * @return \SplFileInfo
      */
     public function file(): \SplFileInfo;
 
     /**
      * Content (if not use file reference)
      *
-     * @return string
      */
     public function content(): string;
 
     /**
      * Set content
      *
-     * @param string|null $content
      */
-    public function setContent(string $content = null);
+    public function setContent(?string $content = null): void;
 
     /**
      * Formatted content (if not use file reference)
      *
      * @return string|null
      */
-    public function formattedContent();
+    public function formattedContent(): ?string;
 
     /**
      * Set formatted content
      *
-     * @param string|null $formattedContent
      */
-    public function setFormattedContent(string $formattedContent = null);
+    public function setFormattedContent(?string $formattedContent = null): void;
 
     /**
      * Relative pathname
      *
-     * @return string
      */
     public function relativePathname(): string;
 
     /**
      * Filename
      *
-     * @return string
      */
     public function filename(): string;
 
     /**
      * Data
      *
-     * @return Configuration
      */
     public function data(): Configuration;
 
     /**
      * Source is a generator
      *
-     * @return bool
      */
     public function isGenerator(): bool;
 
     /**
      * Mark Source as being a generator
      */
-    public function setIsGenerator();
+    public function setIsGenerator(): void;
 
     /**
      * Mark Source as not being a generator
      */
-    public function setIsNotGenerator();
+    public function setIsNotGenerator(): void;
 
     /**
      * Source is generated (from a generator)
      *
-     * @return bool
      */
     public function isGenerated(): bool;
 
     /**
      * Mark Source as being generated (by a generator)
      */
-    public function setIsGenerated();
+    public function setIsGenerated(): void;
 
     /**
      * Mark Source as not being generated (by a generator)
      */
-    public function setIsNotGenerated();
+    public function setIsNotGenerated(): void;
 
     /**
      * Source should be skipped
      *
-     * @return bool
      */
     public function shouldBeSkipped(): bool;
 
     /**
      * Mark Source as being skipped
      */
-    public function setShouldBeSkipped();
+    public function setShouldBeSkipped(): void;
 
     /**
      * Mark Source as not being skipped
      */
-    public function setShouldNotBeSkipped();
+    public function setShouldNotBeSkipped(): void;
 
     /**
      * Force Source to be reprocessed
      */
-    public function forceReprocess();
+    public function forceReprocess(): void;
 
     /**
      * URL
      *
      * Convenience method.
      *
-     * @return string
      */
     public function url(): string;
 
     /**
      * Duplicate the source
      *
-     * @param string $newSourceId
      *
-     * @return SourceInterface
      */
     public function duplicate(string $newSourceId): SourceInterface;
 }

--- a/src/Sculpin/Core/Source/SourceInterface.php
+++ b/src/Sculpin/Core/Source/SourceInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -26,28 +26,28 @@ interface SourceInterface
      *
      * @return String
      */
-    public function sourceId();
+    public function sourceId(): String;
 
     /**
      * Represents a raw source
      *
      * @return boolean
      */
-    public function isRaw();
+    public function isRaw(): bool;
 
     /**
      * Represents a source that can be formatted
      *
      * @return boolean
      */
-    public function canBeFormatted();
+    public function canBeFormatted(): bool;
 
     /**
      * Has changed
      *
      * @return boolean
      */
-    public function hasChanged();
+    public function hasChanged(): bool;
 
     /**
      * Mark source as changed
@@ -64,12 +64,11 @@ interface SourceInterface
      *
      * @return PermalinkInterface
      */
-    public function permalink();
+    public function permalink(): PermalinkInterface;
 
     /**
      * Set permalink
      *
-     * @param PermalinkInterface $permalink
      */
     public function setPermalink(PermalinkInterface $permalink);
 
@@ -78,70 +77,70 @@ interface SourceInterface
      *
      * @return bool
      */
-    public function useFileReference();
+    public function useFileReference(): bool;
 
     /**
      * File reference. (if uses file reference)
      *
      * @return \SplFileInfo
      */
-    public function file();
+    public function file(): \SplFileInfo;
 
     /**
      * Content (if not use file reference)
      *
      * @return string
      */
-    public function content();
+    public function content(): string;
 
     /**
      * Set content
      *
      * @param string|null $content
      */
-    public function setContent($content = null);
+    public function setContent(string $content = null);
 
     /**
      * Formatted content (if not use file reference)
      *
      * @return string
      */
-    public function formattedContent();
+    public function formattedContent(): string;
 
     /**
      * Set formatted content
      *
      * @param string|null $formattedContent
      */
-    public function setFormattedContent($formattedContent = null);
+    public function setFormattedContent(string $formattedContent = null);
 
     /**
      * Relative pathname
      *
      * @return string
      */
-    public function relativePathname();
+    public function relativePathname(): string;
 
     /**
      * Filename
      *
      * @return string
      */
-    public function filename();
+    public function filename(): string;
 
     /**
      * Data
      *
      * @return Configuration
      */
-    public function data();
+    public function data(): Configuration;
 
     /**
      * Source is a generator
      *
      * @return bool
      */
-    public function isGenerator();
+    public function isGenerator(): bool;
 
     /**
      * Mark Source as being a generator
@@ -158,7 +157,7 @@ interface SourceInterface
      *
      * @return bool
      */
-    public function isGenerated();
+    public function isGenerated(): bool;
 
     /**
      * Mark Source as being generated (by a generator)
@@ -175,7 +174,7 @@ interface SourceInterface
      *
      * @return bool
      */
-    public function shouldBeSkipped();
+    public function shouldBeSkipped(): bool;
 
     /**
      * Mark Source as being skipped
@@ -199,7 +198,7 @@ interface SourceInterface
      *
      * @return string
      */
-    public function url();
+    public function url(): string;
 
     /**
      * Duplicate the source
@@ -208,5 +207,5 @@ interface SourceInterface
      *
      * @return SourceInterface
      */
-    public function duplicate($newSourceId);
+    public function duplicate(string $newSourceId): SourceInterface;
 }

--- a/src/Sculpin/Core/Source/SourceInterface.php
+++ b/src/Sculpin/Core/Source/SourceInterface.php
@@ -30,19 +30,16 @@ interface SourceInterface
 
     /**
      * Represents a raw source
-     *
      */
     public function isRaw(): bool;
 
     /**
      * Represents a source that can be formatted
-     *
      */
     public function canBeFormatted(): bool;
 
     /**
      * Has changed
-     *
      */
     public function hasChanged(): bool;
 
@@ -58,7 +55,6 @@ interface SourceInterface
 
     /**
      * Permalink
-     *
      */
     public function permalink(): PermalinkInterface;
 
@@ -69,25 +65,21 @@ interface SourceInterface
 
     /**
      * Use file reference reference instead of string content
-     *
      */
     public function useFileReference(): bool;
 
     /**
      * File reference. (if uses file reference)
-     *
      */
     public function file(): \SplFileInfo;
 
     /**
      * Content (if not use file reference)
-     *
      */
     public function content(): string;
 
     /**
      * Set content
-     *
      */
     public function setContent(?string $content = null): void;
 
@@ -100,31 +92,26 @@ interface SourceInterface
 
     /**
      * Set formatted content
-     *
      */
     public function setFormattedContent(?string $formattedContent = null): void;
 
     /**
      * Relative pathname
-     *
      */
     public function relativePathname(): string;
 
     /**
      * Filename
-     *
      */
     public function filename(): string;
 
     /**
      * Data
-     *
      */
     public function data(): Configuration;
 
     /**
      * Source is a generator
-     *
      */
     public function isGenerator(): bool;
 
@@ -140,7 +127,6 @@ interface SourceInterface
 
     /**
      * Source is generated (from a generator)
-     *
      */
     public function isGenerated(): bool;
 
@@ -156,7 +142,6 @@ interface SourceInterface
 
     /**
      * Source should be skipped
-     *
      */
     public function shouldBeSkipped(): bool;
 
@@ -179,14 +164,11 @@ interface SourceInterface
      * URL
      *
      * Convenience method.
-     *
      */
     public function url(): string;
 
     /**
      * Duplicate the source
-     *
-     *
      */
     public function duplicate(string $newSourceId): SourceInterface;
 }

--- a/src/Sculpin/Core/Source/SourceSet.php
+++ b/src/Sculpin/Core/Source/SourceSet.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,21 +23,21 @@ class SourceSet
      *
      * @var array
      */
-    protected $sources = array();
+    protected $sources = [];
 
     /**
      * New Sources
      *
      * @var array
      */
-    protected $newSources = array();
+    protected $newSources = [];
 
     /**
      * Constructor.
      *
      * @param array $sources
      */
-    public function __construct(array $sources = array())
+    public function __construct(array $sources = [])
     {
         foreach ($sources as $source) {
             $this->sources[$source->sourceId()] = $source;
@@ -46,11 +46,10 @@ class SourceSet
     /**
      * Set contains the source?
      *
-     * @param SourceInterface $source
      *
      * @return boolean
      */
-    public function containsSource(SourceInterface $source)
+    public function containsSource(SourceInterface $source): bool
     {
         return array_key_exists($source->sourceId(), $this->sources);
     }
@@ -58,7 +57,6 @@ class SourceSet
     /**
      * Merge a source
      *
-     * @param SourceInterface $source
      */
     public function mergeSource(SourceInterface $source)
     {
@@ -75,7 +73,7 @@ class SourceSet
      *
      * @return array
      */
-    public function allSources()
+    public function allSources(): array
     {
         return $this->sources;
     }
@@ -85,7 +83,7 @@ class SourceSet
      *
      * @return array
      */
-    public function updatedSources()
+    public function updatedSources(): array
     {
         return array_filter($this->sources, function (SourceInterface $source) {
             return $source->hasChanged();
@@ -108,6 +106,6 @@ class SourceSet
             $source->setHasNotChanged();
         }
 
-        $this->newSources = array();
+        $this->newSources = [];
     }
 }

--- a/src/Sculpin/Core/Source/SourceSet.php
+++ b/src/Sculpin/Core/Source/SourceSet.php
@@ -43,8 +43,6 @@ class SourceSet
     }
     /**
      * Set contains the source?
-     *
-     *
      */
     public function containsSource(SourceInterface $source): bool
     {

--- a/src/Sculpin/Core/Source/SourceSet.php
+++ b/src/Sculpin/Core/Source/SourceSet.php
@@ -45,7 +45,6 @@ class SourceSet
      * Set contains the source?
      *
      *
-     * @return boolean
      */
     public function containsSource(SourceInterface $source): bool
     {
@@ -55,7 +54,7 @@ class SourceSet
     /**
      * Merge a source
      */
-    public function mergeSource(SourceInterface $source)
+    public function mergeSource(SourceInterface $source): void
     {
         if (array_key_exists($source->sourceId(), $this->sources)) {
             unset($this->sources[$source->sourceId()]);
@@ -93,7 +92,7 @@ class SourceSet
      *
      * Should be called after each loop while watching.
      */
-    public function reset()
+    public function reset(): void
     {
         foreach ($this->sources as $source) {
             $source->setHasNotChanged();

--- a/src/Sculpin/Core/Source/SourceSet.php
+++ b/src/Sculpin/Core/Source/SourceSet.php
@@ -34,8 +34,6 @@ class SourceSet
 
     /**
      * Constructor.
-     *
-     * @param array $sources
      */
     public function __construct(array $sources = [])
     {
@@ -56,7 +54,6 @@ class SourceSet
 
     /**
      * Merge a source
-     *
      */
     public function mergeSource(SourceInterface $source)
     {
@@ -70,8 +67,6 @@ class SourceSet
 
     /**
      * All sources
-     *
-     * @return array
      */
     public function allSources(): array
     {
@@ -80,8 +75,6 @@ class SourceSet
 
     /**
      * All sources that have been updated
-     *
-     * @return array
      */
     public function updatedSources(): array
     {

--- a/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
+++ b/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
@@ -13,11 +13,11 @@ namespace Sculpin\Core\Tests\Converter;
 
 use Sculpin\Core\Converter\SourceConverterContext;
 
-class SourceConverterContextTest extends \PHPUnit_Framework_TestCase
+class SourceConverterContextTest extends \PHPUnit\Framework\TestCase
 {
     public function testContent()
     {
-        $source = $this->getMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
         $source
             ->expects($this->once())
             ->method('content')
@@ -30,7 +30,7 @@ class SourceConverterContextTest extends \PHPUnit_Framework_TestCase
 
     public function testSetContent()
     {
-        $source = $this->getMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
         $source
             ->expects($this->once())
             ->method('setContent')

--- a/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
+++ b/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
@@ -17,7 +17,7 @@ use Sculpin\Core\Source\SourceInterface;
 
 class SourceConverterContextTest extends TestCase
 {
-    public function testContent()
+    public function testContent(): void
     {
         $source = $this->createMock(SourceInterface::class);
         $source
@@ -30,7 +30,7 @@ class SourceConverterContextTest extends TestCase
         $this->assertEquals('hello world', $sourceConverterContext->content());
     }
 
-    public function testSetContent()
+    public function testSetContent(): void
     {
         $source = $this->createMock(SourceInterface::class);
         $source

--- a/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
+++ b/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
@@ -11,13 +11,15 @@
 
 namespace Sculpin\Core\Tests\Converter;
 
+use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Converter\SourceConverterContext;
+use Sculpin\Core\Source\SourceInterface;
 
-class SourceConverterContextTest extends \PHPUnit\Framework\TestCase
+class SourceConverterContextTest extends TestCase
 {
     public function testContent()
     {
-        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock(SourceInterface::class);
         $source
             ->expects($this->once())
             ->method('content')
@@ -30,7 +32,7 @@ class SourceConverterContextTest extends \PHPUnit\Framework\TestCase
 
     public function testSetContent()
     {
-        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock(SourceInterface::class);
         $source
             ->expects($this->once())
             ->method('setContent')

--- a/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
+++ b/src/Sculpin/Core/Tests/Converter/SourceConverterContextTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
+++ b/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
@@ -11,9 +11,10 @@
 
 namespace Sculpin\Core\Tests\Formatter;
 
+use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Formatter\FormatContext;
 
-class FormatContextTest extends \PHPUnit\Framework\TestCase
+class FormatContextTest extends TestCase
 {
     public function test()
     {

--- a/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
+++ b/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -17,15 +17,15 @@ class FormatContextTest extends \PHPUnit_Framework_TestCase
 {
     public function test()
     {
-        $formatContext = new FormatContext('someTemplateId', 'template text', array(
+        $formatContext = new FormatContext('someTemplateId', 'template text', [
             'a' => 'Some A Value',
             'formatter' => 'SOME_FORMATTER',
-        ));
+        ]);
 
         $this->assertEquals('someTemplateId', $formatContext->templateId());
         $this->assertEquals('template text', $formatContext->template());
         $this->assertEquals(
-            array('a' => 'Some A Value', 'formatter' => 'SOME_FORMATTER', ),
+            ['a' => 'Some A Value', 'formatter' => 'SOME_FORMATTER', ],
             $formatContext->data()->export()
         );
         $this->assertEquals('SOME_FORMATTER', $formatContext->formatter());

--- a/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
+++ b/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
@@ -16,7 +16,7 @@ use Sculpin\Core\Formatter\FormatContext;
 
 class FormatContextTest extends TestCase
 {
-    public function test()
+    public function test(): void
     {
         $formatContext = new FormatContext('someTemplateId', 'template text', [
             'a' => 'Some A Value',

--- a/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
+++ b/src/Sculpin/Core/Tests/Formatter/FormatContextTest.php
@@ -13,7 +13,7 @@ namespace Sculpin\Core\Tests\Formatter;
 
 use Sculpin\Core\Formatter\FormatContext;
 
-class FormatContextTest extends \PHPUnit_Framework_TestCase
+class FormatContextTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -8,7 +8,7 @@ use Sculpin\Core\Permalink\SourcePermalinkFactory;
 use Sculpin\Core\Source\MemorySource;
 use Sculpin\Core\Source\SourceInterface;
 
-class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
+class SourcePermalinkFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -13,8 +13,6 @@ class SourcePermalinkFactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @dataProvider provideCreateData
-     * @param string $defaultPermalink
-     * @param Permalink $expectedPermalink
      */
     public function testCreate(string $defaultPermalink, SourceInterface $source, Permalink $expectedPermalink)
     {

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -3,12 +3,14 @@
 namespace Sculpin\Core\Tests\Permalink;
 
 use Dflydev\DotAccessConfiguration\Configuration;
+use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Permalink\Permalink;
 use Sculpin\Core\Permalink\SourcePermalinkFactory;
 use Sculpin\Core\Source\MemorySource;
 use Sculpin\Core\Source\SourceInterface;
+use SplFileInfo;
 
-class SourcePermalinkFactoryTest extends \PHPUnit\Framework\TestCase
+class SourcePermalinkFactoryTest extends TestCase
 {
     /**
      * @test
@@ -168,7 +170,7 @@ class SourcePermalinkFactoryTest extends \PHPUnit\Framework\TestCase
             '',
             $relativePathname,
             '',
-            new \SplFileInfo('/tmp'),
+            new SplFileInfo('/tmp'),
             false,
             true,
             false

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Core\Tests\Permalink;
 
@@ -14,10 +14,9 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
      * @test
      * @dataProvider provideCreateData
      * @param string $defaultPermalink
-     * @param SourceInterface $source
      * @param Permalink $expectedPermalink
      */
-    public function testCreate($defaultPermalink, SourceInterface $source, Permalink $expectedPermalink)
+    public function testCreate(string $defaultPermalink, SourceInterface $source, Permalink $expectedPermalink)
     {
         $sourcePermalinkFactory = new SourcePermalinkFactory($defaultPermalink);
 
@@ -28,139 +27,139 @@ class SourcePermalinkFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function provideCreateData()
     {
-        return array(
-            'none setting for permalink' => array(
+        return [
+            'none setting for permalink' => [
                 'none',
                 static::makeTestSource('_posts/2015-01-12-from-buttercup-protects-to-broadway.md'),
                 new Permalink(
                     '_posts/2015-01-12-from-buttercup-protects-to-broadway.md',
                     '/_posts/2015-01-12-from-buttercup-protects-to-broadway.md'
                 ),
-            ),
+            ],
 
-            'pretty permalink page' => array(
+            'pretty permalink page' => [
                 'pretty',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about/index.html',
                     '/about'
                 ),
-            ),
+            ],
 
-            'basename with html ending' => array(
+            'basename with html ending' => [
                 ':basename.html',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about.html',
                     '/about.html'
                 ),
-            ),
+            ],
 
-            'pretty permalink post' => array(
+            'pretty permalink post' => [
                 'pretty',
                 static::makeTestSource('_posts/2015-01-12-from-buttercup-protects-to-broadway.md'),
                 new Permalink(
                     '2015/01/12/from-buttercup-protects-to-broadway/index.html',
                     '/2015/01/12/from-buttercup-protects-to-broadway'
                 ),
-            ),
+            ],
 
-            'Permalink with windows path' => array(
+            'Permalink with windows path' => [
                 ':basename.html',
                 static::makeTestSource('some\windows\path.md'),
                 new Permalink(
                     'some\windows\path.html',
                     '/some/windows/path.html'
                 ),
-            ),
+            ],
 
-            array(
+            [
                 'blog/:year/:month/:day/:slug_title',
-                static::makeTestSource('about.md', array(
+                static::makeTestSource('about.md', [
                     'slug' => 'some/about-me',
                     'calculated_date' => mktime(0, 0, 0, 1, 12, 2005)
-                )),
+                ]),
                 new Permalink(
                     'blog/2005/01/12/some/about-me/index.html',
                     '/blog/2005/01/12/some/about-me'
                 ),
-            ),
+            ],
 
-            array(
+            [
                 ':basename.html/',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about.html/index.html',
                     '/about.html/'
                 ),
-            ),
+            ],
 
-            array(
+            [
                 ':filename.html',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about.md.html',
                     '/about.md.html'
                 ),
-            ),
+            ],
 
-            array(
+            [
                 ':filename.html/',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about.md.html/index.html',
                     '/about.md.html/'
                 ),
-            ),
+            ],
 
-            array(
+            [
                 ':filename',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about.md/index.html',
                     '/about.md'
                 ),
-            ),
+            ],
 
-            array(
+            [
                 ':filename/',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about.md/index.html',
                     '/about.md/'
                 ),
-            ),
+            ],
 
-            'Permalink for .xml' => array(
+            'Permalink for .xml' => [
                 ':filename',
                 static::makeTestSource('about.xml'),
                 new Permalink(
                     'about.xml',
                     '/about.xml'
                 ),
-            ),
+            ],
 
-            'Permalink for .json' => array(
+            'Permalink for .json' => [
                 ':filename',
                 static::makeTestSource('about.json'),
                 new Permalink(
                     'about.json',
                     '/about.json'
                 ),
-            ),
+            ],
 
-            'Permalink with trailing slash' => array(
+            'Permalink with trailing slash' => [
                 ':basename/',
                 static::makeTestSource('about.md'),
                 new Permalink(
                     'about/index.html',
                     '/about/'
                 ),
-            ),
-        );
+            ],
+        ];
     }
 
-    private static function makeTestSource($relativePathname, array $configuration = array())
+    private static function makeTestSource($relativePathname, array $configuration = [])
     {
         $configuration = new Configuration($configuration);
 

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -16,7 +16,7 @@ class SourcePermalinkFactoryTest extends TestCase
      * @test
      * @dataProvider provideCreateData
      */
-    public function testCreate(string $defaultPermalink, SourceInterface $source, Permalink $expectedPermalink)
+    public function testCreate(string $defaultPermalink, SourceInterface $source, Permalink $expectedPermalink): void
     {
         $sourcePermalinkFactory = new SourcePermalinkFactory($defaultPermalink);
 

--- a/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
@@ -30,7 +30,7 @@ class CompositeDataSourceTest extends TestCase
         return $dataSource;
     }
 
-    public function testAddDataSource()
+    public function testAddDataSource(): void
     {
         $ds000 = $this->makeDataSource('TestDataSource:000');
         $ds001 = $this->makeDataSource('TestDataSource:001');
@@ -52,7 +52,7 @@ class CompositeDataSourceTest extends TestCase
         ], $dataSource->dataSources());
     }
 
-    public function testDataSourceId()
+    public function testDataSourceId(): void
     {
         $ds000 = $this->makeDataSource('TestDataSource:000');
         $ds001 = $this->makeDataSource('TestDataSource:001');
@@ -65,7 +65,7 @@ class CompositeDataSourceTest extends TestCase
         $this->assertContains('TestDataSource:002', $dataSource->dataSourceId());
     }
 
-    public function testRefresh()
+    public function testRefresh(): void
     {
         $sourceSet = new SourceSet;
 

--- a/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
@@ -11,14 +11,16 @@
 
 namespace Sculpin\Core\Tests\Source;
 
+use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Source\CompositeDataSource;
+use Sculpin\Core\Source\DataSourceInterface;
 use Sculpin\Core\Source\SourceSet;
 
-class CompositeDataSourceTest extends \PHPUnit\Framework\TestCase
+class CompositeDataSourceTest extends TestCase
 {
     public function makeDataSource($dataSourceId)
     {
-        $dataSource = $this->createMock('Sculpin\Core\Source\DataSourceInterface');
+        $dataSource = $this->createMock(DataSourceInterface::class);
 
         $dataSource
             ->expects($this->any())

--- a/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
@@ -14,11 +14,11 @@ namespace Sculpin\Core\Tests\Source;
 use Sculpin\Core\Source\CompositeDataSource;
 use Sculpin\Core\Source\SourceSet;
 
-class CompositeDataSourceTest extends \PHPUnit_Framework_TestCase
+class CompositeDataSourceTest extends \PHPUnit\Framework\TestCase
 {
     public function makeDataSource($dataSourceId)
     {
-        $dataSource = $this->getMock('Sculpin\Core\Source\DataSourceInterface');
+        $dataSource = $this->createMock('Sculpin\Core\Source\DataSourceInterface');
 
         $dataSource
             ->expects($this->any())

--- a/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/CompositeDataSourceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -34,20 +34,20 @@ class CompositeDataSourceTest extends \PHPUnit_Framework_TestCase
         $ds001 = $this->makeDataSource('TestDataSource:001');
         $ds002 = $this->makeDataSource('TestDataSource:002');
 
-        $dataSource = new CompositeDataSource(array($ds000, $ds002));
+        $dataSource = new CompositeDataSource([$ds000, $ds002]);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'TestDataSource:000' => $ds000,
             'TestDataSource:002' => $ds002,
-        ), $dataSource->dataSources());
+        ], $dataSource->dataSources());
 
         $dataSource->addDataSource($ds001);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'TestDataSource:000' => $ds000,
             'TestDataSource:002' => $ds002,
             'TestDataSource:001' => $ds001,
-        ), $dataSource->dataSources());
+        ], $dataSource->dataSources());
     }
 
     public function testDataSourceId()
@@ -56,7 +56,7 @@ class CompositeDataSourceTest extends \PHPUnit_Framework_TestCase
         $ds001 = $this->makeDataSource('TestDataSource:001');
         $ds002 = $this->makeDataSource('TestDataSource:002');
 
-        $dataSource = new CompositeDataSource(array($ds000, $ds001, $ds002));
+        $dataSource = new CompositeDataSource([$ds000, $ds001, $ds002]);
 
         $this->assertContains('TestDataSource:000', $dataSource->dataSourceId());
         $this->assertContains('TestDataSource:001', $dataSource->dataSourceId());
@@ -71,14 +71,14 @@ class CompositeDataSourceTest extends \PHPUnit_Framework_TestCase
         $ds001 = $this->makeDataSource('TestDataSource:001');
         $ds002 = $this->makeDataSource('TestDataSource:002');
 
-        foreach (array($ds000, $ds001, $ds002) as $dataSource) {
+        foreach ([$ds000, $ds001, $ds002] as $dataSource) {
             $dataSource
                 ->expects($this->once())
                 ->method('refresh')
                 ->with($this->equalTo($sourceSet));
         }
 
-        $dataSource = new CompositeDataSource(array($ds000, $ds001, $ds002));
+        $dataSource = new CompositeDataSource([$ds000, $ds001, $ds002]);
 
         $dataSource->refresh($sourceSet);
     }

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -3,11 +3,15 @@
 namespace Sculpin\Core\Tests\Source;
 
 use Dflydev\Canal\Analyzer\Analyzer;
+use Dflydev\Canal\InternetMediaType\InternetMediaTypeFactory;
+use Dflydev\Canal\InternetMediaType\InternetMediaTypeInterface;
+use PHPUnit\Framework\TestCase;
+use Sculpin\Core\Source\DataSourceInterface;
 use Sculpin\Core\Source\FileSource;
 use Sculpin\Core\Source\FilesystemDataSource;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FileSourceTest extends \PHPUnit\Framework\TestCase
+class FileSourceTest extends TestCase
 {
     /*
      * mock analyzer for detectFromFilename, should return text/html
@@ -28,7 +32,7 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
 
     public function makeTestAnalyzer()
     {
-        $analyzer = $this->createMock('Dflydev\Canal\Analyzer\Analyzer');
+        $analyzer = $this->createMock(Analyzer::class);
 
         $analyzer
             ->expects($this->any())
@@ -45,7 +49,7 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
 
     public function makeTestInternetMediaType()
     {
-        $type = $this->createMock('Dflydev\Canal\InternetMediaType\InternetMediaTypeInterface');
+        $type = $this->createMock(InternetMediaTypeInterface::class);
 
         $type
             ->expects($this->any())
@@ -57,7 +61,7 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
 
     public function makeTestInternetMediaFactory()
     {
-        $factory = $this->createMock('Dflydev\Canal\InternetMediaType\InternetMediaTypeFactory');
+        $factory = $this->createMock(InternetMediaTypeFactory::class);
 
         $factory
             ->expects($this->any())
@@ -69,7 +73,7 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
 
     public function makeTestDatasource()
     {
-        $datasource = $this->createMock('Sculpin\Core\Source\DataSourceInterface');
+        $datasource = $this->createMock(DataSourceInterface::class);
 
         $datasource
             ->expects($this->any())

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -86,7 +86,7 @@ class FileSourceTest extends TestCase
     /**
      * @dataProvider provideTestParseYaml
      */
-    public function testParseYaml($filename, $msg)
+    public function testParseYaml($filename, $msg): void
     {
         $expectedOutput = $this->getErrorMessage($filename, $msg);
         ob_end_flush();

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -12,7 +12,6 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
 {
     /*
      * mock analyzer for detectFromFilename, should return text/html
-     *
      */
 
     public function makeTestSource(string $filename, bool $hasChanged = true)

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -8,7 +8,7 @@ use Sculpin\Core\Source\FilesystemDataSource;
 use Sculpin\Core\Source\MemorySource;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FileSourceTest extends \PHPUnit_Framework_TestCase
+class FileSourceTest extends \PHPUnit\Framework\TestCase
 {
     /*
      * mock analyzer for detectFromFilename, should return text/html
@@ -30,7 +30,7 @@ class FileSourceTest extends \PHPUnit_Framework_TestCase
 
     public function makeTestAnalyzer()
     {
-        $analyzer = $this->getMock('Dflydev\Canal\Analyzer\Analyzer');
+        $analyzer = $this->createMock('Dflydev\Canal\Analyzer\Analyzer');
 
         $analyzer
             ->expects($this->any())
@@ -47,7 +47,7 @@ class FileSourceTest extends \PHPUnit_Framework_TestCase
 
     public function makeTestInternetMediaType()
     {
-        $type = $this->getMock('Dflydev\Canal\InternetMediaType\InternetMediaTypeInterface');
+        $type = $this->createMock('Dflydev\Canal\InternetMediaType\InternetMediaTypeInterface');
 
         $type
             ->expects($this->any())
@@ -59,7 +59,7 @@ class FileSourceTest extends \PHPUnit_Framework_TestCase
 
     public function makeTestInternetMediaFactory()
     {
-        $factory = $this->getMock('Dflydev\Canal\InternetMediaType\InternetMediaTypeFactory');
+        $factory = $this->createMock('Dflydev\Canal\InternetMediaType\InternetMediaTypeFactory');
 
         $factory
             ->expects($this->any())
@@ -71,7 +71,7 @@ class FileSourceTest extends \PHPUnit_Framework_TestCase
 
     public function makeTestDatasource()
     {
-        $datasource = $this->getMock('Sculpin\Core\Source\DataSourceInterface');
+        $datasource = $this->createMock('Sculpin\Core\Source\DataSourceInterface');
 
         $datasource
             ->expects($this->any())

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -15,7 +15,7 @@ class FileSourceTest extends \PHPUnit\Framework\TestCase
      *
      */
 
-    public function makeTestSource($filename, $hasChanged = true)
+    public function makeTestSource(string $filename, bool $hasChanged = true)
     {
         $source = new FileSource(
             $this->makeTestAnalyzer(),

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace Sculpin\Core\Tests\Source;
 
 use Dflydev\Canal\Analyzer\Analyzer;
@@ -97,23 +98,23 @@ class FileSourceTest extends \PHPUnit_Framework_TestCase
 
     public function provideTestParseYaml()
     {
-        return array(
-            array(__DIR__ . '/../Fixtures/valid/no-end-frontmatter.yml', ''),
-            array(__DIR__ . '/../Fixtures/valid/frontmatter-nocontent.yml', ''),
-            array(__DIR__ . '/../Fixtures/valid/frontmatter-content.yml', ''),
-            array(
+        return [
+            [__DIR__ . '/../Fixtures/valid/no-end-frontmatter.yml', ''],
+            [__DIR__ . '/../Fixtures/valid/frontmatter-nocontent.yml', ''],
+            [__DIR__ . '/../Fixtures/valid/frontmatter-content.yml', ''],
+            [
                 __DIR__ . '/../Fixtures/invalid/one-line-edge-case.yml',
                 'Yaml could not be parsed, parser detected a string.'
-            ),
-            array(
+            ],
+            [
                 __DIR__ . '/../Fixtures/invalid/malformed-yaml.yml',
                 'Yaml could not be parsed, parser detected a string.'
-            ),
-            array(
+            ],
+            [
                 __DIR__ . '/../Fixtures/invalid/malformed-yaml2.yml',
                 'Unable to parse at line 2 (near "first:fsdqf").'
-            ),
-        );
+            ],
+        ];
     }
 
     public function getErrorMessage($filename, $msg)

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -5,7 +5,6 @@ namespace Sculpin\Core\Tests\Source;
 use Dflydev\Canal\Analyzer\Analyzer;
 use Sculpin\Core\Source\FileSource;
 use Sculpin\Core\Source\FilesystemDataSource;
-use Sculpin\Core\Source\MemorySource;
 use Symfony\Component\Finder\SplFileInfo;
 
 class FileSourceTest extends \PHPUnit\Framework\TestCase

--- a/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
+++ b/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
@@ -15,7 +15,7 @@ use Dflydev\DotAccessConfiguration\Configuration as Data;
 use Sculpin\Core\Source\Map\CalculatedDateFromFilenameMap;
 use Sculpin\Core\Source\MemorySource;
 
-class CalculatedDateFromFilenameMapTest extends \PHPUnit_Framework_TestCase
+class CalculatedDateFromFilenameMapTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
+++ b/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
@@ -12,10 +12,12 @@
 namespace Sculpin\Core\Tests\Source\Map;
 
 use Dflydev\DotAccessConfiguration\Configuration as Data;
+use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Source\Map\CalculatedDateFromFilenameMap;
 use Sculpin\Core\Source\MemorySource;
+use SplFileInfo;
 
-class CalculatedDateFromFilenameMapTest extends \PHPUnit\Framework\TestCase
+class CalculatedDateFromFilenameMapTest extends TestCase
 {
     public function setUp()
     {
@@ -73,7 +75,7 @@ class CalculatedDateFromFilenameMapTest extends \PHPUnit\Framework\TestCase
             "formatted contents",
             __FILE__,
             __FILE__,
-            new \SplFileInfo(__FILE__),
+            new SplFileInfo(__FILE__),
             false,
             false,
             false
@@ -89,7 +91,7 @@ class CalculatedDateFromFilenameMapTest extends \PHPUnit\Framework\TestCase
             "formatted contents",
             $path,
             $path,
-            new \SplFileInfo(__FILE__),
+            new SplFileInfo(__FILE__),
             false,
             false,
             false

--- a/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
+++ b/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -68,7 +68,7 @@ class CalculatedDateFromFilenameMapTest extends \PHPUnit_Framework_TestCase
     {
         return new MemorySource(
             uniqid(),
-            new Data(array('calculated_date' => $timestamp)),
+            new Data(['calculated_date' => $timestamp]),
             "contents",
             "formatted contents",
             __FILE__,

--- a/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
+++ b/src/Sculpin/Core/Tests/Source/Map/CalculatedDateFromFilenameMapTest.php
@@ -19,13 +19,13 @@ use SplFileInfo;
 
 class CalculatedDateFromFilenameMapTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->map = new CalculatedDateFromFilenameMap();
     }
 
     /** @test */
-    public function itShouldNotModifyAnExistingCalculatedDate()
+    public function itShouldNotModifyAnExistingCalculatedDate(): void
     {
         $source = $this->getSourceWithCalculatedDate($timestamp = 123456);
 
@@ -35,7 +35,7 @@ class CalculatedDateFromFilenameMapTest extends TestCase
     }
 
     /** @test */
-    public function itShouldSetTheCalculatedDateIfFound()
+    public function itShouldSetTheCalculatedDateIfFound(): void
     {
         $source = $this->getSourceWithoutCalculatedDateAndPathname("2013-12-12-sculpin-is-great.markdown");
 
@@ -45,7 +45,7 @@ class CalculatedDateFromFilenameMapTest extends TestCase
     }
 
     /** @test */
-    public function itShouldIncludeTheTimeIfFound()
+    public function itShouldIncludeTheTimeIfFound(): void
     {
         $source = $this->getSourceWithoutCalculatedDateAndPathname("2013-12-12-220212-sculpin-is-great.markdown");
 
@@ -55,7 +55,7 @@ class CalculatedDateFromFilenameMapTest extends TestCase
     }
 
     /** @test */
-    public function itShouldIgnoreTheTimeIfItsProbablyNotATime()
+    public function itShouldIgnoreTheTimeIfItsProbablyNotATime(): void
     {
         $source = $this->getSourceWithoutCalculatedDateAndPathname(
             "2013-12-12-10-reasons-why-sculpin-is-great.markdown"

--- a/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
@@ -11,13 +11,15 @@
 
 namespace Sculpin\Core\Tests\Source;
 
+use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Source\ProxySource;
+use Sculpin\Core\Source\SourceInterface;
 
-class ProxySourceTest extends \PHPUnit\Framework\TestCase
+class ProxySourceTest extends TestCase
 {
     public function testSetFormattedContent()
     {
-        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock(SourceInterface::class);
         $source
             ->expects($this->once())
             ->method('setFormattedContent')

--- a/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
@@ -17,7 +17,7 @@ use Sculpin\Core\Source\SourceInterface;
 
 class ProxySourceTest extends TestCase
 {
-    public function testSetFormattedContent()
+    public function testSetFormattedContent(): void
     {
         $source = $this->createMock(SourceInterface::class);
         $source

--- a/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
@@ -13,11 +13,11 @@ namespace Sculpin\Core\Tests\Source;
 
 use Sculpin\Core\Source\ProxySource;
 
-class ProxySourceTest extends \PHPUnit_Framework_TestCase
+class ProxySourceTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetFormattedContent()
     {
-        $source = $this->getMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
         $source
             ->expects($this->once())
             ->method('setFormattedContent')

--- a/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/ProxySourceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.

--- a/src/Sculpin/Core/Tests/Source/SourceSetTest.php
+++ b/src/Sculpin/Core/Tests/Source/SourceSetTest.php
@@ -13,11 +13,11 @@ namespace Sculpin\Core\Tests\Source;
 
 use Sculpin\Core\Source\SourceSet;
 
-class SourceSetTest extends \PHPUnit_Framework_TestCase
+class SourceSetTest extends \PHPUnit\Framework\TestCase
 {
     public function makeTestSource($sourceId, $hasChanged = true)
     {
-        $source = $this->getMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
 
         $source
             ->expects($this->any())

--- a/src/Sculpin/Core/Tests/Source/SourceSetTest.php
+++ b/src/Sculpin/Core/Tests/Source/SourceSetTest.php
@@ -34,7 +34,7 @@ class SourceSetTest extends TestCase
         return $source;
     }
 
-    public function testContainsSource()
+    public function testContainsSource(): void
     {
         $source000 = $this->makeTestSource('TestSource:000');
         $source001 = $this->makeTestSource('TestSource:001');
@@ -53,7 +53,7 @@ class SourceSetTest extends TestCase
         $this->assertTrue($sourceSet->containsSource($source002));
     }
 
-    public function testMergeSource()
+    public function testMergeSource(): void
     {
         $source000a = $this->makeTestSource('TestSource:000');
         $source000a
@@ -84,7 +84,7 @@ class SourceSetTest extends TestCase
         $this->assertEquals('b', $internalSources['TestSource:000']->content());
     }
 
-    public function testAllSources()
+    public function testAllSources(): void
     {
         $source000 = $this->makeTestSource('TestSource:000');
         $source001 = $this->makeTestSource('TestSource:001');
@@ -99,7 +99,7 @@ class SourceSetTest extends TestCase
         ], $sourceSet->allSources());
     }
 
-    public function testUpdatedSources()
+    public function testUpdatedSources(): void
     {
         $source000 = $this->makeTestSource('TestSource:000');
         $source001 = $this->makeTestSource('TestSource:001', false);
@@ -113,7 +113,7 @@ class SourceSetTest extends TestCase
         ], $sourceSet->updatedSources());
     }
 
-    public function testReset()
+    public function testReset(): void
     {
         $source000 = $this->makeTestSource('TestSource:000');
         $source001 = $this->makeTestSource('TestSource:001');

--- a/src/Sculpin/Core/Tests/Source/SourceSetTest.php
+++ b/src/Sculpin/Core/Tests/Source/SourceSetTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -38,7 +38,7 @@ class SourceSetTest extends \PHPUnit_Framework_TestCase
         $source001 = $this->makeTestSource('TestSource:001');
         $source002 = $this->makeTestSource('TestSource:002');
 
-        $sourceSet = new SourceSet(array($source000, $source002));
+        $sourceSet = new SourceSet([$source000, $source002]);
 
         $this->assertTrue($sourceSet->containsSource($source000));
         $this->assertFalse($sourceSet->containsSource($source001));
@@ -88,13 +88,13 @@ class SourceSetTest extends \PHPUnit_Framework_TestCase
         $source001 = $this->makeTestSource('TestSource:001');
         $source002 = $this->makeTestSource('TestSource:002');
 
-        $sourceSet = new SourceSet(array($source000, $source001, $source002));
+        $sourceSet = new SourceSet([$source000, $source001, $source002]);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'TestSource:000' => $source000,
             'TestSource:001' => $source001,
             'TestSource:002' => $source002,
-        ), $sourceSet->allSources());
+        ], $sourceSet->allSources());
     }
 
     public function testUpdatedSources()
@@ -103,12 +103,12 @@ class SourceSetTest extends \PHPUnit_Framework_TestCase
         $source001 = $this->makeTestSource('TestSource:001', false);
         $source002 = $this->makeTestSource('TestSource:002');
 
-        $sourceSet = new SourceSet(array($source000, $source001, $source002));
+        $sourceSet = new SourceSet([$source000, $source001, $source002]);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'TestSource:000' => $source000,
             'TestSource:002' => $source002,
-        ), $sourceSet->updatedSources());
+        ], $sourceSet->updatedSources());
     }
 
     public function testReset()
@@ -117,13 +117,13 @@ class SourceSetTest extends \PHPUnit_Framework_TestCase
         $source001 = $this->makeTestSource('TestSource:001');
         $source002 = $this->makeTestSource('TestSource:002');
 
-        foreach (array($source000, $source001, $source002) as $source) {
+        foreach ([$source000, $source001, $source002] as $source) {
             $source
                 ->expects($this->once())
                 ->method('setHasNotChanged');
         }
 
-        $sourceSet = new SourceSet(array($source000, $source001, $source002));
+        $sourceSet = new SourceSet([$source000, $source001, $source002]);
         $sourceSet->reset();
     }
 }

--- a/src/Sculpin/Core/Tests/Source/SourceSetTest.php
+++ b/src/Sculpin/Core/Tests/Source/SourceSetTest.php
@@ -11,13 +11,15 @@
 
 namespace Sculpin\Core\Tests\Source;
 
+use PHPUnit\Framework\TestCase;
+use Sculpin\Core\Source\SourceInterface;
 use Sculpin\Core\Source\SourceSet;
 
-class SourceSetTest extends \PHPUnit\Framework\TestCase
+class SourceSetTest extends TestCase
 {
     public function makeTestSource($sourceId, $hasChanged = true)
     {
-        $source = $this->createMock('Sculpin\Core\Source\SourceInterface');
+        $source = $this->createMock(SourceInterface::class);
 
         $source
             ->expects($this->any())

--- a/src/Sculpin/Core/Util/DirectorySeparatorNormalizer.php
+++ b/src/Sculpin/Core/Util/DirectorySeparatorNormalizer.php
@@ -36,7 +36,6 @@ class DirectorySeparatorNormalizer
      *
      * @param string $directorySeparator Directory separator
      *
-     * @return DirectorySeparatorNormalizer
      */
     public function setDirectorySeparator(string $directorySeparator): DirectorySeparatorNormalizer
     {
@@ -52,7 +51,7 @@ class DirectorySeparatorNormalizer
      *
      * @return null|string
      */
-    public function normalize(string $path = null)
+    public function normalize(?string $path = null): ?string
     {
         if ($this->preferredDirectorySeparator === $this->directorySeparator) {
             return $path;

--- a/src/Sculpin/Core/Util/DirectorySeparatorNormalizer.php
+++ b/src/Sculpin/Core/Util/DirectorySeparatorNormalizer.php
@@ -35,7 +35,6 @@ class DirectorySeparatorNormalizer
      * Useful for testing to override DIRECTORY_SEPARATOR.
      *
      * @param string $directorySeparator Directory separator
-     *
      */
     public function setDirectorySeparator(string $directorySeparator): DirectorySeparatorNormalizer
     {
@@ -48,8 +47,6 @@ class DirectorySeparatorNormalizer
      * Normalize filesystem paths to a preferred $separator
      *
      * @param string $path Path
-     *
-     * @return null|string
      */
     public function normalize(?string $path = null): ?string
     {

--- a/src/Sculpin/Core/Util/DirectorySeparatorNormalizer.php
+++ b/src/Sculpin/Core/Util/DirectorySeparatorNormalizer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /*
  * This file is a part of Sculpin.
@@ -23,7 +23,7 @@ class DirectorySeparatorNormalizer
      *
      * @param string $preferredDirectorySeparator Preferred directory separator
      */
-    public function __construct($preferredDirectorySeparator = '/')
+    public function __construct(string $preferredDirectorySeparator = '/')
     {
         $this->preferredDirectorySeparator = $preferredDirectorySeparator;
         $this->directorySeparator = DIRECTORY_SEPARATOR;
@@ -38,7 +38,7 @@ class DirectorySeparatorNormalizer
      *
      * @return DirectorySeparatorNormalizer
      */
-    public function setDirectorySeparator($directorySeparator)
+    public function setDirectorySeparator(string $directorySeparator): DirectorySeparatorNormalizer
     {
         $this->directorySeparator = $directorySeparator;
 
@@ -52,7 +52,7 @@ class DirectorySeparatorNormalizer
      *
      * @return null|string
      */
-    public function normalize($path = null)
+    public function normalize(string $path = null)
     {
         if ($this->preferredDirectorySeparator === $this->directorySeparator) {
             return $path;

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -2,6 +2,8 @@
 
 namespace Sculpin\Tests\Functional;
 
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -10,7 +12,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * and run the sculpin binary against it. Test project files
  * will automatically be created and removed with every test.
  */
-class FunctionalTestCase extends \PHPUnit\Framework\TestCase
+class FunctionalTestCase extends TestCase
 {
     const PROJECT_DIR = '/__SculpinTestProject__';
 
@@ -168,12 +170,12 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
     private function readFile($filePath): string
     {
         if (!self::$fs->exists($filePath)) {
-            throw new \PHPUnit\Framework\Exception("Unable to read file at path $filePath: file does not exist");
+            throw new Exception("Unable to read file at path $filePath: file does not exist");
         }
 
         $content = file_get_contents($filePath);
         if ($content === false) {
-            throw new \PHPUnit\Framework\Exception("Unable to read file at path $filePath: failed to read file.");
+            throw new Exception("Unable to read file at path $filePath: failed to read file.");
         }
 
         return $content;

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -62,6 +62,10 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
     {
         $binPath = __DIR__ . '/../../../../bin';
         $projectDir = self::projectDir();
+
+        var_dump("$binPath/sculpin $command --project-dir $projectDir --env=test");
+        die;
+
         exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
     }
 

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -14,24 +14,24 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class FunctionalTestCase extends TestCase
 {
-    const PROJECT_DIR = '/__SculpinTestProject__';
+    public const PROJECT_DIR = '/__SculpinTestProject__';
 
     /** @var Filesystem */
     protected static $fs;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fs = new Filesystem();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->setUpTestProject();
     }
 
-    protected function setUpTestProject()
+    protected function setUpTestProject(): void
     {
         $this->tearDownTestProject();
 
@@ -48,7 +48,7 @@ class FunctionalTestCase extends TestCase
         $this->writeToProjectFile('/source/_layouts/raw.html.twig', '{% block content %}{% endblock content %}');
     }
 
-    protected function tearDownTestProject()
+    protected function tearDownTestProject(): void
     {
         $projectDir = self::projectDir();
         if (self::$fs->exists($projectDir)) {
@@ -59,7 +59,7 @@ class FunctionalTestCase extends TestCase
     /**
      * Execute a command against the sculpin binary
      */
-    protected function executeSculpin(string $command)
+    protected function executeSculpin(string $command): void
     {
         $binPath = __DIR__ . '/../../../../bin';
         $projectDir = self::projectDir();
@@ -67,7 +67,7 @@ class FunctionalTestCase extends TestCase
         exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
     }
 
-    protected function addProjectDirectory(string $path, bool $recursive = true)
+    protected function addProjectDirectory(string $path, bool $recursive = true): void
     {
         $pathParts = explode('/', $path);
         // Remove leading slash
@@ -89,7 +89,7 @@ class FunctionalTestCase extends TestCase
         }
     }
 
-    protected function addProjectFile(string $filePath, string $content = null)
+    protected function addProjectFile(string $filePath, ?string $content = null): void
     {
         $dirPathParts = explode('/', $filePath);
         // Remove leading slash
@@ -113,7 +113,7 @@ class FunctionalTestCase extends TestCase
         }
     }
 
-    protected function copyFixtureToProject(string $fixturePath, string $projectPath)
+    protected function copyFixtureToProject(string $fixturePath, string $projectPath): void
     {
         self::$fs->copy($fixturePath, self::projectDir() . $projectPath);
     }
@@ -121,14 +121,14 @@ class FunctionalTestCase extends TestCase
     /**
      * @param null   $msg
      */
-    protected function assertProjectHasFile(string $filePath, $msg = null)
+    protected function assertProjectHasFile(string $filePath, $msg = null): void
     {
         $msg = $msg ?: "Expected project to contain file at path $filePath.";
 
         $this->assertTrue(self::$fs->exists(self::projectDir() . $filePath), $msg);
     }
 
-    protected function assertProjectHasGeneratedFile(string $filePath, string $msg = null)
+    protected function assertProjectHasGeneratedFile(string $filePath, ?string $msg = null): void
     {
         $outputDir = '/output_test';
 
@@ -136,7 +136,7 @@ class FunctionalTestCase extends TestCase
         $this->assertProjectHasFile($outputDir . $filePath, $msg);
     }
 
-    protected function writeToProjectFile(string $filePath, string $content)
+    protected function writeToProjectFile(string $filePath, string $content): void
     {
         self::$fs->dumpFile(self::projectDir() . $filePath, $content);
     }

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -10,7 +10,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * and run the sculpin binary against it. Test project files
  * will automatically be created and removed with every test.
  */
-class FunctionalTestCase extends \PHPUnit_Framework_TestCase
+class FunctionalTestCase extends \PHPUnit\Framework\TestCase
 {
     const PROJECT_DIR = '/__SculpinTestProject__';
 
@@ -196,12 +196,12 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     private function readFile($filePath): string
     {
         if (!self::$fs->exists($filePath)) {
-            throw new \PHPUnit_Framework_Exception("Unable to read file at path $filePath: file does not exist");
+            throw new \PHPUnit\Framework\Exception("Unable to read file at path $filePath: file does not exist");
         }
 
         $content = file_get_contents($filePath);
         if ($content === false) {
-            throw new \PHPUnit_Framework_Exception("Unable to read file at path $filePath: failed to read file.");
+            throw new \PHPUnit\Framework\Exception("Unable to read file at path $filePath: failed to read file.");
         }
 
         return $content;

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -56,7 +56,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
 
     /**
      * Execute a command against the sculpin binary
-     * @param string $command
      */
     protected function executeSculpin(string $command)
     {
@@ -66,10 +65,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
     }
 
-    /**
-     * @param string $path
-     * @param bool $recursive
-     */
     protected function addProjectDirectory(string $path, bool $recursive = true)
     {
         $pathParts = explode('/', $path);
@@ -92,10 +87,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @param string $filePath
-     * @param string $content
-     */
     protected function addProjectFile(string $filePath, string $content = null)
     {
         $dirPathParts = explode('/', $filePath);
@@ -120,17 +111,12 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @param string $fixturePath
-     * @param string $projectPath
-     */
     protected function copyFixtureToProject(string $fixturePath, string $projectPath)
     {
         self::$fs->copy($fixturePath, self::projectDir() . $projectPath);
     }
 
     /**
-     * @param string $filePath
      * @param null   $msg
      */
     protected function assertProjectHasFile(string $filePath, $msg = null)
@@ -140,10 +126,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         $this->assertTrue(self::$fs->exists(self::projectDir() . $filePath), $msg);
     }
 
-    /**
-     * @param string $filePath
-     * @param string $msg
-     */
     protected function assertProjectHasGeneratedFile(string $filePath, string $msg = null)
     {
         $outputDir = '/output_test';
@@ -152,17 +134,12 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         $this->assertProjectHasFile($outputDir . $filePath, $msg);
     }
 
-    /**
-     * @param string $filePath
-     * @param string $content
-     */
     protected function writeToProjectFile(string $filePath, string $content)
     {
         self::$fs->dumpFile(self::projectDir() . $filePath, $content);
     }
 
     /**
-     * @param string $filePath
      * @return Crawler
      */
     protected function crawlGeneratedProjectFile(string $filePath): Crawler
@@ -171,7 +148,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param string $filePath
      * @return Crawler
      */
     protected function crawlProjectFile(string $filePath): Crawler
@@ -180,7 +156,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param string $filePath
      * @return Crawler
      */
     private function crawlFile(string $filePath): Crawler
@@ -190,10 +165,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         return new Crawler($content);
     }
 
-    /**
-     * @param $filePath
-     * @return string
-     */
     private function readFile($filePath): string
     {
         if (!self::$fs->exists($filePath)) {
@@ -208,9 +179,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         return $content;
     }
 
-    /**
-     * @return string
-     */
     protected static function projectDir(): string
     {
         return __DIR__ . self::PROJECT_DIR;

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -1,5 +1,4 @@
-<?php
-
+<?php declare(strict_types=1);
 
 namespace Sculpin\Tests\Functional;
 
@@ -34,11 +33,11 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     {
         $this->tearDownTestProject();
 
-        $projectFiles = array(
+        $projectFiles = [
             '/config/sculpin_kernel.yml',
             '/config/sculpin_site.yml',
             '/source/_layouts/raw.html.twig',
-        );
+        ];
 
         foreach ($projectFiles as $file) {
             $this->addProjectFile($file);
@@ -59,7 +58,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * Execute a command against the sculpin binary
      * @param string $command
      */
-    protected function executeSculpin($command)
+    protected function executeSculpin(string $command)
     {
         $binPath = __DIR__ . '/../../../../bin';
         $projectDir = self::projectDir();
@@ -70,7 +69,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $path
      * @param bool $recursive
      */
-    protected function addProjectDirectory($path, $recursive = true)
+    protected function addProjectDirectory(string $path, bool $recursive = true)
     {
         $pathParts = explode('/', $path);
         // Remove leading slash
@@ -96,7 +95,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @param string $content
      */
-    protected function addProjectFile($filePath, $content = null)
+    protected function addProjectFile(string $filePath, string $content = null)
     {
         $dirPathParts = explode('/', $filePath);
         // Remove leading slash
@@ -124,7 +123,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $fixturePath
      * @param string $projectPath
      */
-    protected function copyFixtureToProject($fixturePath, $projectPath)
+    protected function copyFixtureToProject(string $fixturePath, string $projectPath)
     {
         self::$fs->copy($fixturePath, self::projectDir() . $projectPath);
     }
@@ -133,7 +132,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @param null   $msg
      */
-    protected function assertProjectHasFile($filePath, $msg = null)
+    protected function assertProjectHasFile(string $filePath, $msg = null)
     {
         $msg = $msg ?: "Expected project to contain file at path $filePath.";
 
@@ -144,7 +143,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @param string $msg
      */
-    protected function assertProjectHasGeneratedFile($filePath, $msg = null)
+    protected function assertProjectHasGeneratedFile(string $filePath, string $msg = null)
     {
         $outputDir = '/output_test';
 
@@ -156,7 +155,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @param string $content
      */
-    protected function writeToProjectFile($filePath, $content)
+    protected function writeToProjectFile(string $filePath, string $content)
     {
         self::$fs->dumpFile(self::projectDir() . $filePath, $content);
     }
@@ -165,7 +164,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @return Crawler
      */
-    protected function crawlGeneratedProjectFile($filePath)
+    protected function crawlGeneratedProjectFile(string $filePath): Crawler
     {
         return $this->crawlProjectFile('/output_test' . $filePath);
     }
@@ -174,7 +173,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @return Crawler
      */
-    protected function crawlProjectFile($filePath)
+    protected function crawlProjectFile(string $filePath): Crawler
     {
         return $this->crawlFile(self::projectDir() . $filePath);
     }
@@ -183,7 +182,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param string $filePath
      * @return Crawler
      */
-    private function crawlFile($filePath)
+    private function crawlFile(string $filePath): Crawler
     {
         $content = $this->readFile($filePath);
 
@@ -194,7 +193,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
      * @param $filePath
      * @return string
      */
-    private function readFile($filePath)
+    private function readFile($filePath): string
     {
         if (!self::$fs->exists($filePath)) {
             throw new \PHPUnit_Framework_Exception("Unable to read file at path $filePath: file does not exist");
@@ -211,7 +210,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     /**
      * @return string
      */
-    protected static function projectDir()
+    protected static function projectDir(): string
     {
         return __DIR__ . self::PROJECT_DIR;
     }

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -63,9 +63,6 @@ class FunctionalTestCase extends \PHPUnit\Framework\TestCase
         $binPath = __DIR__ . '/../../../../bin';
         $projectDir = self::projectDir();
 
-        var_dump("$binPath/sculpin $command --project-dir $projectDir --env=test");
-        die;
-
         exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
     }
 

--- a/src/Sculpin/Tests/Functional/GenerateFromMarkdownTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromMarkdownTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Tests\Functional;
 

--- a/src/Sculpin/Tests/Functional/GenerateFromMarkdownTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromMarkdownTest.php
@@ -5,7 +5,7 @@ namespace Sculpin\Tests\Functional;
 class GenerateFromMarkdownTest extends FunctionalTestCase
 {
     /** @test */
-    public function shouldGenerateAnHtmlFileFromMarkdown()
+    public function shouldGenerateAnHtmlFileFromMarkdown(): void
     {
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.md', '/source/hello_world.md');
 
@@ -15,7 +15,7 @@ class GenerateFromMarkdownTest extends FunctionalTestCase
     }
 
     /** @test */
-    public function shouldGenerateHtmlContentFromMarkdown()
+    public function shouldGenerateHtmlContentFromMarkdown(): void
     {
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.md', '/source/hello_world.md');
 
@@ -27,7 +27,7 @@ class GenerateFromMarkdownTest extends FunctionalTestCase
     }
 
     /** @test */
-    public function shouldGenerateIntoNestedDirectories()
+    public function shouldGenerateIntoNestedDirectories(): void
     {
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.md', '/source/hello/world.md');
 
@@ -37,7 +37,7 @@ class GenerateFromMarkdownTest extends FunctionalTestCase
     }
 
     /** @test */
-    public function shouldGenerateHtmlUsingALayout()
+    public function shouldGenerateHtmlUsingALayout(): void
     {
         $this->addProjectFile('/source/_layouts/my_layout.html.twig', <<<EOT
 <body>

--- a/src/Sculpin/Tests/Functional/GenerateFromPostsTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromPostsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Sculpin\Tests\Functional;
 

--- a/src/Sculpin/Tests/Functional/GenerateFromPostsTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromPostsTest.php
@@ -5,7 +5,7 @@ namespace Sculpin\Tests\Functional;
 class GenerateFromPostsTest extends FunctionalTestCase
 {
     /** @test */
-    public function shouldGenerateAnHtmlFileFromEmptyPost()
+    public function shouldGenerateAnHtmlFileFromEmptyPost(): void
     {
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/blog_index.html', '/source/index.html');
         $this->addProjectDirectory(__DIR__ . '/Fixture/source/_posts');


### PR DESCRIPTION
### Why?

- majority of [PHP world big players are bumping to PHP 7.1](https://gophp71.org/)
- upcoming [PHP 7.2](https://github.com/php-ai/php-ml/pull/147) in few days
- we could add PHP 7.0/7.1 typehints via coding standards more easily in the future
- [as measured on Packagist - 67 % people](https://seld.be/notes/php-versions-stats-2017-2-edition) are on PHP 7.0+ and growing
- easier to maintain, more reliable code without testing it
- thanks to typehints, I could found and prevent some bugs already

### Related Changes

- drop hhvm since it [focuses on PHP 5 mainly and version 7 won't be developed further](https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html)
- also Symfony dropped hhvm [support months ago](https://symfony.com/blog/symfony-4-end-of-hhvm-support)