### PR TITLE
Enhance exception handling

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -49,32 +49,32 @@ class TwigFormatter implements FormatterInterface
         $this->arrayLoader = $arrayLoader;
     }
 
-     /**
+    /**
      * {@inheritdoc}
+     *
+     * @throws \Throwable
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
      */
     public function formatBlocks(FormatContext $formatContext): array
     {
-        try {
-            $this->arrayLoader->setTemplate(
-                $formatContext->templateId(),
-                $this->massageTemplate($formatContext)
-            );
-            $data = $formatContext->data()->export();
-            $template = $this->twig->loadTemplate($formatContext->templateId());
+        $this->arrayLoader->setTemplate(
+            $formatContext->templateId(),
+            $this->massageTemplate($formatContext)
+        );
+        $data = $formatContext->data()->export();
+        $template = $this->twig->loadTemplate($formatContext->templateId());
 
-            if (!count($blockNames = $this->findAllBlocks($template, $data))) {
-                return ['content' => $template->render($data)];
-            }
-            $blocks = [];
-            foreach ($blockNames as $blockName) {
-                $blocks[$blockName] = $template->renderBlock($blockName, $data);
-            }
-
-            return $blocks;
-        } catch (\Exception $e) {
-            print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
-            return [];
+        if (!count($blockNames = $this->findAllBlocks($template, $data))) {
+            return ['content' => $template->render($data)];
         }
+        $blocks = [];
+        foreach ($blockNames as $blockName) {
+            $blocks[$blockName] = $template->renderBlock($blockName, $data);
+        }
+
+        return $blocks;
     }
 
     public function findAllBlocks(\Twig_Template $template, array $context): array
@@ -84,22 +84,21 @@ class TwigFormatter implements FormatterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
      */
     public function formatPage(FormatContext $formatContext): string
     {
-        try {
-            $this->arrayLoader->setTemplate(
-                $formatContext->templateId(),
-                $this->massageTemplate($formatContext)
-            );
+        $this->arrayLoader->setTemplate(
+            $formatContext->templateId(),
+            $this->massageTemplate($formatContext)
+        );
 
-            $data = $formatContext->data()->export();
+        $data = $formatContext->data()->export();
 
-            return $this->twig->render($formatContext->templateId(), $data);
-        } catch (\Exception $e) {
-            print ' [ ' . get_class($e) . ': ' . $e->getMessage() . " ]\n";
-            return '';
-        }
+        return $this->twig->render($formatContext->templateId(), $data);
     }
 
     /**

--- a/src/Sculpin/Core/Io/ConsoleIo.php
+++ b/src/Sculpin/Core/Io/ConsoleIo.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sculpin\Core\Io;
 
+use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Helper\HelperSet;
 
 /**
  * The Input/Output helper.
@@ -71,7 +71,7 @@ class ConsoleIo implements IoInterface
      */
     public function isVerbose(): bool
     {
-        return $this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;
+        return $this->output->isVerbose();
     }
 
     /**
@@ -79,7 +79,7 @@ class ConsoleIo implements IoInterface
      */
     public function isVeryVerbose(): bool
     {
-        return $this->output->getVerbosity() >= 3; // OutputInterface::VERBOSITY_VERY_VERBOSE
+        return $this->output->isVeryVerbose();
     }
 
     /**
@@ -87,7 +87,7 @@ class ConsoleIo implements IoInterface
      */
     public function isDebug(): bool
     {
-        return $this->output->getVerbosity() >= 4; // OutputInterface::VERBOSITY_DEBUG
+        return $this->output->isDebug();
     }
 
     /**

--- a/src/Sculpin/Core/Output/FilesystemWriter.php
+++ b/src/Sculpin/Core/Output/FilesystemWriter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sculpin\Core\Output;
 
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -50,6 +51,8 @@ class FilesystemWriter implements WriterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws IOException
      */
     public function write(OutputInterface $output): void
     {
@@ -58,7 +61,7 @@ class FilesystemWriter implements WriterInterface
             $this->filesystem->copy($output->file(), $outputPath, true);
         } else {
             $this->filesystem->mkdir(dirname($outputPath));
-            file_put_contents($outputPath, $output->formattedContent());
+            $this->filesystem->dumpFile($outputPath, $output->formattedContent());
         }
     }
 

--- a/src/Sculpin/Core/Sculpin.php
+++ b/src/Sculpin/Core/Sculpin.php
@@ -24,6 +24,7 @@ use Sculpin\Core\Output\SourceOutput;
 use Sculpin\Core\Output\WriterInterface;
 use Sculpin\Core\Permalink\SourcePermalinkFactoryInterface;
 use Sculpin\Core\Source\DataSourceInterface;
+use Sculpin\Core\Source\SourceInterface;
 use Sculpin\Core\Source\SourceSet;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -149,7 +150,7 @@ class Sculpin
 
         $this->eventDispatcher->dispatch(self::EVENT_BEFORE_RUN, new SourceSetEvent($sourceSet));
 
-        if ($updatedSources = array_filter($sourceSet->updatedSources(), function ($source) {
+        if ($updatedSources = array_filter($sourceSet->updatedSources(), function (SourceInterface $source) {
             return !$source->isGenerated();
         })) {
             if (!$found) {

--- a/src/Sculpin/Core/Source/SourceSet.php
+++ b/src/Sculpin/Core/Source/SourceSet.php
@@ -75,7 +75,7 @@ class SourceSet
     /**
      * All sources
      *
-     * @return array
+     * @return SourceInterface[]
      */
     public function allSources(): array
     {
@@ -85,7 +85,7 @@ class SourceSet
     /**
      * All sources that have been updated
      *
-     * @return array
+     * @return SourceInterface[]
      */
     public function updatedSources(): array
     {

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -41,6 +41,7 @@ class FunctionalTestCase extends TestCase
         $projectFiles = [
             '/config/sculpin_kernel.yml',
             '/config/sculpin_site.yml',
+            '/source/_layouts/default.html.twig',
             '/source/_layouts/raw.html.twig',
         ];
 
@@ -48,7 +49,11 @@ class FunctionalTestCase extends TestCase
             $this->addProjectFile($file);
         }
 
-        $this->writeToProjectFile('/source/_layouts/raw.html.twig', '{% block content %}{% endblock content %}');
+        $this->writeToProjectFile('/source/_layouts/default.html.twig', '{% block content %}{% endblock content %}');
+        $this->writeToProjectFile(
+            '/source/_layouts/raw.html.twig',
+            '{% extends "default" %}{% block content %}{% endblock content %}'
+        );
     }
 
     protected function tearDownTestProject(): void


### PR DESCRIPTION
_Please close if this is not in-line with project design_ :+1: 	

This PR moves the bulk of exception handling to the console command:
 - When running the server prints `<error>Error message details</>`
 - When running in debug (`-vvv`) prints `<comment>Stack trace array</>`
 - Running in watch mode (no server) prints;
    - `<error>Error message details</>`
    - `<comment>Stack trace array</>`
 - Otherwise the exception is re-thrown

Makes life a lot easier to fix problems, including the hidden in the `FunctionalTestCase` :wink: 