### PR TITLE
Fail on twig errors

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -54,27 +54,22 @@ class TwigFormatter implements FormatterInterface
      */
     public function formatBlocks(FormatContext $formatContext): array
     {
-        try {
-            $this->arrayLoader->setTemplate(
-                $formatContext->templateId(),
-                $this->massageTemplate($formatContext)
-            );
-            $data = $formatContext->data()->export();
-            $template = $this->twig->loadTemplate($formatContext->templateId());
+        $this->arrayLoader->setTemplate(
+            $formatContext->templateId(),
+            $this->massageTemplate($formatContext)
+        );
+        $data = $formatContext->data()->export();
+        $template = $this->twig->resolveTemplate($formatContext->templateId());
 
-            if (!count($blockNames = $this->findAllBlocks($template, $data))) {
-                return ['content' => $template->render($data)];
-            }
-            $blocks = [];
-            foreach ($blockNames as $blockName) {
-                $blocks[$blockName] = $template->renderBlock($blockName, $data);
-            }
-
-            return $blocks;
-        } catch (\Exception $e) {
-            print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
-            return [];
+        if (!count($blockNames = $this->findAllBlocks($template, $data))) {
+            return ['content' => $template->render($data)];
         }
+        $blocks = [];
+        foreach ($blockNames as $blockName) {
+            $blocks[$blockName] = $template->renderBlock($blockName, $data);
+        }
+
+        return $blocks;
     }
 
     public function findAllBlocks(\Twig_Template $template, array $context): array
@@ -87,19 +82,14 @@ class TwigFormatter implements FormatterInterface
      */
     public function formatPage(FormatContext $formatContext): string
     {
-        try {
-            $this->arrayLoader->setTemplate(
-                $formatContext->templateId(),
-                $this->massageTemplate($formatContext)
-            );
+        $this->arrayLoader->setTemplate(
+            $formatContext->templateId(),
+            $this->massageTemplate($formatContext)
+        );
 
-            $data = $formatContext->data()->export();
+        $data = $formatContext->data()->export();
 
-            return $this->twig->render($formatContext->templateId(), $data);
-        } catch (\Exception $e) {
-            print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
-            return '';
-        }
+        return $this->twig->render($formatContext->templateId(), $data);
     }
 
     /**

--- a/src/Sculpin/Tests/Functional/Fixture/source/blog_index.html
+++ b/src/Sculpin/Tests/Functional/Fixture/source/blog_index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: raw
 title: Home
 generator: pagination
 pagination:


### PR DESCRIPTION
Fixes #384
The generation will now stop on these errors, exiting with a non 0 exit value to make sure the error is noticed and fixed.
Found out some tests that were testing something were not really testing much, as they just checked for an existing file, but it has been just empty this whole time.

The reported case would stop execution and show an error like this:
Formatting: 
In test.html.twig line 4:
Unexpected "endmacro" tag (expecting closing tag for the "if" tag defined near line 3).  