### PR TITLE
Add Generic.Arrays.DisallowLongArraySyntax rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,4 +8,5 @@
  <file>./src/</file>
 
  <rule ref="PSR2"/>
+ <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 </ruleset>


### PR DESCRIPTION
cc @simensen @beryllium 