### PR TITLE
closing classes from accidental extension and symfony best practices

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
@@ -21,12 +21,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Content Type Creation Command.
+ * Helper command to create a new content type.
  *
  * Outputs the YAML required to add a new content type, and optionally
  * generates the associated boilerplate for the type.
  */
-class ContentCreateCommand extends AbstractCommand
+final class ContentCreateCommand extends AbstractCommand
 {
     private const DIRECTORY_FLAG = '_directory_';
 
@@ -109,7 +109,7 @@ EOT
         }
     }
 
-    protected function generateBoilerplateManifest(string $plural, string $singular, array $taxonomies = []): array
+    private function generateBoilerplateManifest(string $plural, string $singular, array $taxonomies = []): array
     {
         $app = $this->getApplication();
         if (!$app instanceof Application) {
@@ -133,13 +133,13 @@ EOT
 
         // content type view template
         $index            = $rootDir . '/source/_views/' . $singular . '.html';
-        $manifest[$index] = $this->getViewTemplate($plural, $singular, $taxonomies);
+        $manifest[$index] = $this->getViewTemplate($plural, $taxonomies);
 
         foreach ($taxonomies as $taxonomy) {
             $singularTaxonomy = Inflector::singularize($taxonomy);
             // content taxonomy index template
             $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '.html';
-            $manifest[$index] = $this->getTaxonomyIndexTemplate($plural, $singular, $taxonomy, $singularTaxonomy);
+            $manifest[$index] = $this->getTaxonomyIndexTemplate($plural, $taxonomy, $singularTaxonomy);
 
             // content taxonomy directory
             $storageFolder            = $rootDir . '/source/' . $plural . '/' . $taxonomy;
@@ -147,13 +147,13 @@ EOT
 
             // content taxonomy view template(s)
             $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '/' . $singularTaxonomy . '.html';
-            $manifest[$index] = $this->getTaxonomyViewTemplate($plural, $singular, $taxonomy, $singularTaxonomy);
+            $manifest[$index] = $this->getTaxonomyViewTemplate($plural, $singular, $singularTaxonomy);
         }
 
         return $manifest;
     }
 
-    protected function getOutputMessage(string $type, string $singularType, array $taxonomies = []): string
+    private function getOutputMessage(string $type, string $singularType, array $taxonomies = []): string
     {
         $outputMessage = <<<EOT
 =============================================
@@ -181,7 +181,7 @@ EOT;
         return $outputMessage;
     }
 
-    protected function getIndexTemplate(string $plural, string $singular)
+    private function getIndexTemplate(string $plural, string $singular)
     {
         $title = ucfirst($plural);
 
@@ -214,7 +214,7 @@ use: [$plural]
 EOT;
     }
 
-    protected function getViewTemplate(string $plural, string $singular, array $taxonomies = []): string
+    private function getViewTemplate(string $plural, array $taxonomies = []): string
     {
         $output = <<<EOT
 {% extends 'default' %}
@@ -264,9 +264,8 @@ EOT;
         return $output;
     }
 
-    protected function getTaxonomyIndexTemplate(
+    private function getTaxonomyIndexTemplate(
         string $plural,
-        string $singular,
         string $taxonomy,
         string $singularTaxonomy
     ): string {
@@ -287,10 +286,9 @@ use: [${plural}_${taxonomy}]
 EOT;
     }
 
-    protected function getTaxonomyViewTemplate(
+    private function getTaxonomyViewTemplate(
         string $plural,
         string $singular,
-        string $taxonomy,
         string $singularTaxonomy
     ): string {
         $title = ucfirst($plural);

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
@@ -22,8 +22,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Content Types Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinContentTypesExtension extends Extension

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sculpin\Bundle\MarkdownBundle\DependencyInjection;
 
+use Sculpin\Bundle\MarkdownBundle\PhpMarkdownExtraParser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface
@@ -35,9 +34,11 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('parser_class')
-                    ->defaultValue('Sculpin\Bundle\MarkdownBundle\PhpMarkdownExtraParser')
+                    ->info('The markdown parser to use - must be a class without any constructor arguments')
+                    ->defaultValue(PhpMarkdownExtraParser::class)
                 ->end()
                 ->arrayNode('extensions')
+                    ->info('File name extensions to handle as markdown')
                     ->defaultValue(['md', 'mdown', 'mkdn', 'markdown'])
                     ->prototype('scalar')->end()
                 ->end()

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/SculpinMarkdownExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Markdown Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinMarkdownExtension extends Extension

--- a/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/MarkdownConverter.php
@@ -23,31 +23,29 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Michelf\Markdown;
 
 /**
- * Markdown Converter.
+ * Convert Markdown content with michelf/php-markdown.
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
+final class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
 {
     /**
-     * Markdown
-     *
      * @var ParserInterface
      */
-    protected $markdown;
+    private $markdown;
 
     /**
-     * Extensions
+     * File name extensions that are handled as markdown.
      *
-     * @var array
+     * @var string[]
      */
-    protected $extensions = [];
+    private $extensions = [];
 
     /**
      * Constructor.
      *
      * @param ParserInterface $markdown
-     * @param array           $extensions Extensions
+     * @param string[]        $extensions file name extensions that are handled as markdown
      */
     public function __construct(ParserInterface $markdown, array $extensions = [])
     {
@@ -77,9 +75,9 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
     }
 
     /**
-     * Before run
+     * Event hook to register this converter for all sources that have markdown file extensions.
      *
-     * @param SourceSetEvent $sourceSetEvent Source Set Event
+     * @internal
      */
     public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {
@@ -98,8 +96,9 @@ class MarkdownConverter implements ConverterInterface, EventSubscriberInterface
     /**
      * This method is called to generate an id="" attribute for a header.
      *
+     * @internal
+     *
      * @param string $headerText raw markdown input for the header name
-     * @return string
      */
     public function generateHeaderId(string $headerText): string
     {

--- a/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownExtraParser.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownExtraParser.php
@@ -8,7 +8,7 @@ use Michelf\MarkdownExtra;
 use Sculpin\Core\Converter\ParserInterface;
 
 /**
- * Class PhpMarkdownExtraParser
+ * Provide Michelf\MarkdownExtra as Sculpin parser.
  */
 class PhpMarkdownExtraParser extends MarkdownExtra implements ParserInterface
 {

--- a/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownParser.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/PhpMarkdownParser.php
@@ -8,7 +8,7 @@ use Michelf\Markdown;
 use Sculpin\Core\Converter\ParserInterface;
 
 /**
- * Class PhpMarkdownParser
+ * Provide Michelf\Markdown as Sculpin parser.
  */
 class PhpMarkdownParser extends Markdown implements ParserInterface
 {

--- a/src/Sculpin/Bundle/MarkdownBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/MarkdownBundle/Resources/config/services.xml
@@ -3,15 +3,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sculpin_markdown.converter.class">Sculpin\Bundle\MarkdownBundle\MarkdownConverter</parameter>
-    </parameters>
-
     <services>
 
         <service id="sculpin_markdown.parser" class="%sculpin_markdown.parser.class%" />
 
-        <service id="sculpin_markdown.converter" class="%sculpin_markdown.converter.class%" public="true">
+        <service id="sculpin_markdown.converter" class="Sculpin\Bundle\MarkdownBundle\MarkdownConverter" public="true">
             <argument type="service" id="sculpin_markdown.parser" />
             <tag name="sculpin.converter" alias="markdown" />
             <tag name="sculpin.custom_mime_extensions" type="text/markdown" parameter="sculpin_markdown.extensions" />

--- a/src/Sculpin/Bundle/MarkdownBundle/SculpinMarkdownBundle.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/SculpinMarkdownBundle.php
@@ -16,8 +16,6 @@ namespace Sculpin\Bundle\MarkdownBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Markdown Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinMarkdownBundle extends Bundle

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/ConvertListener.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/ConvertListener.php
@@ -20,18 +20,18 @@ use Sculpin\Core\Sculpin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Sculpin Markdown/Twig Compatibility Bundle.
+ * Hide some twig instructions from markdown parser.
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class ConvertListener implements EventSubscriberInterface
+final class ConvertListener implements EventSubscriberInterface
 {
     /**
      * List of regular expressions needing placeholders
      *
      * @var array
      */
-    protected static $addPlaceholderRe = [
+    private static $addPlaceholderRe = [
         '/^({%\s+block\s+(\w+).+?%})$/m',  // {% %} style code
         '/^({%\s+endblock\s+%})$/m',       // {% %} style code
         '/^({{.+?}})$/m',                  // {{ }} style code
@@ -42,14 +42,14 @@ class ConvertListener implements EventSubscriberInterface
      *
      * @var string
      */
-    protected static $placeholder = "\n<div><!-- sculpin-hidden -->$1<!-- /sculpin-hidden --></div>\n";
+    private static $placeholder = "\n<div><!-- sculpin-hidden -->$1<!-- /sculpin-hidden --></div>\n";
 
     /**
      * Regex used to remove placeholder
      *
      * @var string
      */
-    protected static $removePlaceholderRe = "/(\n?<div><!-- sculpin-hidden -->|<!-- \/sculpin-hidden --><\/div>\n|\n?&lt;div&gt;&lt;!-- sculpin-hidden --&gt;|&lt;!-- \/sculpin-hidden --&gt;&lt;\/div&gt;\n)/m"; // @codingStandardsIgnoreLine
+    private static $removePlaceholderRe = "/(\n?<div><!-- sculpin-hidden -->|<!-- \/sculpin-hidden --><\/div>\n|\n?&lt;div&gt;&lt;!-- sculpin-hidden --&gt;|&lt;!-- \/sculpin-hidden --&gt;&lt;\/div&gt;\n)/m"; // @codingStandardsIgnoreLine
 
     /**
      * {@inheritdoc}
@@ -64,8 +64,6 @@ class ConvertListener implements EventSubscriberInterface
 
     /**
      * Called before conversion
-     *
-     * @param ConvertEvent $convertEvent Convert Event
      */
     public function beforeConvert(ConvertEvent $convertEvent): void
     {
@@ -85,8 +83,6 @@ class ConvertListener implements EventSubscriberInterface
 
     /**
      * Called after conversion
-     *
-     * @param ConvertEvent $convertEvent Convert event
      */
     public function afterConvert(ConvertEvent $convertEvent): void
     {

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/Resources/config/services.xml
@@ -3,13 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sculpin_markdown_twig_compat.convert_listener.class">Sculpin\Bundle\MarkdownTwigCompatBundle\ConvertListener</parameter>
-    </parameters>
-
     <services>
 
-        <service id="sculpin_markdown_twig_compat.converter_listener" class="%sculpin_markdown_twig_compat.convert_listener.class%" public="true">
+        <service id="sculpin_markdown_twig_compat.converter_listener" class="Sculpin\Bundle\MarkdownTwigCompatBundle\ConvertListener" public="true">
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/src/Sculpin/Bundle/MarkdownTwigCompatBundle/SculpinMarkdownTwigCompatBundle.php
+++ b/src/Sculpin/Bundle/MarkdownTwigCompatBundle/SculpinMarkdownTwigCompatBundle.php
@@ -16,8 +16,6 @@ namespace Sculpin\Bundle\MarkdownTwigCompatBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Markdown/Twig Compatibility Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinMarkdownTwigCompatBundle extends Bundle

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/SculpinPaginationExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Pagination Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinPaginationExtension extends Extension

--- a/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
+++ b/src/Sculpin/Bundle/PaginationBundle/PaginationGenerator.php
@@ -23,36 +23,25 @@ use Sculpin\Core\Permalink\SourcePermalinkFactory;
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class PaginationGenerator implements GeneratorInterface
+final class PaginationGenerator implements GeneratorInterface
 {
     /**
-     * Data Provider Manager
-     *
      * @var DataProviderManager
      */
-    protected $dataProviderManager;
+    private $dataProviderManager;
 
     /**
-     * Source permalink factory
-     *
      * @var SourcePermalinkFactory
      */
-    protected $permalinkFactory;
+    private $permalinkFactory;
 
     /**
      * Max per page (default)
      *
      * @var int
      */
-    protected $maxPerPage;
+    private $maxPerPage;
 
-    /**
-     * Constructor
-     *
-     * @param DataProviderManager    $dataProviderManager Data Provider Manager
-     * @param SourcePermalinkFactory $permalinkFactory    Factory for generating permalinks
-     * @param int                    $maxPerPage          Max items per page
-     */
     public function __construct(
         DataProviderManager $dataProviderManager,
         SourcePermalinkFactory $permalinkFactory,

--- a/src/Sculpin/Bundle/PaginationBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/PaginationBundle/Resources/config/services.xml
@@ -3,13 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sculpin_pagination.generator.class">Sculpin\Bundle\PaginationBundle\PaginationGenerator</parameter>
-    </parameters>
-
     <services>
 
-        <service id="sculpin_pagination.generator" class="%sculpin_pagination.generator.class%">
+        <service id="sculpin_pagination.generator" class="Sculpin\Bundle\PaginationBundle\PaginationGenerator">
             <argument type="service" id="sculpin.data_provider_manager" />
             <argument type="service" id="sculpin.source_permalink_factory" />
             <argument>%sculpin_pagination.max_per_page%</argument>

--- a/src/Sculpin/Bundle/PaginationBundle/SculpinPaginationBundle.php
+++ b/src/Sculpin/Bundle/PaginationBundle/SculpinPaginationBundle.php
@@ -16,8 +16,6 @@ namespace Sculpin\Bundle\PaginationBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Pagination Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinPaginationBundle extends Bundle

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/SculpinPostsExtension.php
@@ -18,8 +18,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
- * Sculpin Posts Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinPostsExtension extends Extension

--- a/src/Sculpin/Bundle/PostsBundle/SculpinPostsBundle.php
+++ b/src/Sculpin/Bundle/PostsBundle/SculpinPostsBundle.php
@@ -16,8 +16,6 @@ namespace Sculpin\Bundle\PostsBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Posts Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinPostsBundle extends Bundle

--- a/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/AbstractCommand.php
@@ -13,22 +13,19 @@ declare(strict_types=1);
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
+use Sculpin\Bundle\StandaloneBundle\SculpinStandaloneBundle;
 use Sculpin\Core\Console\Command\ContainerAwareCommand;
 
 /**
- * Generate Command.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 abstract class AbstractCommand extends ContainerAwareCommand
 {
     /**
      * Test to see if Sculpin is running in standalone mode.
-     *
-     * @return bool
      */
     protected function isStandaloneSculpin(): bool
     {
-        return class_exists('Sculpin\\Bundle\\StandaloneBundle\\SculpinStandaloneBundle', false);
+        return class_exists(SculpinStandaloneBundle::class, false);
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -3,29 +3,15 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the Symfony package.
+ * This file is a part of Sculpin.
  *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This command is derived from the Symfony container debug command,
  * (c) Fabien Potencier <fabien@symfony.com>
- *
- * Copyright (c) 2004-2014 Fabien Potencier
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
-
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
-
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
  */
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
@@ -45,7 +31,7 @@ use Symfony\Component\DependencyInjection\Definition;
  *
  * @author Ryan Weaver <ryan@thatsquality.com>
  */
-class ContainerDebugCommand extends ContainerAwareCommand
+final class ContainerDebugCommand extends ContainerAwareCommand
 {
     /**
      * {@inheritdoc}
@@ -179,7 +165,7 @@ EOF
         }
     }
 
-    protected function validateInput(InputInterface $input)
+    private function validateInput(InputInterface $input)
     {
         $options = ['tags', 'tag', 'parameters', 'parameter'];
 
@@ -202,7 +188,7 @@ EOF
         }
     }
 
-    protected function outputServices(
+    private function outputServices(
         OutputInterface $output,
         $serviceIds,
         $showPrivate = false,
@@ -322,7 +308,7 @@ EOF
         }
     }
 
-    protected function buildArgumentsArray($serviceId, $className, array $tagAttributes = []): array
+    private function buildArgumentsArray($serviceId, $className, array $tagAttributes = []): array
     {
         $arguments = [$serviceId];
         foreach ($tagAttributes as $tagAttribute) {
@@ -336,7 +322,7 @@ EOF
     /**
      * Renders detailed service information about one service
      */
-    protected function outputService(OutputInterface $output, string $serviceId)
+    private function outputService(OutputInterface $output, string $serviceId)
     {
         $definition = $this->resolveServiceDefinition($serviceId);
 
@@ -389,7 +375,7 @@ EOF
         }
     }
 
-    protected function outputParameters(OutputInterface $output, array $parameters): void
+    private function outputParameters(OutputInterface $output, array $parameters): void
     {
         $output->writeln($this->getHelper('formatter')->formatSection('container', 'List of parameters'));
 
@@ -439,7 +425,7 @@ EOF
      * @return Definition|Alias
      * @throws \Exception
      */
-    protected function resolveServiceDefinition($serviceId)
+    private function resolveServiceDefinition($serviceId)
     {
         $container = $this->getContainer();
         if ($container instanceof ContainerBuilder) {
@@ -465,7 +451,7 @@ EOF
      *
      * @throws \Exception
      */
-    protected function outputTags(OutputInterface $output, bool $showPrivate = false): void
+    private function outputTags(OutputInterface $output, bool $showPrivate = false): void
     {
         $container = $this->getContainer();
         if (! $container instanceof ContainerBuilder) {
@@ -504,7 +490,7 @@ EOF
         }
     }
 
-    protected function formatParameter($value)
+    private function formatParameter($value)
     {
         if (is_bool($value) || is_array($value) || (null === $value)) {
             return json_encode($value);

--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -20,6 +20,7 @@ use Sculpin\Core\Io\IoInterface;
 use Sculpin\Core\Sculpin;
 use Sculpin\Core\Source\DataSourceInterface;
 use Sculpin\Core\Source\SourceSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,7 +31,7 @@ use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 
 /**
- * Generate Command.
+ * Generate the site.
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
@@ -103,7 +104,7 @@ EOT
         $watch = $input->getOption('watch') ?: false;
         $sculpin = $this->getContainer()->get('sculpin');
         $dataSource = $this->getContainer()->get('sculpin.data_source');
-        $sourceSet = new SourceSet;
+        $sourceSet = new SourceSet();
 
         $config = $this->getContainer()->get('sculpin.site_configuration');
         if ($url = $input->getOption('url')) {
@@ -154,18 +155,16 @@ EOT
     /**
      * Cleanup an output directory by deleting it.
      *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
-     * @param string          $dir    The directory to remove
+     * @param string $dir The directory to remove
      */
-    protected function clean(InputInterface $input, OutputInterface $output, string $dir): void
+    private function clean(InputInterface $input, OutputInterface $output, string $dir): void
     {
         $fileSystem = $this->getContainer()->get('filesystem');
 
         if ($fileSystem->exists($dir)) {
             if ($input->isInteractive()) {
                 // Prompt the user for confirmation.
-                /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+                /** @var QuestionHelper $helper */
                 $helper = $this->getHelper('question');
                 $question = new ConfirmationQuestion(sprintf(
                     'Are you sure you want to delete all the contents of the %s directory?',

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -20,9 +20,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Init Command - Initialize default website configuration and structure.
+ * Initialize default website configuration and structure.
  */
-class InitCommand extends AbstractCommand
+final class InitCommand extends AbstractCommand
 {
     public const COMMAND_SUCCESS          = 0;
     public const PROJECT_FOLDER_NOT_EMPTY = 101;
@@ -108,7 +108,7 @@ EOT
         return self::COMMAND_SUCCESS;
     }
 
-    protected function ensureCleanSlate(string $projectDir, OutputInterface $output): bool
+    private function ensureCleanSlate(string $projectDir, OutputInterface $output): bool
     {
         $fs = new Filesystem();
         if ($fs->exists($projectDir . '/app')) {
@@ -126,7 +126,7 @@ EOT
         return true;
     }
 
-    protected function createDefaultKernel(string $projectDir, OutputInterface $output): bool
+    private function createDefaultKernel(string $projectDir, OutputInterface $output): bool
     {
         $contents = <<<EOF
 <?php
@@ -147,7 +147,7 @@ EOF;
         return true;
     }
 
-    protected function createSiteKernelFile(string $projectDir, OutputInterface $output): bool
+    private function createSiteKernelFile(string $projectDir, OutputInterface $output): bool
     {
         $contents = <<<EOF
 sculpin_content_types:
@@ -160,7 +160,7 @@ EOF;
         return true;
     }
 
-    protected function createSiteConfigFile(
+    private function createSiteConfigFile(
         string $projectDir,
         string $title,
         string $subTitle,
@@ -178,7 +178,7 @@ EOF;
         return true;
     }
 
-    protected function createSourceFolder(string $projectDir, OutputInterface $output): bool
+    private function createSourceFolder(string $projectDir, OutputInterface $output): bool
     {
         $fs = new Filesystem();
 
@@ -210,7 +210,7 @@ EOF
         return true;
     }
 
-    protected function createFile(string $path, string $contents): void
+    private function createFile(string $path, string $contents): void
     {
         $fs = new Filesystem();
         $fs->dumpFile($path, $contents);

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
@@ -19,8 +19,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Serve Command.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class ServeCommand extends AbstractCommand

--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -28,20 +28,20 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Application
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class Application extends BaseApplication
+final class Application extends BaseApplication
 {
-    protected $kernel;
-    private $registrationErrors = [];
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
 
     /**
-     * Constructor.
-     *
-     * @param KernelInterface           $kernel           A KernelInterface instance
+     * @var \Throwable[]
      */
+    private $registrationErrors = [];
+
     public function __construct(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
@@ -150,7 +150,7 @@ class Application extends BaseApplication
         return $this->kernel;
     }
 
-    protected function registerCommands(): void
+    private function registerCommands(): void
     {
         $this->kernel->boot();
 

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/ConverterManagerPass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Converter Manager pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class ConverterManagerPass implements CompilerPassInterface
+final class ConverterManagerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/CustomMimeTypesRepositoryPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/CustomMimeTypesRepositoryPass.php
@@ -17,11 +17,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Text Extension Provider pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class CustomMimeTypesRepositoryPass implements CompilerPassInterface
+final class CustomMimeTypesRepositoryPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataProviderManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataProviderManagerPass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Data Provider pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class DataProviderManagerPass implements CompilerPassInterface
+final class DataProviderManagerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DataSourcePass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Data Source pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class DataSourcePass implements CompilerPassInterface
+final class DataSourcePass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DirectoryOverridePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/DirectoryOverridePass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Directory Override pass
+ * @author Kevin Boyd
  */
 class DirectoryOverridePass implements CompilerPassInterface
 {

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/EventSubscriberOverridePass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/EventSubscriberOverridePass.php
@@ -17,9 +17,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Override default visibility of services tagged with kernel.event_subscriber
+ * Make sure that all services tagged with kernel.event_subscriber are public.
  */
-class EventSubscriberOverridePass implements CompilerPassInterface
+final class EventSubscriberOverridePass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/FormatterManagerPass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Formatter pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class FormatterManagerPass implements CompilerPassInterface
+final class FormatterManagerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/GeneratorManagerPass.php
@@ -18,11 +18,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Generator pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class GeneratorManagerPass implements CompilerPassInterface
+final class GeneratorManagerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/WriterPass.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Compiler/WriterPass.php
@@ -17,11 +17,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
- * Writer pass
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class WriterPass implements CompilerPassInterface
+final class WriterPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
@@ -17,11 +17,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
     * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/SculpinExtension.php
@@ -19,11 +19,9 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class SculpinExtension extends Extension
+final class SculpinExtension extends Extension
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -20,8 +20,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
- * Base Kernel implementation
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 abstract class AbstractKernel extends Kernel
@@ -169,9 +167,9 @@ abstract class AbstractKernel extends Kernel
     }
 
     /**
-     * Get additional Sculpin bundles to register
+     * Get additional Sculpin bundles to register.
      *
-     * @return array
+     * @return string[] Fully qualified class names of the bundles to register.
      */
     abstract protected function getAdditionalSculpinBundles(): array;
 }

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/DefaultKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/DefaultKernel.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Sculpin\Bundle\SculpinBundle\HttpKernel;
 
 /**
- * Default Kernel implementation
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class DefaultKernel extends AbstractKernel
 {
     /**
      * {@inheritdoc}
+     *
+     * Overwrite this method to add additional bundles to your Sculpin application.
      */
     protected function getAdditionalSculpinBundles(): array
     {

--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/KernelFactory.php
@@ -17,19 +17,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
- * Kernel Factory
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class KernelFactory
+final class KernelFactory
 {
-    /**
-     * Create a kernel.
-     *
-     * @param InputInterface $input Input
-     *
-     * @return Kernel
-     */
     public static function create(InputInterface $input): Kernel
     {
         $env = $input->getParameterOption(['--env', '-e'], getenv('SCULPIN_DEBUG') ?: 'dev');

--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -22,27 +22,35 @@ use React\Socket\Server as ReactSocketServer;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * HTTP Server
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class HttpServer
+final class HttpServer
 {
-    protected $debug;
-    protected $env;
-    protected $loop;
-    protected $output;
-    protected $port;
+    /**
+     * @var bool
+     */
+    private $debug;
 
     /**
-     * Constructor
-     *
-     * @param OutputInterface $output  Output
-     * @param string          $docroot Docroot
-     * @param string          $env     Environment
-     * @param bool            $debug   Debug
-     * @param int             $port    Port
+     * @var string
      */
+    private $env;
+
+    /**
+     * @var StreamSelectLoop
+     */
+    private $loop;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var int
+     */
+    private $port;
+
     public function __construct(OutputInterface $output, string $docroot, string $env, bool $debug, ?int $port = null)
     {
         $repository = new PhpRepository;

--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -3,48 +3,31 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sculpin.matcher.class">dflydev\util\antPathMatcher\AntPathMatcher</parameter>
-        <parameter key="sculpin.site_configuration.class">Dflydev\DotAccessConfiguration\Configuration</parameter>
-        <parameter key="sculpin.site_configuration_factory.class">Sculpin\Core\SiteConfiguration\SiteConfigurationFactory</parameter>
-        <parameter key="sculpin.writer.class">Sculpin\Core\Output\FilesystemWriter</parameter>
-        <parameter key="sculpin.data_provider_manager.class">Sculpin\Core\DataProvider\DataProviderManager</parameter>
-        <parameter key="sculpin.generator_manager.class">Sculpin\Core\Generator\GeneratorManager</parameter>
-        <parameter key="sculpin.formatter_manager.class">Sculpin\Core\Formatter\FormatterManager</parameter>
-        <parameter key="sculpin.converter_manager.class">Sculpin\Core\Converter\ConverterManager</parameter>
-        <parameter key="sculpin.class">Sculpin\Core\Sculpin</parameter>
-        <parameter key="sculpin.data_source.class">Sculpin\Core\Source\CompositeDataSource</parameter>
-        <parameter key="sculpin.default_filesystem_data_source.class">Sculpin\Core\Source\FilesystemDataSource</parameter>
-        <parameter key="sculpin.default_config_filesystem_data_source.class">Sculpin\Core\Source\ConfigFilesystemDataSource</parameter>
-        <parameter key="sculpin.source_permalink_factory.class">Sculpin\Core\Permalink\SourcePermalinkFactory</parameter>
-        <parameter key="sculpin.configuration.path_configurator.class">Sculpin\Bundle\SculpinBundle\Sculpin\Configuration\PathConfigurator</parameter>
-    </parameters>
-
     <services>
 
-        <service id="sculpin.matcher" class="%sculpin.matcher.class%" />
+        <service id="sculpin.matcher" class="dflydev\util\antPathMatcher\AntPathMatcher" />
 
-        <service id="sculpin.site_configuration_factory" class="%sculpin.site_configuration_factory.class%">
+        <service id="sculpin.site_configuration_factory" class="Sculpin\Core\SiteConfiguration\SiteConfigurationFactory">
             <argument>%kernel.project_dir%</argument>
             <argument>%kernel.environment%</argument>
         </service>
 
-        <service id="sculpin.site_configuration" class="%sculpin.site_configuration.class%" public="true">
+        <service id="sculpin.site_configuration" class="Dflydev\DotAccessConfiguration\Configuration" public="true">
             <factory service="sculpin.site_configuration_factory" method="create" />
         </service>
 
-        <service id="sculpin.source_permalink_factory" class="%sculpin.source_permalink_factory.class%">
+        <service id="sculpin.source_permalink_factory" class="Sculpin\Core\Permalink\SourcePermalinkFactory">
             <argument>%sculpin.permalink%</argument>
         </service>
 
-        <service id="sculpin.writer" class="%sculpin.writer.class%" public="true">
+        <service id="sculpin.writer" class="Sculpin\Core\Output\FilesystemWriter" public="true">
             <argument type="service" id="filesystem" />
             <argument>%sculpin.output_dir%</argument>
         </service>
 
-        <service id="sculpin.data_provider_manager" class="%sculpin.data_provider_manager.class%" />
+        <service id="sculpin.data_provider_manager" class="Sculpin\Core\DataProvider\DataProviderManager" />
 
-        <service id="sculpin.generator_manager" class="%sculpin.generator_manager.class%">
+        <service id="sculpin.generator_manager" class="Sculpin\Core\Generator\GeneratorManager">
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sculpin.site_configuration" />
             <call method="setDataProviderManager">
@@ -52,7 +35,7 @@
             </call>
         </service>
 
-        <service id="sculpin.formatter_manager" class="%sculpin.formatter_manager.class%">
+        <service id="sculpin.formatter_manager" class="Sculpin\Core\Formatter\FormatterManager">
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sculpin.site_configuration" />
             <call method="setDataProviderManager">
@@ -60,12 +43,12 @@
             </call>
         </service>
 
-        <service id="sculpin.converter_manager" class="%sculpin.converter_manager.class%">
+        <service id="sculpin.converter_manager" class="Sculpin\Core\Converter\ConverterManager">
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sculpin.formatter_manager" />
         </service>
 
-        <service id="sculpin" class="%sculpin.class%" public="true">
+        <service id="sculpin" class="Sculpin\Core\Sculpin" public="true">
             <argument type="service" id="sculpin.site_configuration" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sculpin.source_permalink_factory" />
@@ -92,7 +75,7 @@
             <argument type="service" id="sculpin.canal.detector" />
         </service>
 
-        <service id="sculpin.default_filesystem_data_source" class="%sculpin.default_filesystem_data_source.class%">
+        <service id="sculpin.default_filesystem_data_source" class="Sculpin\Core\Source\FilesystemDataSource">
             <argument>%sculpin.source_dir%</argument>
             <argument>%sculpin.exclude%</argument>
             <argument>%sculpin.ignore%</argument>
@@ -102,7 +85,7 @@
             <tag name="sculpin.data_source" />
         </service>
 
-        <service id="sculpin.default_config_filesystem_data_source" class="%sculpin.default_config_filesystem_data_source.class%">
+        <service id="sculpin.default_config_filesystem_data_source" class="Sculpin\Core\Source\ConfigFilesystemDataSource">
             <argument>%kernel.project_dir%/config</argument>
             <argument type="service" id="sculpin.site_configuration" />
             <argument type="service" id="sculpin.site_configuration_factory" />
@@ -110,7 +93,7 @@
             <tag name="sculpin.data_source" />
         </service>
 
-        <service id="sculpin.data_source" class="%sculpin.data_source.class%" public="true"/>
+        <service id="sculpin.data_source" class="Sculpin\Core\Source\CompositeDataSource" public="true"/>
 
         <service id="sculpin.custom_mime_types_repository" class="Dflydev\ApacheMimeTypes\ArrayRepository" />
 

--- a/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
+++ b/src/Sculpin/Bundle/SculpinBundle/SculpinBundle.php
@@ -28,8 +28,6 @@ use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Framework Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinBundle extends Bundle

--- a/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/DependencyInjection/SculpinStandaloneExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Framework Bundle Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinStandaloneExtension extends Extension

--- a/src/Sculpin/Bundle/StandaloneBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/StandaloneBundle/Resources/config/services.xml
@@ -2,16 +2,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="event_dispatcher.class">Symfony\Component\EventDispatcher\EventDispatcher</parameter>
-        <parameter key="filesystem.class">Symfony\Component\Filesystem\Filesystem</parameter>
-        <parameter key="templating.engines" type="collection" />
-    </parameters>
+
     <services>
-        <service id="event_dispatcher" class="%event_dispatcher.class%" public="true">
+        <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\EventDispatcher" public="true">
             <argument type="service" id="service_container" />
         </service>
-        <service id="filesystem" class="%filesystem.class%" public="true" />
+        <service id="filesystem" class="Symfony\Component\Filesystem\Filesystem" public="true" />
         <service id="Sculpin\Bundle\StandaloneBundle\Command\CacheClearCommand"
                  class="Sculpin\Bundle\StandaloneBundle\Command\CacheClearCommand">
             <tag name="console.command"/>

--- a/src/Sculpin/Bundle/StandaloneBundle/SculpinStandaloneBundle.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/SculpinStandaloneBundle.php
@@ -19,8 +19,6 @@ use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Standalone Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinStandaloneBundle extends Bundle

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sculpin\Bundle\TextileBundle\DependencyInjection;
 
+use Netcarver\Textile\Parser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface
@@ -34,7 +33,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('parser_class')->defaultValue('Netcarver\Textile\Parser')->end()
+                ->scalarNode('parser_class')->defaultValue(Parser::class)->end()
                 ->arrayNode('extensions')
                     ->defaultValue(['textile'])
                     ->prototype('scalar')->end()

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/SculpinTextileExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Textile Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinTextileExtension extends Extension

--- a/src/Sculpin/Bundle/TextileBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/TextileBundle/Resources/config/services.xml
@@ -3,14 +3,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sculpin_textile.converter.class">Sculpin\Bundle\TextileBundle\TextileConverter</parameter>
-    </parameters>
-
     <services>
         <service id="sculpin_textile.parser" class="%sculpin_textile.parser.class%" />
 
-        <service id="sculpin_textile.converter" class="%sculpin_textile.converter.class%" public="true">
+        <service id="sculpin_textile.converter" class="Sculpin\Bundle\TextileBundle\TextileConverter" public="true">
             <argument type="service" id="sculpin_textile.parser" />
             <tag name="sculpin.converter" alias="textile" />
             <tag name="sculpin.custom_mime_extensions" type="text/textile" parameter="sculpin_textile.extensions" />

--- a/src/Sculpin/Bundle/TextileBundle/SculpinTextileBundle.php
+++ b/src/Sculpin/Bundle/TextileBundle/SculpinTextileBundle.php
@@ -16,8 +16,6 @@ namespace Sculpin\Bundle\TextileBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Textile Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinTextileBundle extends Bundle

--- a/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
+++ b/src/Sculpin/Bundle/TextileBundle/TextileConverter.php
@@ -22,35 +22,28 @@ use Sculpin\Core\Source\SourceInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Textile Converter.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class TextileConverter implements ConverterInterface, EventSubscriberInterface
+final class TextileConverter implements ConverterInterface, EventSubscriberInterface
 {
     /**
-     * Textile parser
-     *
      * @var Parser
      */
-    protected $parser;
+    private $textileParser;
 
     /**
-     * Extensions
+     * File name extensions that are handled as textile.
      *
-     * @var array
+     * @var string[]
      */
-    protected $extensions = [];
+    private $extensions = [];
 
     /**
-     * Constructor.
-     *
-     * @param Parser $parser     Parser
-     * @param array  $extensions Extensions
+     * @param string[] $extensions file name extensions that are handled as markdown
      */
     public function __construct(Parser $parser, array $extensions = [])
     {
-        $this->parser = $parser;
+        $this->textileParser = $parser;
         $this->extensions = $extensions;
     }
 
@@ -59,7 +52,7 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
      */
     public function convert(ConverterContextInterface $converterContext): void
     {
-        $converterContext->setContent($this->parser->parse($converterContext->content()));
+        $converterContext->setContent($this->textileParser->parse($converterContext->content()));
     }
 
     /**
@@ -73,9 +66,9 @@ class TextileConverter implements ConverterInterface, EventSubscriberInterface
     }
 
     /**
-     * Before run
+     * Event hook to register this converter for all sources that have markdown file extensions.
      *
-     * @param SourceSetEvent $sourceSetEvent Source Set Event
+     * @internal
      */
     public function beforeRun(SourceSetEvent $sourceSetEvent): void
     {

--- a/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
+++ b/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Dump Autoload Command.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class ListCommand extends ContainerAwareCommand

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/SculpinThemeExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Theme Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinThemeExtension extends Extension

--- a/src/Sculpin/Bundle/ThemeBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/ThemeBundle/Resources/config/services.xml
@@ -12,27 +12,24 @@
             <parameter>%sculpin_theme.root_dir%/*/*/_partials/**</parameter>
             <parameter>%sculpin_theme.root_dir%/*/*/theme.yml</parameter>
         </parameter>
-        <parameter key="sculpin_theme.theme_registry.class">Sculpin\Bundle\ThemeBundle\ThemeRegistry</parameter>
-        <parameter key="sculpin_theme.theme_twig_loader.class">Sculpin\Bundle\ThemeBundle\ThemeTwigLoader</parameter>
-        <parameter key="sculpin_theme.theme_twig_extension.class">Sculpin\Bundle\ThemeBundle\ThemeTwigExtension</parameter>
     </parameters>
 
     <services>
 
-        <service id="sculpin_theme.theme_registry" class="%sculpin_theme.theme_registry.class%" public="true">
+        <service id="sculpin_theme.theme_registry" class="Sculpin\Bundle\ThemeBundle\ThemeRegistry" public="true">
             <argument>null</argument>
             <argument>%sculpin_theme.directory%</argument>
             <argument>%sculpin_theme.theme%</argument>
             <tag name="sculpin.path_configurator" type="exclude" parameter="sculpin_theme.exclude_patterns" />
         </service>
 
-        <service id="sculpin_theme.theme_twig_loader" class="%sculpin_theme.theme_twig_loader.class%">
+        <service id="sculpin_theme.theme_twig_loader" class="Sculpin\Bundle\ThemeBundle\ThemeTwigLoader">
             <argument type="service" id="sculpin_theme.theme_registry" />
             <argument>%sculpin_twig.extensions%</argument>
             <tag name="twig.loaders.append" />
         </service>
 
-        <service id="sculpin_theme.theme_twig_extension" class="%sculpin_theme.theme_twig_extension.class%">
+        <service id="sculpin_theme.theme_twig_extension" class="Sculpin\Bundle\ThemeBundle\ThemeTwigExtension">
             <argument type="service" id="sculpin_theme.theme_registry" />
             <argument>%sculpin.source_dir%</argument>
             <argument>%sculpin_theme.root_dir%</argument>

--- a/src/Sculpin/Bundle/ThemeBundle/SculpinThemeBundle.php
+++ b/src/Sculpin/Bundle/ThemeBundle/SculpinThemeBundle.php
@@ -16,8 +16,6 @@ namespace Sculpin\Bundle\ThemeBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Theme Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinThemeBundle extends Bundle

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
@@ -9,15 +9,26 @@ use Twig\TwigFunction;
 
 class ThemeTwigExtension extends AbstractExtension
 {
+    /**
+     * @var array|null
+     */
     private $theme;
-    private $sourceDir;
-    private $directory;
 
-    public function __construct(ThemeRegistry $themeRegistry, $sourceDir, $directory)
+    /**
+     * @var string
+     */
+    private $sourceDirectory;
+
+    /**
+     * @var string
+     */
+    private $themeDirectory;
+
+    public function __construct(ThemeRegistry $themeRegistry, string $sourceDirectory, string $themeDirectory)
     {
         $this->theme = $themeRegistry->findActiveTheme();
-        $this->sourceDir = $sourceDir;
-        $this->directory = $directory;
+        $this->sourceDirectory = $sourceDirectory;
+        $this->themeDirectory = $themeDirectory;
     }
 
     /**
@@ -45,10 +56,6 @@ class ThemeTwigExtension extends AbstractExtension
      *
      * Will always return a value. Default return value is the input unless the
      * file actually exists at a theme location.
-     *
-     * @param string $resource
-     *
-     * @return string
      */
     public function themePath(string $resource): string
     {
@@ -56,7 +63,7 @@ class ThemeTwigExtension extends AbstractExtension
             return $resource;
         }
 
-        if (file_exists($this->sourceDir.'/'.$resource)) {
+        if (file_exists($this->sourceDirectory.'/'.$resource)) {
             return $resource;
         }
 
@@ -84,7 +91,7 @@ class ThemeTwigExtension extends AbstractExtension
      */
     public function themePathExists(string $resource): bool
     {
-        if (file_exists($this->sourceDir.'/'.$resource)) {
+        if (file_exists($this->sourceDirectory.'/'.$resource)) {
             return true;
         }
 
@@ -120,7 +127,7 @@ class ThemeTwigExtension extends AbstractExtension
     {
         $paths = [];
 
-        if (file_exists($this->sourceDir.'/'.$resource)) {
+        if (file_exists($this->sourceDirectory.'/'.$resource)) {
             $paths[] = $resource;
         }
 
@@ -146,7 +153,7 @@ class ThemeTwigExtension extends AbstractExtension
     private function findThemeResource(array $theme, string $resource): ?string
     {
         if (file_exists($theme['path'].'/'.$resource)) {
-            return $this->directory.'/'.$theme['name'].'/'.$resource;
+            return $this->themeDirectory.'/'.$theme['name'].'/'.$resource;
         }
 
         return null;

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
@@ -19,7 +19,9 @@ use Twig\Loader\LoaderInterface;
 
 class ThemeTwigLoader implements LoaderInterface
 {
-    /** @var ChainLoader */
+    /**
+     * @var ChainLoader
+     */
     private $chainLoader;
 
     public function __construct(ThemeRegistry $themeRegistry, array $extensions)

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class Configuration implements ConfigurationInterface

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * Sculpin Twig Extension.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
 class SculpinTwigExtension extends Extension

--- a/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
@@ -16,7 +16,7 @@ namespace Sculpin\Bundle\TwigBundle;
 use Twig\Loader\FilesystemLoader as TwigFilesystemLoader;
 
 /**
- * Filesystem Loader.
+ * I twig loader that uses the file modification timestamp in the cache key.
  *
  * @method getSourceContext(string $name) \Twig\Source
  *

--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -21,31 +21,38 @@ use Twig\Loader\LoaderInterface;
 use Twig\Source as TwigSource;
 
 /**
- * Flexible Extension Filesystem Loader.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class FlexibleExtensionFilesystemLoader implements LoaderInterface, EventSubscriberInterface
+final class FlexibleExtensionFilesystemLoader implements LoaderInterface, EventSubscriberInterface
 {
     /**
-     * Filesystem loader
-     *
      * @var FilesystemLoader
      */
-    protected $filesystemLoader;
-
-    protected $cachedCacheKey = [];
-    protected $cachedCacheKeyExtension = [];
-    protected $cachedCacheKeyException = [];
-    protected $extensions = [];
+    private $filesystemLoader;
 
     /**
-     * Constructor.
-     *
-     * @param string   $sourceDir
+     * @var string[]
+     */
+    private $cachedCacheKey = [];
+
+    /**
+     * @var string[]
+     */
+    private $cachedCacheKeyExtension = [];
+
+    /**
+     * @var \Throwable[]
+     */
+    private $cachedCacheKeyException = [];
+    /**
+     * @var string[]
+     */
+    private $extensions = [];
+
+    /**
      * @param string[] $sourcePaths
      * @param string[] $paths
-     * @param string[] $extensions
+     * @param string[] $extensions  List of file extensions for twig files
      */
     public function __construct(string $sourceDir, array $sourcePaths, array $paths, array $extensions)
     {
@@ -54,12 +61,8 @@ class FlexibleExtensionFilesystemLoader implements LoaderInterface, EventSubscri
         }, $sourcePaths);
 
         $allPaths = array_merge(
-            array_filter($mappedSourcePaths, function ($path) {
-                return file_exists($path);
-            }),
-            array_filter($paths, function ($path) {
-                return file_exists($path);
-            })
+            array_filter($mappedSourcePaths, 'file_exists'),
+            array_filter($paths, 'file_exists')
         );
 
         $this->filesystemLoader = new FilesystemLoader($allPaths);

--- a/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
@@ -3,20 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sculpin_twig.flexible_extension_filesystem_loader.class">Sculpin\Bundle\TwigBundle\FlexibleExtensionFilesystemLoader</parameter>
-        <parameter key="sculpin_twig.array_loader.class">Twig\Loader\ArrayLoader</parameter>
-        <parameter key="sculpin_twig.loader.class">Twig\Loader\ChainLoader</parameter>
-        <parameter key="sculpin_twig.template_resetter.class">Sculpin\Bundle\TwigBundle\TemplateResetter</parameter>
-        <parameter key="sculpin_twig.twig.class">Sculpin\Bundle\TwigBundle\Environment</parameter>
-        <parameter key="sculpin_twig.formatter.class">Sculpin\Bundle\TwigBundle\TwigFormatter</parameter>
-        <parameter key="sculpin_twig.extensions.debug.class">Twig\Extension\DebugExtension</parameter>
-        <parameter key="sculpin_twig.extensions.intl.class">Twig\Extensions\IntlExtension</parameter>
-    </parameters>
-
     <services>
 
-        <service id="sculpin_twig.flexible_extension_filesystem_loader" class="%sculpin_twig.flexible_extension_filesystem_loader.class%" public="true">
+        <service id="sculpin_twig.flexible_extension_filesystem_loader" class="Sculpin\Bundle\TwigBundle\FlexibleExtensionFilesystemLoader" public="true">
             <argument>%sculpin.source_dir%</argument>
             <argument>%sculpin_twig.source_view_paths%</argument>
             <argument>%sculpin_twig.view_paths%</argument>
@@ -26,40 +15,40 @@
             <tag name="sculpin.custom_mime_extensions" type="text/twig" parameter="sculpin_twig.extensions" />
         </service>
 
-        <service id="sculpin_twig.array_loader" class="%sculpin_twig.array_loader.class%">
+        <service id="sculpin_twig.array_loader" class="Twig\Loader\ArrayLoader">
             <argument type="collection" />
         </service>
 
-        <service id="sculpin_twig.loader" class="%sculpin_twig.loader.class%">
+        <service id="sculpin_twig.loader" class="Twig\Loader\ChainLoader">
             <argument type="collection">
                 <argument type="service" id="sculpin_twig.array_loader" />
                 <argument type="service" id="sculpin_twig.flexible_extension_filesystem_loader" />
             </argument>
         </service>
 
-        <service id="sculpin_twig.twig" class="%sculpin_twig.twig.class%">
+        <service id="sculpin_twig.twig" class="Sculpin\Bundle\TwigBundle\Environment">
             <argument type="service" id="sculpin_twig.loader" />
             <argument type="collection">
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
         </service>
 
-        <service id="sculpin_twig.formatter" class="%sculpin_twig.formatter.class%">
+        <service id="sculpin_twig.formatter" class="Sculpin\Bundle\TwigBundle\TwigFormatter">
             <argument type="service" id="sculpin_twig.twig" />
             <argument type="service" id="sculpin_twig.array_loader" />
             <tag name="sculpin.formatter" alias="twig" />
         </service>
 
-        <service id="sculpin_twig.template_resetter" class="%sculpin_twig.template_resetter.class%" public="true">
+        <service id="sculpin_twig.template_resetter" class="Sculpin\Bundle\TwigBundle\TemplateResetter" public="true">
             <argument type="service" id="sculpin_twig.twig" />
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="sculpin_twig.extensions.debug" class="%sculpin_twig.extensions.debug.class%">
+        <service id="sculpin_twig.extensions.debug" class="Twig\Extension\DebugExtension">
             <tag name="twig.extension" />
         </service>
 
-        <service id="sculpin_twig.extensions.intl" class="%sculpin_twig.extensions.intl.class%">
+        <service id="sculpin_twig.extensions.intl" class="Twig\Extensions\IntlExtension">
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sculpin/Bundle/TwigBundle/SculpinTwigBundle.php
+++ b/src/Sculpin/Bundle/TwigBundle/SculpinTwigBundle.php
@@ -19,11 +19,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Sculpin Twig Bundle.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class SculpinTwigBundle extends Bundle
+final class SculpinTwigBundle extends Bundle
 {
     public const FORMATTER_NAME = 'twig';
 

--- a/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TemplateResetter.php
@@ -18,19 +18,12 @@ use Sculpin\Core\Sculpin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Template Resetter.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class TemplateResetter implements EventSubscriberInterface
+final class TemplateResetter implements EventSubscriberInterface
 {
-    protected $twig;
+    private $twig;
 
-    /**
-     * Constructor.
-     *
-     * @param Environment $twig
-     */
     public function __construct(Environment $twig)
     {
         $this->twig = $twig;
@@ -47,7 +40,7 @@ class TemplateResetter implements EventSubscriberInterface
     }
 
     /**
-     * Before run
+     * Invalidate templates if any of the sources have been updated.
      *
      * @param SourceSetEvent $sourceSetEvent Source Set Event
      */

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -20,32 +20,20 @@ use Twig\Loader\ArrayLoader;
 use Twig\Template;
 
 /**
- * Twig Formatter.
- *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class TwigFormatter implements FormatterInterface
+final class TwigFormatter implements FormatterInterface
 {
     /**
-     * Twig
-     *
-     * @var \Twig\Environment
+     * @var Environment
      */
-    protected $twig;
+    private $twig;
 
     /**
-     * Array loader
-     *
      * @var ArrayLoader
      */
-    protected $arrayLoader;
+    private $arrayLoader;
 
-    /**
-     * Constructor.
-     *
-     * @param Environment $twig        Twig
-     * @param ArrayLoader $arrayLoader Array Loader
-     */
     public function __construct(Environment $twig, ArrayLoader $arrayLoader)
     {
         $this->twig = $twig;
@@ -109,12 +97,13 @@ class TwigFormatter implements FormatterInterface
      */
     public function reset()
     {
+        // TODO should we delete this?
         // cache clearing is completely removed in twig v2
         // $this->twig->clearCacheFiles();
         // $this->twig->clearTemplateCache();
     }
 
-    protected function massageTemplate(FormatContext $formatContext)
+    private function massageTemplate(FormatContext $formatContext)
     {
         $template = $formatContext->template();
         if ($layout = $formatContext->data()->get('layout')) {


### PR DESCRIPTION
symfony recommends to not use parameters for the classes that implement services. i only kept the ones that are actually configurable. everything else should be done with service decorators or custom compiler passes if ever needed, to make things less implicit.