### PR TITLE
Add :folder permalink property

### DIFF
--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -135,6 +135,27 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
                 $permalink = preg_replace('/:basename_real/', $basename, $permalink);
                 $permalink = preg_replace('/:basename/', $prettyBasename, $permalink);
 
+                $folder = '';
+                // Find FIRST position here
+                $folderPos = strpos($pathname, DIRECTORY_SEPARATOR);
+                if ($folderPos !== false) {
+                    $folderTemp = $pathname;
+
+                    // Strip the first folder if it's a type folder
+                    if ('_' === substr($pathname, 0, 1)) {
+                        $folderTemp = substr($pathname, $folderPos+1);
+                    }
+
+                    // Now check for actual subfolders we are interested in here
+                    // Find LAST position here
+                    $lastFolderPos = strrpos($folderTemp, DIRECTORY_SEPARATOR);
+
+                    if ($lastFolderPos !== false) {
+                        $folder = substr($folderTemp, 0, $lastFolderPos) . '/';
+                    }
+                }
+                $permalink = preg_replace('/:folder/', $folder, $permalink);
+
                 if (preg_match('#(^|[\\/])[^.]+$#', $permalink)
                     // Exclude .md and .twig for BC
                     || substr($permalink, -3, 3) === '.md'

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -160,6 +160,42 @@ class SourcePermalinkFactoryTest extends TestCase
                     '/about/'
                 ),
             ],
+
+            'Folder with basename, no type' => [
+                ':folder:basename.html',
+                static::makeTestSource('site/about.md'),
+                new Permalink(
+                    'site/about.html',
+                    '/site/about.html'
+                ),
+            ],
+
+            'Folder with basename, no folder, no type' => [
+                ':folder:basename.html',
+                static::makeTestSource('about.md'),
+                new Permalink(
+                    'about.html',
+                    '/about.html'
+                ),
+            ],
+
+            'Folder with basename, with type, no folder' => [
+                'posts/:folder:basename.html',
+                static::makeTestSource('_posts/somepost.md'),
+                new Permalink(
+                    'posts/somepost.html',
+                    '/posts/somepost.html'
+                ),
+            ],
+
+            'Folder with basename, with type' => [
+                'posts/:folder:basename.html',
+                static::makeTestSource('_posts/somefolder/somepost.md'),
+                new Permalink(
+                    'posts/somefolder/somepost.html',
+                    '/posts/somefolder/somepost.html'
+                ),
+            ],
         ];
     }
 


### PR DESCRIPTION
Allows for permalinks to include the folders. Example would be a file in _posts/something/other.md could then have a permalink setting of /posts/:folder:basename.html and result in /posts/something/other.html as output, while _posts/a-post.md would still output /posts/a-post.html as well.

Will create a PR for the docs as well.