### PR TITLE
Change Travis distro to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 
+dist: trusty
 sudo: false
 
 cache:


### PR DESCRIPTION
HHVM build fails only because Precise is not supported anymore.