### PR TITLE
Add setter for canBeFormatted property of AbstractSource class

### DIFF
--- a/src/Sculpin/Core/Source/AbstractSource.php
+++ b/src/Sculpin/Core/Source/AbstractSource.php
@@ -352,6 +352,14 @@ abstract class AbstractSource implements SourceInterface
     }
 
     /**
+     * Mark source as can be formatted
+     */
+    public function setCanBeFormatted()
+    {
+        $this->canBeFormatted = true;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function file()


### PR DESCRIPTION
Hi!

I use this bundle https://github.com/rjkip/SculpinRstBundle to generate the RST format, but the generated files are rst extension, not html (as expected), but to achieve this, we need to set the `canBeFormatted` property to true, which the given PR does.

A big request to view and accept this PR. Thank you!

cc @beryllium 