### PR TITLE
Create basic initialization command for clean-slate projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
 cache
+__BlankSculpinProject__/
 __SculpinTestProject__/
 clover.xml

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,8 @@
 
  <file>./src/</file>
 
+ <exclude-pattern>*/__BlankSculpinProject__/*</exclude-pattern>
+
  <rule ref="PSR2"/>
  <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 </ruleset>

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -15,6 +15,7 @@ namespace Sculpin\Bundle\SculpinBundle\Command;
 
 use Sculpin\Bundle\SculpinBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -26,6 +27,9 @@ class InitCommand extends AbstractCommand
     public const COMMAND_SUCCESS          = 0;
     public const PROJECT_FOLDER_NOT_EMPTY = 101;
 
+    public const DEFAULT_SUBTITLE = 'A Static Site Powered By Sculpin';
+    public const DEFAULT_TITLE    = 'My Sculpin Site';
+
     /**
      * {@inheritdoc}
      */
@@ -36,7 +40,22 @@ class InitCommand extends AbstractCommand
         $this
             ->setName($prefix.'init')
             ->setDescription('Initialize a default site configuration.')
-            ->setDefinition([])
+            ->setDefinition([
+                new InputOption(
+                    'title',
+                    't',
+                    InputOption::VALUE_REQUIRED,
+                    'Specify a title for your Sculpin site.',
+                    self::DEFAULT_TITLE
+                ),
+                new InputOption(
+                    'subtitle',
+                    's',
+                    InputOption::VALUE_REQUIRED,
+                    'Specify a sub-title for your Sculpin site.',
+                    self::DEFAULT_SUBTITLE
+                ),
+            ])
             ->setHelp(<<<EOT
 The <info>init</info> command initializes a default site configuration.
 
@@ -55,6 +74,9 @@ EOT
                 $output->writeln($message);
             }
         }
+
+        $title    = $input->getOption('title');
+        $subTitle = $input->getOption('subtitle');
 
         $projectDir = $this->getContainer()->getParameter('sculpin.project_dir');
         $output->writeln('Project Directory: <info>' . $projectDir . '</info>');
@@ -75,9 +97,9 @@ EOT
 
         // 3. Create default Site config files
         $this->createSiteKernelFile($projectDir, $output);
-        $this->createSiteConfigFile($projectDir, $output);
+        $this->createSiteConfigFile($projectDir, $title, $subTitle, $output);
 
-        // 4. Create source folder and very first basic entry in source folder
+        // 4. Create source folder (with or without posts) and the very first basic entry in the source folder
         $this->createSourceFolder($projectDir, $output);
 
         $output->writeln('<info>Success!</info>');
@@ -138,11 +160,15 @@ EOF;
         return true;
     }
 
