### PR TITLE
Skip certain ContentType files

### DIFF
--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -84,8 +84,21 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
             }
 
             if ($this->filter->match($source)) {
+                // Skip hidden files.
+                if (0 === strpos($source->filename(), '.')) {
+                    $source->setShouldBeSkipped();
+
+                    continue;
+                }
+
                 // Skip file types that cannot be parsed into blocks.
+                // Files without an extension fall into this category
+                // because the formatter looks for specific extensions.
+                // Files without a newline after the YAML front matter
+                // also fall into this category.
                 if (!$source->canBeFormatted()) {
+                    echo 'Skipping empty or unknown file: ' . $source->relativePathname() . PHP_EOL;
+
                     $source->setShouldBeSkipped();
 
                     continue;
@@ -143,12 +156,6 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         }
 
         $item = $this->collection[$sourceId];
-
-        if (!$item->canBeFormatted()) {
-            echo 'Failed to format (unknown file type?) : ' . $sourceId . PHP_EOL;
-
-            return;
-        }
 
         $item->setBlocks($this->formatterManager->formatSourceBlocks($convertEvent->source()));
     }

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -201,6 +201,25 @@ class FunctionalTestCase extends TestCase
 
     /**
      * @param string $filePath
+     * @param string $expected
+     * @param string|null $msg
+     */
+    protected function assertGeneratedFileHasContent(string $filePath, string $expected, ?string $msg = null): void
+    {
+        $outputDir = '/output_test';
+
+        $msg        = $msg ?: "Expected generated file at path $filePath to have content '$expected'.";
+        $fullPath   = static::projectDir() . $outputDir . $filePath;
+        $fileExists = static::$fs->exists($fullPath);
+
+        $this->assertTrue($fileExists, $msg . ' (File Not Found!)');
+
+        $contents = file_get_contents($fullPath);
+        $this->assertContains($expected, $contents, $msg);
+    }
+
+    /**
+     * @param string $filePath
      * @param string $content
      */
     protected function writeToProjectFile(string $filePath, string $content): void

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -22,6 +22,9 @@ class FunctionalTestCase extends TestCase
     /** @var Filesystem */
     protected static $fs;
 
+    /** @var string */
+    protected $executeOutput;
+
     public static function setUpBeforeClass(): void
     {
         static::$fs = new Filesystem();
@@ -72,7 +75,7 @@ class FunctionalTestCase extends TestCase
     {
         $binPath    = __DIR__ . '/../../../../bin';
         $projectDir = static::projectDir();
-        exec("$binPath/sculpin $command --project-dir $projectDir --env=test");
+        exec("$binPath/sculpin $command --project-dir $projectDir --env=test", $this->executeOutput);
     }
 
     /**


### PR DESCRIPTION
A correction to the way files are processed by Sculpin generators. Includes tests. This issue was reported in Issue #432.

If a file is encountered that matches the filter patterns (e.g., `_posts/**`) but cannot be formatted, it will be marked as `ShouldBeSkipped`. If it is hidden, this will be done silently - otherwise, a `Skipping empty or unknown file: ` message will be displayed.

Overall this is intended as a patch-level improvement. However, it could introduce some unexpected breakages because of how it prevents files from being erroneously written straight to disk (e.g., `sculpin/output_dev/_posts/blog-post-file-with-no-extension` will no longer be written if `sculpin/source/_posts/blog-post-file-with-no-extension` exists; previously, this would completely bypass the permalink strategy used by Sculpin).

Also new in this PR:

- A new assertion (`assertGeneratedFileHasContent`)
- Sculpin tests that invoke sculpin can now access the command's output using `$this->executeOutput`.