### PR TITLE
Move Twig classes/imports to namespaces

### DIFF
--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigExtension.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Sculpin\Bundle\ThemeBundle;
 
-class ThemeTwigExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class ThemeTwigExtension extends AbstractExtension
 {
     private $theme;
     private $sourceDir;
@@ -23,9 +26,9 @@ class ThemeTwigExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_SimpleFunction('theme_path', [$this, 'themePath']),
-            new \Twig_SimpleFunction('theme_path_exists', [$this, 'themePathExists']),
-            new \Twig_SimpleFunction('theme_paths', [$this, 'themePaths']),
+            new TwigFunction('theme_path', [$this, 'themePath']),
+            new TwigFunction('theme_path_exists', [$this, 'themePathExists']),
+            new TwigFunction('theme_paths', [$this, 'themePaths']),
         ];
     }
 
@@ -145,7 +148,7 @@ class ThemeTwigExtension extends \Twig_Extension
         if (file_exists($theme['path'].'/'.$resource)) {
             return $this->directory.'/'.$theme['name'].'/'.$resource;
         }
-        
+
         return null;
     }
 }

--- a/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
+++ b/src/Sculpin/Bundle/ThemeBundle/ThemeTwigLoader.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace Sculpin\Bundle\ThemeBundle;
 
 use Sculpin\Bundle\TwigBundle\FlexibleExtensionFilesystemLoader;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\LoaderInterface;
 
-class ThemeTwigLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
+class ThemeTwigLoader implements LoaderInterface
 {
-    /** @var \Twig_Loader_Chain */
+    /** @var ChainLoader */
     private $chainLoader;
 
     public function __construct(ThemeRegistry $themeRegistry, array $extensions)
@@ -36,7 +38,7 @@ class ThemeTwigLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterf
             }
         }
 
-        $this->chainLoader = new \Twig_Loader_Chain($loaders);
+        $this->chainLoader = new ChainLoader($loaders);
     }
 
     private function findPaths(array $theme, array $paths = []): array

--- a/src/Sculpin/Bundle/TwigBundle/Environment.php
+++ b/src/Sculpin/Bundle/TwigBundle/Environment.php
@@ -16,7 +16,7 @@ namespace Sculpin\Bundle\TwigBundle;
 /**
  * Twig Environment with Loaded Template Invalidation.
  */
-class Environment extends \Twig_Environment
+class Environment extends \Twig\Environment
 {
     /**
      * We aren't supposed to be using loadTemplate directly, and Twig V2 took away our ability to invalidate it.

--- a/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FilesystemLoader.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Sculpin\Bundle\TwigBundle;
 
+use Twig\Loader\FilesystemLoader as TwigFilesystemLoader;
+
 /**
  * Filesystem Loader.
  *
+ * @method getSourceContext(string $name) \Twig\Source
+ *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class FilesystemLoader extends \Twig_Loader_Filesystem
+class FilesystemLoader extends TwigFilesystemLoader
 {
     /**
      * {@inheritdoc}

--- a/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
+++ b/src/Sculpin/Bundle/TwigBundle/FlexibleExtensionFilesystemLoader.php
@@ -16,13 +16,16 @@ namespace Sculpin\Bundle\TwigBundle;
 use Sculpin\Core\Event\SourceSetEvent;
 use Sculpin\Core\Sculpin;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
+use Twig\Source as TwigSource;
 
 /**
  * Flexible Extension Filesystem Loader.
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventSubscriberInterface
+class FlexibleExtensionFilesystemLoader implements LoaderInterface, EventSubscriberInterface
 {
     /**
      * Filesystem loader
@@ -68,7 +71,7 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
     /**
      * {@inheritdoc}
      */
-    public function getSourceContext($name): \Twig_Source
+    public function getSourceContext($name): TwigSource
     {
         $this->getCacheKey($name);
 
@@ -98,11 +101,11 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
                 $this->cachedCacheKeyExtension[$name] = $extension;
 
                 return $this->cachedCacheKey[$name];
-            } catch (\Twig_Error_Loader $e) {
+            } catch (LoaderError $e) {
             }
         }
 
