### PR TITLE
Add support for commands as services

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -21,6 +21,7 @@ use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\GeneratorManagerPa
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\PathConfiguratorPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\CustomMimeTypesRepositoryPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -42,5 +43,6 @@ class SculpinBundle extends Bundle
         $container->addCompilerPass(new PathConfiguratorPass);
         $container->addCompilerPass(new CustomMimeTypesRepositoryPass);
         $container->addCompilerPass(new DataSourcePass);
+        $container->addCompilerPass(new AddConsoleCommandPass());
     }
 }


### PR DESCRIPTION
In current moment we can see such errors:

```
PHP Deprecated: Auto-registration of the command 
"Sculpin\Bundle\SculpinBundle\Command\ServeCommand" is 
deprecated since Symfony 3.4 and won't be supported in 4.0. 
Use PSR-4 based service discovery instead
```

This is due to the fact that the commands must be explicitly registered as services, this PR adds support for this.

The source of the implementation was taken from the framework-bundle https://github.com/symfony/framework-bundle/blob/505aa68e04b160318c68b61f02fc1c341f43fa34/Console/Application.php

