### PR TITLE
Use sculpin.writer to govern output_dir_override

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -81,10 +81,8 @@ EOT
             }
         }
 
-        $override = $this->getContainer()->hasParameter('sculpin.output_dir_override')
-            ? $this->getContainer()->getParameter('sculpin.output_dir_override')
-            : null;
-        $docroot  = $override ?: $this->getContainer()->getParameter('sculpin.output_dir');
+        $writer  = $this->getContainer()->get('sculpin.writer');
+        $docroot = $writer->getOutputDir();
         if ($input->getOption('clean')) {
             $this->clean($input, $output, $docroot);
         }

--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -37,7 +37,7 @@
             <argument>%sculpin.permalink%</argument>
         </service>
 
-        <service id="sculpin.writer" class="%sculpin.writer.class%">
+        <service id="sculpin.writer" class="%sculpin.writer.class%" public="true">
             <argument type="service" id="filesystem" />
             <argument>%sculpin.output_dir%</argument>
         </service>

--- a/src/Sculpin/Core/Output/FilesystemWriter.php
+++ b/src/Sculpin/Core/Output/FilesystemWriter.php
@@ -71,4 +71,13 @@ class FilesystemWriter implements WriterInterface
     {
         $this->outputDir = $outputDir;
     }
+
+    /**
+     * Retrieve the output directory
+     *
+     * @return string
+     */
+    public function getOutputDir(): string {
+        return $this->outputDir;
+    }
 }


### PR DESCRIPTION
This is so that bundles can accept `sculpin.writer` as an argument and won't have to worry about accepting both `sculpin.output_dir` AND `sculpin.output_dir_override` as arguments.