### PR TITLE
Add a webpack encore helper to Twig

### DIFF
--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -43,6 +43,13 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(['', 'twig', 'html', 'html.twig', 'twig.html'])
                     ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('webpack_manifest')
+                    ->info(
+                        'Optional relative path to the Webpack Encore manifest file within source/ '
+                        . '(e.g., "build/manifest.json")'
+                    )
+                    ->defaultNull()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/SculpinTwigExtension.php
@@ -37,6 +37,7 @@ class SculpinTwigExtension extends Extension
         $container->setParameter('sculpin_twig.source_view_paths', $config['source_view_paths']);
         $container->setParameter('sculpin_twig.view_paths', $config['view_paths']);
         $container->setParameter('sculpin_twig.extensions', $config['extensions']);
+        $container->setParameter('sculpin_twig.webpack_manifest', $config['webpack_manifest']);
 
         if (! extension_loaded('intl')) {
             // Do not enable the intl Twig extension if the intl PHP extension is not installed.

--- a/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/TwigBundle/Resources/config/services.xml
@@ -52,6 +52,12 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="sculpin_twig.helpers.webpack_encore_helper" class="Sculpin\Bundle\TwigBundle\WebpackEncoreHelper">
+            <argument>%sculpin.source_dir%</argument>
+            <argument>%sculpin_twig.webpack_manifest%</argument>
+            <tag name="twig.extension" />
+        </service>
+
     </services>
 
 </container>

--- a/src/Sculpin/Bundle/TwigBundle/WebpackEncoreHelper.php
+++ b/src/Sculpin/Bundle/TwigBundle/WebpackEncoreHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sculpin\Bundle\TwigBundle;
+
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+class WebpackEncoreHelper extends AbstractExtension implements GlobalsInterface
+{
+    protected $sourceDir;
+    protected $manifest;
+
+    public function __construct(string $sourceDir, ?string $manifest)
+    {
+        $this->sourceDir = $sourceDir;
+        $this->manifest = $manifest;
+    }
+
+    public function getGlobals(): array
+    {
+        $manifestContents = $this->getManifestContents();
+
+        if (!$manifestContents) {
+            return [
+                'webpack_manifest' =>
+                    [
+                        'error' => 'Please configure the `sculpin_twig.webpack_manifest` variable '
+                            . 'in your app/config/sculpin_kernel.yml file. For example:' . "\n\n"
+                            . 'sculpin_twig:' . "\n"
+                            . '    webpack_manifest: build/manifest.json'
+                    ]
+            ];
+        }
+
+        $manifest = json_decode($manifestContents, true);
+
+        return [
+            'webpack_manifest' => $manifest,
+        ];
+    }
+
+    private function getManifestContents(): string
+    {
+        $path = $this->sourceDir . DIRECTORY_SEPARATOR . $this->manifest;
+
+        if (!file_exists($path) || !is_readable($path)) {
+            return '';
+        }
+
+        return file_get_contents($path);
+    }
+}

--- a/src/Sculpin/Tests/Functional/Fixture/webpack_manifest/manifest.json
+++ b/src/Sculpin/Tests/Functional/Fixture/webpack_manifest/manifest.json
@@ -1,0 +1,4 @@
+{
+    "build/css/app.css": "/build/css/app.9141cd43.css",
+    "build/js/app.js": "/build/js/app.43dcc737.js"
+}

--- a/src/Sculpin/Tests/Functional/Fixture/webpack_manifest/manifest_test.md
+++ b/src/Sculpin/Tests/Functional/Fixture/webpack_manifest/manifest_test.md
@@ -1,0 +1,7 @@
+---
+title: testing webpack manifest
+---
+
+Testing CSS {{ webpack_manifest['build/css/app.css']|default('/build/css/app.css') }}
+Testing JS {{ webpack_manifest['build/js/app.js']|default('/build/js/app.js') }}
+

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -42,8 +42,8 @@ class FunctionalTestCase extends TestCase
         $this->tearDownTestProject();
 
         $projectFiles = [
-            '/config/sculpin_kernel.yml',
-            '/config/sculpin_site.yml',
+            '/app/config/sculpin_kernel.yml',
+            '/app/config/sculpin_site.yml',
             '/source/_layouts/default.html.twig',
             '/source/_layouts/raw.html.twig',
         ];


### PR DESCRIPTION
This helper exposes the `manifest.json` generated by webpack as a global variable in Twig, so that `production` assets can be referenced with their file hashes.

### Usage

To configure the helper, define this parameter in your `app/config/sculpin_kernel.yml` or `app/config/sculpin_kernel_prod.yml` file:

```yaml
sculpin_twig:
    webpack_manifest: build/manifest.json
```

The above example tells Sculpin to look in the `project_dir/source/` folder for `build/manifest.json`.

Once this is pointing at the correct file, you can use these Twig snippets to include your CSS and JS files:

```twig
<!-- CSS example -->
<link rel="stylesheet" href="{{ site.url }}{{ webpack_manifest['build/css/app.css']|default('/build/css/app.css') }}"/>

<!-- JS example -->
<script type="text/javascript" src="{{ site.url }}{{ webpack_manifest['build/js/app.js']|default('/build/js/app.js') }}"></script>
```

This fix is based on some custom logic I built into [whateverthing.com](https://whateverthing.com). I want to add it to Sculpin so that folks can use it in all their projects, such as requested in sculpin/sculpin-blog-skeleton#79.

The proposed implementation has some rough edges (such as that Twig syntax), and might be a bit too targeted to the specific problem. Some other file-related requests have come up, such as #441 and #444 about including files (or lists of files) from disk inside Twig templates. Perhaps there is an approach that could solve all of these concerns at once?