-        throw $this->cachedCacheKeyException[$name] = new \Twig_Error_Loader(
+        throw $this->cachedCacheKeyException[$name] = new LoaderError(
             sprintf('Template "%s" is not defined.', $name)
         );
     }
@@ -126,7 +129,7 @@ class FlexibleExtensionFilesystemLoader implements \Twig_LoaderInterface, EventS
     {
         try {
             $this->getCacheKey($name);
-        } catch (\Twig_Error_Loader $e) {
+        } catch (LoaderError $e) {
             return false;
         }
 

--- a/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
@@ -5,13 +5,13 @@
 
     <parameters>
         <parameter key="sculpin_twig.flexible_extension_filesystem_loader.class">Sculpin\Bundle\TwigBundle\FlexibleExtensionFilesystemLoader</parameter>
-        <parameter key="sculpin_twig.array_loader.class">Twig_Loader_Array</parameter>
-        <parameter key="sculpin_twig.loader.class">Twig_Loader_Chain</parameter>
+        <parameter key="sculpin_twig.array_loader.class">Twig\Loader\ArrayLoader</parameter>
+        <parameter key="sculpin_twig.loader.class">Twig\Loader\ChainLoader</parameter>
         <parameter key="sculpin_twig.template_resetter.class">Sculpin\Bundle\TwigBundle\TemplateResetter</parameter>
         <parameter key="sculpin_twig.twig.class">Sculpin\Bundle\TwigBundle\Environment</parameter>
         <parameter key="sculpin_twig.formatter.class">Sculpin\Bundle\TwigBundle\TwigFormatter</parameter>
-        <parameter key="sculpin_twig.extensions.debug.class">Twig_Extension_Debug</parameter>
-        <parameter key="sculpin_twig.extensions.intl.class">Twig_Extensions_Extension_Intl</parameter>
+        <parameter key="sculpin_twig.extensions.debug.class">Twig\Extension\DebugExtension</parameter>
+        <parameter key="sculpin_twig.extensions.intl.class">Twig\Extensions\IntlExtension</parameter>
     </parameters>
 
     <services>

--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -15,6 +15,9 @@ namespace Sculpin\Bundle\TwigBundle;
 
 use Sculpin\Core\Formatter\FormatContext;
 use Sculpin\Core\Formatter\FormatterInterface;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Template;
 
 /**
  * Twig Formatter.
@@ -26,31 +29,36 @@ class TwigFormatter implements FormatterInterface
     /**
      * Twig
      *
-     * @var \Twig_Environment
+     * @var \Twig\Environment
      */
     protected $twig;
 
     /**
      * Array loader
      *
-     * @var \Twig_Loader_Array
+     * @var ArrayLoader
      */
     protected $arrayLoader;
 
     /**
      * Constructor.
      *
-     * @param \Twig_Environment  $twig        Twig
-     * @param \Twig_Loader_Array $arrayLoader Array Loader
+     * @param Environment $twig        Twig
+     * @param ArrayLoader $arrayLoader Array Loader
      */
-    public function __construct(\Twig_Environment $twig, \Twig_Loader_Array $arrayLoader)
+    public function __construct(Environment $twig, ArrayLoader $arrayLoader)
     {
         $this->twig = $twig;
         $this->arrayLoader = $arrayLoader;
     }
 
-     /**
+    /**
      * {@inheritdoc}
+     *
+     * @throws \Throwable
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function formatBlocks(FormatContext $formatContext): array
     {
@@ -77,13 +85,17 @@ class TwigFormatter implements FormatterInterface
         }
     }
 
-    public function findAllBlocks(\Twig_Template $template, array $context): array
+    public function findAllBlocks(Template $template, array $context): array
     {
         return $template->getBlockNames($context);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function formatPage(FormatContext $formatContext): string
     {


### PR DESCRIPTION
This PR moves Twig class/import use to namespaces, cleaning up deprecation warnings in the process.

A note on removing ExistsLoaderInterface: https://twig.symfony.com/doc/2.x/deprecated.html#interfaces

If #421 is accepted prior to this, the PHPDoc in `GenerateCommand` will need tweaking too :smiley_cat: 