### PR TITLE
Update react/http to v1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/inflector": "^1.3",
         "michelf/php-markdown": "^1.9",
         "netcarver/textile": "^3.6",
-        "react/http": "^0.8.3",
+        "react/http": "^1.0",
         "sculpin/sculpin-theme-composer-plugin": "^1.0",
         "symfony/config": "^4.1",
         "symfony/console": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70d4b2344cbbf01aa8f5f950f0994c61",
+    "content-hash": "9df58ee75988ce27e6d0e2356d22c011",
     "packages": [
         {
             "name": "dflydev/ant-path-matcher",
@@ -847,30 +847,35 @@
         },
         {
             "name": "react/http",
-            "version": "v0.8.6",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/http.git",
-                "reference": "248202e57195d06a4375f6d2f5c5b9ff9da3ea9e"
+                "reference": "865694453c95122f8972b9ed7961efb3c517fc5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http/zipball/248202e57195d06a4375f6d2f5c5b9ff9da3ea9e",
-                "reference": "248202e57195d06a4375f6d2f5c5b9ff9da3ea9e",
+                "url": "https://api.github.com/repos/reactphp/http/zipball/865694453c95122f8972b9ed7961efb3c517fc5e",
+                "reference": "865694453c95122f8972b9ed7961efb3c517fc5e",
                 "shasum": ""
             },
             "require": {
                 "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
                 "php": ">=5.3.0",
+                "psr/http-message": "^1.0",
+                "react/event-loop": "^1.0 || ^0.5",
                 "react/promise": "^2.3 || ^1.2.1",
                 "react/promise-stream": "^1.1",
-                "react/socket": "^1.0 || ^0.8.3",
-                "react/stream": "^1.0 || ^0.7.1",
+                "react/socket": "^1.1",
+                "react/stream": "^1.0 || ^0.7.5",
                 "ringcentral/psr7": "^1.2"
             },
             "require-dev": {
                 "clue/block-react": "^1.1",
-                "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+                "clue/http-proxy-react": "^1.3",
+                "clue/reactphp-ssh-proxy": "^1.0",
+                "clue/socks-react": "^1.0",
+                "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
             },
             "type": "library",
             "autoload": {
@@ -882,16 +887,43 @@
             "license": [
                 "MIT"
             ],
-            "description": "Event-driven, streaming plaintext HTTP and secure HTTPS server for ReactPHP",
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven, streaming HTTP client and server implementation for ReactPHP",
             "keywords": [
+                "async",
+                "client",
                 "event-driven",
                 "http",
+                "http client",
+                "http server",
                 "https",
+                "psr-7",
                 "reactphp",
                 "server",
                 "streaming"
             ],
-            "time": "2020-01-12T13:15:06+00:00"
+            "time": "2020-07-11T13:29:43+00:00"
         },
         {
             "name": "react/promise",

--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -16,7 +16,7 @@ namespace Sculpin\Bundle\SculpinBundle\HttpServer;
 use Dflydev\ApacheMimeTypes\PhpRepository;
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\StreamSelectLoop;
-use React\Http\Response;
+use React\Http\Message\Response;
 use React\Http\Server as ReactHttpServer;
 use React\Socket\Server as ReactSocketServer;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -66,7 +66,7 @@ final class HttpServer
             $this->loop
         );
 
-        $httpServer = new ReactHttpServer(function (ServerRequestInterface $request) use (
+        $httpServer = new ReactHttpServer($this->loop, function (ServerRequestInterface $request) use (
             $repository,
             $docroot,
             $output


### PR DESCRIPTION
This minimal changeset updates react/http to the stable `v1.0.0` released a few days ago: https://github.com/reactphp/http/releases/tag/v1.0.0

I've updated the code to resolve some minor BC breaks, but this doesn't seem to be covered by the existing test suite afaict. I've manually checked the `sculpin serve` command and verified this appears to work as expected.

Let me know if there's anything else that needs to be done to get this merged :+1: 