-    protected function createSiteConfigFile(string $projectDir, OutputInterface $output): bool
-    {
+    protected function createSiteConfigFile(
+        string $projectDir,
+        string $title,
+        string $subTitle,
+        OutputInterface $output
+    ): bool {
         $contents = <<<EOF
-title: My Sculpin Site
-subtitle: A Static Site Powered By Sculpin
+title: "$title"
+subtitle: "$subTitle"
 google_analytics_tracking_id: ''
 url: ''
 

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Bundle\SculpinBundle\Command;
+
+use Sculpin\Bundle\SculpinBundle\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Init Command - Initialize default website configuration and structure.
+ */
+class InitCommand extends AbstractCommand
+{
+    public const COMMAND_SUCCESS          = 0;
+    public const PROJECT_FOLDER_NOT_EMPTY = 101;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $prefix = $this->isStandaloneSculpin() ? '' : 'sculpin:';
+
+        $this
+            ->setName($prefix.'init')
+            ->setDescription('Initialize a default site configuration.')
+            ->setDefinition([])
+            ->setHelp(<<<EOT
+The <info>init</info> command initializes a default site configuration.
+
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $application = $this->getApplication();
+        if ($application instanceof Application) {
+            foreach ($application->getMissingSculpinBundlesMessages() as $message) {
+                $output->writeln($message);
+            }
+        }
+
+        $projectDir = $this->getContainer()->getParameter('sculpin.project_dir');
+        $output->writeln('Project Directory: <info>' . $projectDir . '</info>');
+
+        $output->writeln('Initializing <info>./app</info> and <info>./source</info> for Sculpin' . "\n");
+
+        // Actions:
+
+        // 1. Ensure we're operating on a clean slate
+        if (!$this->ensureCleanSlate($projectDir, $output)) {
+            $output->writeln('<error>This command can only be run in an uninitialized folder.</error>');
+
+            return self::PROJECT_FOLDER_NOT_EMPTY;
+        }
+
+        // 2. Create default Kernel
+        $this->createDefaultKernel($projectDir, $output);
+
+        // 3. Create default Site config files
+        $this->createSiteKernelFile($projectDir, $output);
+        $this->createSiteConfigFile($projectDir, $output);
+
+        // 4. Create source folder and very first basic entry in source folder
+        $this->createSourceFolder($projectDir, $output);
+
+        $output->writeln('<info>Success!</info>');
+        $output->writeln('Run "sculpin generate --watch --server" to see your static site in action.');
+
+        return self::COMMAND_SUCCESS;
+    }
+
+    protected function ensureCleanSlate(string $projectDir, OutputInterface $output): bool
+    {
+        $fs = new Filesystem();
+        if ($fs->exists($projectDir . '/app')) {
+            $output->writeln('<info>/app folder exists.</info>');
+
+            return false;
+        }
+
+        if ($fs->exists($projectDir . '/source')) {
+            $output->writeln('<info>/source folder exists.</info>');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function createDefaultKernel(string $projectDir, OutputInterface $output): bool
+    {
+        $contents = <<<EOF
+<?php
+
+class SculpinKernel extends \Sculpin\Bundle\SculpinBundle\HttpKernel\AbstractKernel
+{
+    protected function getAdditionalSculpinBundles(): array
+    {
+        return [
+//            'App\\Bundle\\ExampleBundle\\AppExampleBundle'
+        ];
+    }
+}
+
+EOF;
+        $this->createFile($projectDir . '/app/SculpinKernel.php', $contents);
+
+        return true;
+    }
+
+    protected function createSiteKernelFile(string $projectDir, OutputInterface $output): bool
+    {
+        $contents = <<<EOF
+sculpin_content_types:
+    posts:
+      enabled: false
+
+EOF;
+        $this->createFile($projectDir . '/app/config/sculpin_kernel.yml', $contents);
+
+        return true;
+    }
+
+    protected function createSiteConfigFile(string $projectDir, OutputInterface $output): bool
+    {
+        $contents = <<<EOF
+title: My Sculpin Site
+subtitle: A Static Site Powered By Sculpin
+google_analytics_tracking_id: ''
+url: ''
+
+EOF;
+        $this->createFile($projectDir . '/app/config/sculpin_site.yml', $contents);
+
+        return true;
+    }
+
+    protected function createSourceFolder(string $projectDir, OutputInterface $output): bool
+    {
+        $fs = new Filesystem();
+
+        $fs->dumpFile(
+            $projectDir . '/source/index.md',
+            <<<EOF
+---
+layout: default
+---
+
+<h1>Welcome to {{site.title}}</h1>
+
+EOF
+        );
+
+        $fs->dumpFile(
+            $projectDir . '/source/_views/default.html',
+            <<<EOF
+<html>
+<head><title>{{site.title}}</title></head>
+<body>
+{% block content_wrapper %}{% block content '' %}{% endblock content_wrapper %}
+</body>
+</html>
+
+EOF
+        );
+
+        return true;
+    }
+
+    protected function createFile(string $path, string $contents): void
+    {
+        $fs = new Filesystem();
+        $fs->dumpFile($path, $contents);
+    }
+}

--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -124,6 +124,11 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Sculpin\Bundle\SculpinBundle\Command\InitCommand"
+                 class="Sculpin\Bundle\SculpinBundle\Command\InitCommand">
+            <tag name="console.command"/>
+        </service>
+
         <service id="Sculpin\Bundle\SculpinBundle\Command\ServeCommand"
                  class="Sculpin\Bundle\SculpinBundle\Command\ServeCommand">
             <tag name="console.command"/>

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -17,14 +17,14 @@ use Symfony\Component\Process\Process;
  */
 class FunctionalTestCase extends TestCase
 {
-    const PROJECT_DIR = '/__SculpinTestProject__';
+    protected const PROJECT_DIR = '/__SculpinTestProject__';
 
     /** @var Filesystem */
     protected static $fs;
 
     public static function setUpBeforeClass()
     {
-        self::$fs = new Filesystem();
+        static::$fs = new Filesystem();
     }
 
     public function setUp()
@@ -53,9 +53,9 @@ class FunctionalTestCase extends TestCase
 
     protected function tearDownTestProject()
     {
-        $projectDir = self::projectDir();
-        if (self::$fs->exists($projectDir)) {
-            self::$fs->remove($projectDir);
+        $projectDir = static::projectDir();
+        if (static::$fs->exists($projectDir)) {
+            static::$fs->remove($projectDir);
         }
     }
 
@@ -65,8 +65,8 @@ class FunctionalTestCase extends TestCase
      */
     protected function executeSculpin($command)
     {
-        $binPath = __DIR__ . '/../../../../bin';
-        $projectDir = self::projectDir();
+        $binPath    = __DIR__ . '/../../../../bin';
+        $projectDir = static::projectDir();
         exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
     }
 
@@ -84,7 +84,7 @@ class FunctionalTestCase extends TestCase
     protected function executeSculpinAsync($command, $start = true, callable $callback = null)
     {
         $binPath    = __DIR__ . '/../../../../bin';
-        $projectDir = self::projectDir();
+        $projectDir = static::projectDir();
         $process    = new Process("$binPath/sculpin $command --project-dir $projectDir --env=test");
 
         if ($start) {
@@ -104,18 +104,18 @@ class FunctionalTestCase extends TestCase
         // Remove leading slash
         array_shift($pathParts);
 
-        $projectDir = self::projectDir();
+        $projectDir = static::projectDir();
 
         if (!$recursive) {
-            self::$fs->mkdir("$projectDir/$path");
+            static::$fs->mkdir("$projectDir/$path");
             return;
         }
 
         $currPath = "$projectDir/";
         foreach ($pathParts as $dir) {
             $currPath .= "$dir/";
-            if (!self::$fs->exists($currPath)) {
-                self::$fs->mkdir($currPath);
+            if (!static::$fs->exists($currPath)) {
+                static::$fs->mkdir($currPath);
             }
         }
     }
@@ -140,7 +140,7 @@ class FunctionalTestCase extends TestCase
         }
 
         // Create the file
-        self::$fs->touch(self::projectDir() . $filePath);
+        static::$fs->touch(static::projectDir() . $filePath);
 
         // Add content to the file
         if (!is_null($content)) {
@@ -154,7 +154,7 @@ class FunctionalTestCase extends TestCase
      */
     protected function copyFixtureToProject($fixturePath, $projectPath)
     {
-        self::$fs->copy($fixturePath, self::projectDir() . $projectPath);
+        static::$fs->copy($fixturePath, static::projectDir() . $projectPath);
     }
 
     /**
@@ -165,7 +165,7 @@ class FunctionalTestCase extends TestCase
     {
         $msg = $msg ?: "Expected project to contain file at path $filePath.";
 
-        $this->assertTrue(self::$fs->exists(self::projectDir() . $filePath), $msg);
+        $this->assertTrue(static::$fs->exists(static::projectDir() . $filePath), $msg);
     }
 
     /**
@@ -186,7 +186,7 @@ class FunctionalTestCase extends TestCase
      */
     protected function writeToProjectFile($filePath, $content)
     {
-        self::$fs->dumpFile(self::projectDir() . $filePath, $content);
+        static::$fs->dumpFile(static::projectDir() . $filePath, $content);
     }
 
     /**
@@ -204,7 +204,7 @@ class FunctionalTestCase extends TestCase
      */
     protected function crawlProjectFile($filePath)
     {
-        return $this->crawlFile(self::projectDir() . $filePath);
+        return $this->crawlFile(static::projectDir() . $filePath);
     }
 
     /**
@@ -224,7 +224,7 @@ class FunctionalTestCase extends TestCase
      */
     private function readFile($filePath)
     {
-        if (!self::$fs->exists($filePath)) {
+        if (!static::$fs->exists($filePath)) {
             throw new \PHPUnit\Framework\Exception("Unable to read file at path $filePath: file does not exist");
         }
 
@@ -241,6 +241,6 @@ class FunctionalTestCase extends TestCase
      */
     protected static function projectDir()
     {
-        return __DIR__ . self::PROJECT_DIR;
+        return __DIR__ . static::PROJECT_DIR;
     }
 }

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -87,20 +87,25 @@ class InitCommandTest extends FunctionalTestCase
     protected function assertProjectInitialized($projectDir): void
     {
         $files = $this->finder->in($projectDir);
-        $this->assertSame(
-            [
-                $projectDir . '/app',
-                $projectDir . '/app/config',
-                $projectDir . '/app/config/sculpin_site.yml',
-                $projectDir . '/app/config/sculpin_kernel.yml',
-                $projectDir . '/app/SculpinKernel.php',
-                $projectDir . '/source',
-                $projectDir . '/source/_views',
-                $projectDir . '/source/_views/default.html',
-                $projectDir . '/source/index.md',
-            ],
-            array_keys(iterator_to_array($files))
-        );
+
+        $expected = [
+            $projectDir . '/app',
+            $projectDir . '/app/config',
+            $projectDir . '/app/config/sculpin_site.yml',
+            $projectDir . '/app/config/sculpin_kernel.yml',
+            $projectDir . '/app/SculpinKernel.php',
+            $projectDir . '/source',
+            $projectDir . '/source/_views',
+            $projectDir . '/source/_views/default.html',
+            $projectDir . '/source/index.md',
+        ];
+
+        $actual = array_keys(iterator_to_array($files));
+
+        natsort($expected);
+        natsort($actual);
+
+        $this->assertSame($expected, $actual);
     }
 
     protected function assertYamlFileEqualsArray(array $expected, string $file): void

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sculpin\Tests\Functional;
+
+use Sculpin\Bundle\SculpinBundle\Command\InitCommand;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+
+class InitCommandTest extends FunctionalTestCase
+{
+    protected const PROJECT_DIR = '/__BlankSculpinProject__';
+
+    /** @var Finder */
+    protected $finder;
+
+    public function setUp()
+    {
+        $this->tearDownTestProject();
+        $this->addProjectDirectory('', $recursive = false);
+        $this->finder = new Finder();
+    }
+
+    /** @test */
+    public function shouldInitSpecifiedOutputDir(): void
+    {
+        $projectDir = static::projectDir();
+        $this->assertProjectEmpty($projectDir);
+
+        $this->executeSculpin('init');
+
+        $this->assertProjectInitialized($projectDir);
+
+        $this->assertYamlFileEqualsArray(
+            ['sculpin_content_types' => ['posts' => ['enabled' => false]]],
+            $projectDir . '/app/config/sculpin_kernel.yml'
+        );
+
+        $this->assertYamlFileEqualsArray(
+            [
+                'title'                        => InitCommand::DEFAULT_TITLE,
+                'subtitle'                     => InitCommand::DEFAULT_SUBTITLE,
+                'google_analytics_tracking_id' => '',
+                'url'                          => '',
+            ],
+            $projectDir . '/app/config/sculpin_site.yml'
+        );
+    }
+
+    /** @test */
+    public function shouldInitWithSpecifiedParameters(): void
+    {
+        $projectDir = static::projectDir();
+        $this->assertProjectEmpty($projectDir);
+
+        $this->executeSculpin('init -t "My Custom Title" -s "Custom Subtitle"');
+
+        $this->assertProjectInitialized($projectDir);
+
+        $this->assertYamlFileEqualsArray(
+            ['sculpin_content_types' => ['posts' => ['enabled' => false]]],
+            $projectDir . '/app/config/sculpin_kernel.yml'
+        );
+
+        $this->assertYamlFileEqualsArray(
+            [
+                'title'                        => 'My Custom Title',
+                'subtitle'                     => 'Custom Subtitle',
+                'google_analytics_tracking_id' => '',
+                'url'                          => '',
+            ],
+            $projectDir . '/app/config/sculpin_site.yml'
+        );
+    }
+
+    protected function assertProjectEmpty($projectDir): void
+    {
+        $files = $this->finder->in($projectDir);
+        $this->assertSame(
+            [],
+            array_keys(iterator_to_array($files)),
+            'Expected project dir to be empty'
+        );
+    }
+
+    protected function assertProjectInitialized($projectDir): void
+    {
+        $files = $this->finder->in($projectDir);
+        $this->assertSame(
+            [
+                $projectDir . '/app',
+                $projectDir . '/app/config',
+                $projectDir . '/app/config/sculpin_site.yml',
+                $projectDir . '/app/config/sculpin_kernel.yml',
+                $projectDir . '/app/SculpinKernel.php',
+                $projectDir . '/source',
+                $projectDir . '/source/_views',
+                $projectDir . '/source/_views/default.html',
+                $projectDir . '/source/index.md',
+            ],
+            array_keys(iterator_to_array($files))
+        );
+    }
+
+    protected function assertYamlFileEqualsArray(array $expected, string $file): void
+    {
+        $this->assertSame($expected, Yaml::parseFile($file));
+    }
+}

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -102,8 +102,8 @@ class InitCommandTest extends FunctionalTestCase
 
         $actual = array_keys(iterator_to_array($files));
 
-        natsort($expected);
-        natsort($actual);
+        sort($expected);
+        sort($actual);
 
         $this->assertSame($expected, $actual);
     }

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -15,7 +15,7 @@ class InitCommandTest extends FunctionalTestCase
     /** @var Finder */
     protected $finder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tearDownTestProject();
         $this->addProjectDirectory('', $recursive = false);


### PR DESCRIPTION
This new command (`sculpin init`) will prep a very bare-bones set of files in order to get people up and running faster.

The files it creates are:

```
app/SculpinKernel.php
app/config/sculpin_kernel.php
app/config/sculpin_site.php
source/index.md
source/_views/default.html
```

It will ensure the `app` and `source` directories do not exist before it tries to create them.

There is a lot of room for improvement, from adding parameters to pre-fill information all the way up to creating an interactive menu for choosing whether the site should be a Company site, a Blog, or a Portfolio. That will hopefully be possible in the future.