### PR TITLE
Fix a bug that caused some globals to be skipped

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
+++ b/src/Sculpin/Bundle/TwigBundle/TwigFormatter.php
@@ -55,6 +55,10 @@ final class TwigFormatter implements FormatterInterface
             $this->massageTemplate($formatContext)
         );
         $data = $formatContext->data()->export();
+        
+        // apply twig globals to the context array prior to loading the template
+        $data = $this->twig->mergeGlobals($data);
+        
         $template = $this->twig->loadTemplate($formatContext->templateId());
 
         if (!count($blockNames = $this->findAllBlocks($template, $data))) {


### PR DESCRIPTION
If the globals were defined by an extension, there was a scenario that caused them to be skipped. Maybe this isn't the right place to fix it, but it does seem to work in my local testing.