### PR TITLE
Use reflection to bring back Twig template cache invalidation

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/Environment.php
+++ b/src/Sculpin/Bundle/TwigBundle/Environment.php
@@ -29,7 +29,7 @@ class Environment extends \Twig_Environment
             $me     = new \ReflectionClass($this);
             $parent = $me;
 
-            while ($parent !== false) {
+            while ($parent instanceof \ReflectionClass) {
                 $me     = $parent;
                 $parent = $me->getParentClass();
             }

--- a/src/Sculpin/Bundle/TwigBundle/Environment.php
+++ b/src/Sculpin/Bundle/TwigBundle/Environment.php
@@ -23,7 +23,8 @@ class Environment extends \Twig_Environment
      *
      * Hacky workaround to expose invalidation.
      */
-    public function invalidateLoadedTemplates() {
+    public function invalidateLoadedTemplates()
+    {
         try {
             $me     = new \ReflectionClass($this);
             $parent = $me;
@@ -36,6 +37,7 @@ class Environment extends \Twig_Environment
             $templates = $me->getProperty('loadedTemplates');
             $templates->setAccessible(true);
             $templates->setValue($this, []);
-        } catch (\ReflectionException $e) {}
+        } catch (\ReflectionException $e) {
+        }
     }
 }

--- a/src/Sculpin/Bundle/TwigBundle/Environment.php
+++ b/src/Sculpin/Bundle/TwigBundle/Environment.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Bundle\TwigBundle;
+
+/**
+ * Twig Environment with Loaded Template Invalidation.
+ */
+class Environment extends \Twig_Environment
+{
+    /**
+     * We aren't supposed to be using loadTemplate directly, and Twig V2 took away our ability to invalidate it.
+     *
+     * Hacky workaround to expose invalidation.
+     */
+    public function invalidateLoadedTemplates() {
+        try {
+            $me     = new \ReflectionClass($this);
+            $parent = $me;
+
+            while ($parent !== false) {
+                $me     = $parent;
+                $parent = $me->getParentClass();
+            }
+
+            $templates = $me->getProperty('loadedTemplates');
+            $templates->setAccessible(true);
+            $templates->setValue($this, []);
+        } catch (\ReflectionException $e) {}
+    }
+}

--- a/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <parameter key="sculpin_twig.array_loader.class">Twig_Loader_Array</parameter>
         <parameter key="sculpin_twig.loader.class">Twig_Loader_Chain</parameter>
         <parameter key="sculpin_twig.template_resetter.class">Sculpin\Bundle\TwigBundle\TemplateResetter</parameter>
-        <parameter key="sculpin_twig.twig.class">Twig_Environment</parameter>
+        <parameter key="sculpin_twig.twig.class">Sculpin\Bundle\TwigBundle\Environment</parameter>
         <parameter key="sculpin_twig.formatter.class">Sculpin\Bundle\TwigBundle\TwigFormatter</parameter>
         <parameter key="sculpin_twig.extensions.debug.class">Twig_Extension_Debug</parameter>
         <parameter key="sculpin_twig.extensions.intl.class">Twig_Extensions_Extension_Intl</parameter>

--- a/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
@@ -29,9 +29,9 @@ class TemplateResetter implements EventSubscriberInterface
     /**
      * Constructor.
      *
-     * @param \Twig_Environment $twig
+     * @param Environment $twig
      */
-    public function __construct(\Twig_Environment $twig)
+    public function __construct(Environment $twig)
     {
         $this->twig = $twig;
     }
@@ -53,9 +53,9 @@ class TemplateResetter implements EventSubscriberInterface
      */
     public function beforeRun(SourceSetEvent $sourceSetEvent)
     {
-        if ($sourceSetEvent->updatedSources()) {
-            // removed in twig v2
-            //$this->twig->clearTemplateCache();
+        $updated = $sourceSetEvent->updatedSources();
+        if ($updated) {
+            $this->twig->invalidateLoadedTemplates();
         }
     }
 }

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -8,6 +8,7 @@ namespace Sculpin\Tests\Functional;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 /**
  * This test case allows you to create a test project on the fly,
@@ -67,6 +68,30 @@ class FunctionalTestCase extends TestCase
         $binPath = __DIR__ . '/../../../../bin';
         $projectDir = self::projectDir();
         exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
+    }
+
+    /**
+     * Asynchronously execute a command against the sculpin binary
+     *
+     * Remember to stop the process when finished!
+     *
+     * @param string   $command
+     * @param bool     $start     Default: start the process right away
+     * @param callable $callback
+     *
+     * @return Process
+     */
+    protected function executeSculpinAsync($command, $start = true, callable $callback = null)
+    {
+        $binPath    = __DIR__ . '/../../../../bin';
+        $projectDir = self::projectDir();
+        $process    = new Process("$binPath/sculpin $command --project-dir $projectDir --env=test");
+
+        if ($start) {
+            $process->start($callback);
+        }
+
+        return $process;
     }
 
     /**


### PR DESCRIPTION
This is a bit hacky, but it should fix issue #362 and hopefully get the `develop` branch on track to merge into master.