### PR TITLE
adjust for textile 3.6

### DIFF
--- a/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
+++ b/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
@@ -59,7 +59,7 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
      */
     public function convert(ConverterContextInterface $converterContext): void
     {
-        $converterContext->setContent($this->parser->textileThis($converterContext->content()));
+        $converterContext->setContent($this->parser->parse($converterContext->content()));
     }
 
     /**


### PR DESCRIPTION
the `textileThis` method has been renamed to `parse` and textileThis is deprecated.