### PR TITLE
Fix uncaught exception on checking the existence of a loader

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -124,7 +124,11 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
      */
     public function exists($name)
     {
-        $this->getCacheKey($name);
+        try {
+            $this->getCacheKey($name);
+        } catch (\Twig_Error_Loader $e) {
+            return false;
+        }
 
         $extension = $this->cachedCacheKeyExtension[$name];
 


### PR DESCRIPTION
Because if there is no extension on the latest iteration is exception occurs, which currently is not catched, and the work will be completed a fatal error.

https://github.com/sculpin/sculpin/blob/70acab357b1f4ff8bdff5b6a3339d30183cd83ca/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php#L105