### PR TITLE
Migrate PermalinkStrategyCollection definition to the container

### DIFF
--- a/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollectionFactory.php
+++ b/src/Sculpin/Contrib/Taxonomy/PermalinkStrategyCollectionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Contrib\Taxonomy;
+
+final class PermalinkStrategyCollectionFactory
+{
+    /**
+     * @param string|array $taxonomy
+     */
+    public static function create($taxonomy): PermalinkStrategyCollection
+    {
+        $collection = new PermalinkStrategyCollection();
+        if (is_string($taxonomy)) {
+            return $collection;
+        }
+        foreach ($taxonomy['strategies'] ?? [] as $strategy) {
+            $collection->push(new $strategy());
+        }
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
When working on a (pure) Symfony 4.2 project the container dumping will fail as `Sculpin\Contrib\Taxonomy\PermalinkStrategyCollection` is built as an object in the bundle's DI extension, instead of by the container, resulting in the exception:

```
  [Symfony\Component\DependencyInjection\Exception\RuntimeException]             
  Unable to dump a service container if a parameter is an object or a resource.  
```

This PR moves construction to a service factory, and the service to a `Symfony\Component\DependencyInjection\Definition`.
