### PR TITLE
Add an option to specify a different `source` directory.

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -61,6 +61,7 @@ class GenerateCommand extends AbstractCommand
                 new InputOption('url', null, InputOption::VALUE_REQUIRED, 'Override URL.'),
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Port'),
                 new InputOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output Directory'),
+                new InputOption('source-dir', null, InputOption::VALUE_REQUIRED, 'Source Directory'),
             ])
             ->setHelp(<<<EOT
 The <info>generate</info> command generates a site.

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DirectoryOverridePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DirectoryOverridePass.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Directory Override pass
+ */
+class DirectoryOverridePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (true === $container->hasParameter('sculpin.source_dir_override')) {
+            $override = $container->getParameter('sculpin.source_dir_override');
+
+            if ($override) {
+                $container->setParameter(
+                    'sculpin.source_dir',
+                    '%sculpin.project_dir%/%sculpin.source_dir_override%'
+                );
+            }
+        }
+
+        if (true === $container->hasParameter('sculpin.output_dir_override')) {
+            $override = $container->getParameter('sculpin.output_dir_override');
+
+            if ($override) {
+                $container->setParameter(
+                    'sculpin.output_dir',
+                    '%sculpin.project_dir%/%sculpin.output_dir_override%'
+                );
+            }
+        }
+    }
+}

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -36,20 +36,12 @@ abstract class AbstractKernel extends Kernel
      */
     public function __construct(string $environment, bool $debug, array $overrides = [])
     {
-        $projectDir = $overrides['projectDir'] ?? null;
-        if (null !== $projectDir) {
-            $this->projectDir = $projectDir;
-            $this->rootDir    = $projectDir . '/app';
-        }
+        $this->projectDir = $overrides['projectDir'] ?? null;
+        $this->outputDir  = $overrides['outputDir']  ?? null;
+        $this->sourceDir  = $overrides['sourceDir']  ?? null;
 
-        $outputDir = $overrides['outputDir'] ?? null;
-        if (null !== $outputDir) {
-            $this->outputDir = $outputDir;
-        }
-
-        $sourceDir = $overrides['sourceDir'] ?? null;
-        if (null !== $sourceDir) {
-            $this->sourceDir = $sourceDir;
+        if (null !== $this->projectDir) {
+            $this->rootDir = $this->projectDir . '/app';
         }
 
         parent::__construct($environment, $debug);

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -26,14 +26,15 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 abstract class AbstractKernel extends Kernel
 {
-    protected $projectDir;
-    protected $outputDir;
     protected $missingSculpinBundles = [];
+    protected $outputDir;
+    protected $projectDir;
+    protected $sourceDir;
 
     /**
      * {@inheritdoc}
      */
-    public function __construct(string $environment, bool $debug, ?array $overrides = [])
+    public function __construct(string $environment, bool $debug, array $overrides = [])
     {
         $projectDir = $overrides['projectDir'] ?? null;
         if (null !== $projectDir) {
@@ -44,6 +45,11 @@ abstract class AbstractKernel extends Kernel
         $outputDir = $overrides['outputDir'] ?? null;
         if (null !== $outputDir) {
             $this->outputDir = $outputDir;
+        }
+
+        $sourceDir = $overrides['sourceDir'] ?? null;
+        if (null !== $sourceDir) {
+            $this->sourceDir = $sourceDir;
         }
 
         parent::__construct($environment, $debug);
@@ -61,6 +67,7 @@ abstract class AbstractKernel extends Kernel
         return array_merge(parent::getKernelParameters(), [
             'sculpin.project_dir'         => $this->projectDir,
             'sculpin.output_dir_override' => $this->outputDir,
+            'sculpin.source_dir_override' => $this->sourceDir,
         ]);
     }
 

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
@@ -40,6 +40,7 @@ class KernelFactory
         );
 
         $outputDir = $input->getParameterOption(['--output-dir'], getenv('SCULPIN_OUTPUT_DIR') ?: null);
+        $sourceDir = $input->getParameterOption(['--source-dir'], getenv('SCULPIN_SOURCE_DIR') ?: null);
 
         // do something here to locate and try to create
         // a custom kernel.
@@ -51,6 +52,7 @@ class KernelFactory
         $overrides = [
             'projectDir' => $projectDir,
             'outputDir'  => $outputDir,
+            'sourceDir'  => $sourceDir,
         ];
 
         if (file_exists($customKernel = $projectDir.'/app/SculpinKernel.php')) {

--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -20,6 +20,7 @@ use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\FormatterManagerPa
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\GeneratorManagerPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\PathConfiguratorPass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\CustomMimeTypesRepositoryPass;
+use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\DirectoryOverridePass;
 use Sculpin\Bundle\SculpinBundle\DependencyInjection\Compiler\WriterPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
@@ -46,5 +47,6 @@ class SculpinBundle extends Bundle
         $container->addCompilerPass(new DataSourcePass);
         $container->addCompilerPass(new WriterPass);
         $container->addCompilerPass(new AddConsoleCommandPass);
+        $container->addCompilerPass(new DirectoryOverridePass);
     }
 }

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -169,6 +169,17 @@ class FunctionalTestCase extends TestCase
     }
 
     /**
+     * @param string        $filePath
+     * @param string|null   $msg
+     */
+    protected function assertProjectLacksFile(string $filePath, ?string $msg = null): void
+    {
+        $msg = $msg ?: "Expected project to NOT contain file at path $filePath.";
+
+        $this->assertFalse(static::$fs->exists(static::projectDir() . $filePath), $msg);
+    }
+
+    /**
      * @param string $filePath
      * @param string|null $msg
      */

--- a/src/Sculpin/Tests/Functional/GenerateCommandTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateCommandTest.php
@@ -20,4 +20,27 @@ class GenerateCommandTest extends FunctionalTestCase
 
         $this->assertProjectHasFile($filePath, $msg);
     }
+
+    /** @test */
+    public function shouldGenerateUsingSpecifiedSourceDir(): void
+    {
+        $filePath  = '/output_test/index.html';
+        $sourceDir = 'custom_source_dir';
+
+        $this->assertProjectLacksFile($filePath, "Expected project to NOT have generated file at path $filePath.");
+
+        // set up test scenario
+        static::$fs->rename(
+            $this->projectDir() . '/source',
+            $this->projectDir() . '/' . $sourceDir
+        );
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/blog_index.html', '/'. $sourceDir .'/index.html');
+        $this->addProjectDirectory('/' . $sourceDir . '/_posts');
+
+        // generate the site
+        $this->executeSculpin('generate --source-dir=' . $sourceDir);
+
+        // check that it worked
+        $this->assertProjectHasFile($filePath, "Expected project to have generated file at path $filePath.");
+    }
 }


### PR DESCRIPTION
One of the goals for Sculpin 3.0 is to have not just an `--output-dir` option, but also a `--source-dir` option. This PR attempts to deliver on that, and it also attempts to fix a potential issue with `--output-dir` as it relates to sculpin extensions like *icelus* (which in my testing was continuing to write to `output_dev/` - not desirable).

This adds a `DirectoryOverridePass` compiler pass to update the existing container parameters with the newly-overridden values.