### PR TITLE
Fix type error

### DIFF
--- a/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
@@ -45,7 +45,7 @@ class ThemeRegistry
         $themes = array();
 
         foreach ($directories as $directory) {
-            $name = basename(dirname($directory)).'/'.basename($directory);
+            $name = basename(dirname($directory->getRealPath())).'/'.basename($directory->getRealPath());
             $theme = array('name' => $name, 'path' => $directory);
             if (file_exists($directory.'/theme.yml')) {
                 $theme = array_merge(Yaml::parse(file_get_contents($directory.'/theme.yml')), $theme);


### PR DESCRIPTION
Since strict typing is used, currently there is such an error:

`Fatal error: Uncaught TypeError: dirname() expects parameter 1 to be string, object given on line 48`