### PR TITLE
Add relative_pathname and filename for current file

### DIFF
--- a/src/Sculpin/Core/Sculpin.php
+++ b/src/Sculpin/Core/Sculpin.php
@@ -134,6 +134,8 @@ final class Sculpin
             $permalink = $this->permalinkFactory->create($source);
             $source->setPermalink($permalink);
             $source->data()->set('url', $permalink->relativeUrlPath());
+            $source->data()->set('relative_pathname', $source->relativePathname());
+            $source->data()->set('filename', $source->filename());
         }
 
         if ($updatedSources = $sourceSet->updatedSources()) {


### PR DESCRIPTION
In my sculpin project, I have a button in the top of every generated markdown file which redirects me to the edit page of that file on gitlab. In this case i would always need the current file path to land on the current file on gitlab and this is why i added the relative pathname and file name for the current opened file.