### PR TITLE
Make a public service Event Dispatcher

### DIFF
--- a/src/Sculpin/Bundle/StandaloneBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/StandaloneBundle/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <parameter key="templating.engines" type="collection" />
     </parameters>
     <services>
-        <service id="event_dispatcher" class="%event_dispatcher.class%">
+        <service id="event_dispatcher" class="%event_dispatcher.class%" public="true">
             <argument type="service" id="service_container" />
         </service>
         <service id="filesystem" class="%filesystem.class%" public="true" />


### PR DESCRIPTION
It is very important! 

Forgive me, I broke backward compatibility in [my PR](https://github.com/sculpin/sculpin/pull/383): built-in Sculpin events is worked, but custom ones ([example](https://github.com/shopware/devdocs/blob/93cb1789f9b93acf88d82d545ae0883d21e892eb/app/src/AnchorListener.php#L19)) **will not work** because [this condition in event_dispatcher will be true](https://github.com/symfony/event-dispatcher/blob/d8eb135cc2886e01e829f4fd6be148342de39454/DependencyInjection/RegisterListenersPass.php#L51).

Please accept this change as soon as possible!

cc @beryllium @simensen 
