### PR TITLE
Add travis support for OS X tests and PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: php
 
-os:
-- windows
-- linux
-- osx
-
-dist: trusty
 sudo: false
 
 cache:
   directories:
     - $HOME/.composer/cache
+
+addons:
+  homebrew:
+    packages:
+    - php
+    - composer
 
 matrix:
   allow_failures:
@@ -44,7 +44,6 @@ matrix:
         - TEST_COVERAGE=false
         - CHECK_PHPSTAN=false
     - os: osx
-      php: 7.2
       env:
         - DEPS=latest
         - CHECK_CS=false
@@ -53,7 +52,7 @@ matrix:
 
 before_install:
   - travis_retry composer self-update
-  - phpenv config-rm xdebug.ini || true
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then phpenv config-rm xdebug.ini || true; fi
 
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update --no-interaction ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: php
 
+os:
+- windows
+- linux
+- osx
+
 dist: trusty
 sudo: false
 
@@ -8,19 +13,43 @@ cache:
     - $HOME/.composer/cache
 
 matrix:
+  allow_failures:
+    - os:
+      - osx
+      - windows
   include:
-    - php: 7.2
+    - os: linux
+      dist: trusty
+      php: 7.2
       env:
         - DEPS=lowest
-    - php: 7.2
+    - os: linux
+      dist: trusty
+      php: 7.2
       env:
         - DEPS=locked
         - CHECK_CS=true
         - TEST_COVERAGE=true
         - CHECK_PHPSTAN=true
-    - php: 7.2
+    - os: linux
+      dist: trusty
+      php: 7.2
       env:
         - DEPS=latest
+    - os: windows
+      php: 7.2
+      env:
+        - DEPS=latest
+        - CHECK_CS=false
+        - TEST_COVERAGE=false
+        - CHECK_PHPSTAN=false
+    - os: osx
+      php: 7.2
+      env:
+        - DEPS=latest
+        - CHECK_CS=false
+        - TEST_COVERAGE=false
+        - CHECK_PHPSTAN=false
 
 before_install:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ matrix:
       php: 7.2
       env:
         - DEPS=latest
+    - os: linux
+      dist: trusty
+      language: php
+      php: 7.3
+      env:
+        - DEPS=latest
     - os: windows
       language: bash
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ addons:
     - composer
 
 matrix:
+  allow_failures:
+    - os: windows
+      language: bash
   include:
     - os: linux
       dist: trusty
@@ -32,6 +35,7 @@ matrix:
       env:
         - DEPS=latest
     - os: windows
+      language: bash
       env:
         - DEPS=locked
         - CHECK_CS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-language: php
-
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -13,10 +9,6 @@ addons:
     - composer
 
 matrix:
-  allow_failures:
-    - os:
-      - osx
-      - windows
   include:
     - os: linux
       dist: trusty
@@ -37,15 +29,14 @@ matrix:
       env:
         - DEPS=latest
     - os: windows
-      php: 7.2
       env:
-        - DEPS=latest
+        - DEPS=locked
         - CHECK_CS=false
         - TEST_COVERAGE=false
         - CHECK_PHPSTAN=false
     - os: osx
       env:
-        - DEPS=latest
+        - DEPS=locked
         - CHECK_CS=false
         - TEST_COVERAGE=false
         - CHECK_PHPSTAN=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,13 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      language: php
       php: 7.2
       env:
         - DEPS=lowest
     - os: linux
       dist: trusty
+      language: php
       php: 7.2
       env:
         - DEPS=locked
@@ -25,6 +27,7 @@ matrix:
         - CHECK_PHPSTAN=true
     - os: linux
       dist: trusty
+      language: php
       php: 7.2
       env:
         - DEPS=latest


### PR DESCRIPTION
Travis now has experimental support for testing under OS X (and Windows, but that doesn't seem to play nicely with PHP yet). Maybe it will help Sculpin to try and test under these common user envs.

Technically their Windows support doesn't include PHP, and their OS X support may not support it either. Let's find out. (Update: discovered that yes, OS X can be done, but Windows is still difficult.)