### PR TITLE
Add some GitHub actions

### DIFF
--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -1,0 +1,11 @@
+name: Codesniffer
+on: [pull_request]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Composer dependencies
+              run: composer install
+            - name: PHPCS check
+              uses: chekalsky/phpcs-action@v1

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,11 @@
+name: static analysis
+on: [pull_request]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Phpstan check
+              uses: OskarStark/phpstan-ga@0.12.75
+              with:
+                  args: analyse src/ --level 4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,14 @@
+name: PHPUnit
+on: [pull_request]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Composer dependencies
+              run: composer install
+            - name: Configure matchers
+              uses: mheap/phpunit-matcher-action@v1
+            - name: Run Tests
+              run: ./vendor/bin/phpunit --teamcity
+


### PR DESCRIPTION
Adds actions for phpunit, phpstan, and codesniffer.

Does not fully implement the matrices and OS X/Windows support of the TravisCI configuration, that will come later.