### PR TITLE
Generator exceptions

### DIFF
--- a/src/Sculpin/Core/DataProvider/DataProviderManager.php
+++ b/src/Sculpin/Core/DataProvider/DataProviderManager.php
@@ -54,9 +54,16 @@ class DataProviderManager
      * @param string $name Name
      *
      * @return DataProviderInterface
+     * @throws \InvalidArgumentException
      */
     public function dataProvider(string $name): DataProviderInterface
     {
-        return $this->dataProviders[$name];
+        if (isset($this->dataProviders[$name])) {
+            return $this->dataProviders[$name];
+        }
+        throw new \InvalidArgumentException(sprintf(
+            "Requested data provider '%s' could not be found; does the content type exist, or provider not specified?",
+            $name
+        ));
     }
 }

--- a/src/Sculpin/Core/Generator/GeneratorManager.php
+++ b/src/Sculpin/Core/Generator/GeneratorManager.php
@@ -104,9 +104,11 @@ class GeneratorManager
 
             foreach ($generatorNames as $generatorName) {
                 if (!isset($this->generators[$generatorName])) {
-                    throw new \InvalidArgumentException(
-                        "Requested generator '$generatorName' could not be found; was it registered?"
-                    );
+                    throw new \InvalidArgumentException(sprintf(
+                        "Requested generator '%s' could not be found in %s; was it registered?",
+                        $generatorName,
+                        $source->relativePathname()
+                    ));
                 }
 
                 $generators[] = $this->generators[$generatorName];


### PR DESCRIPTION
In the case of the DataProviderManager, an invalid value triggers a noisy stack trace (`E_ALL`) on the console, whereas the exception from this change is handled by the console application.

For the GeneratorManager this change points me directly to the offending file.