### PR TITLE
Cast Yaml::parse() result to array as it can return null

### DIFF
--- a/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeRegistry.php
@@ -48,7 +48,7 @@ class ThemeRegistry
             $name = basename(dirname($directory->getRealPath())).'/'.basename($directory->getRealPath());
             $theme = ['name' => $name, 'path' => $directory];
             if (file_exists($directory.'/theme.yml')) {
-                $theme = array_merge(Yaml::parse(file_get_contents($directory.'/theme.yml')), $theme);
+                $theme = array_merge((array) Yaml::parse(file_get_contents($directory.'/theme.yml')), $theme);
             }
             $themes[$theme['name']] = $theme;
         }


### PR DESCRIPTION
Hit this when emptying the `theme.yml` file.