### PR TITLE
Fix deprecated method in TreeBuilder

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('sculpin_content_types');
 
-        $rootNode = $treeBuilder->root('sculpin_content_types');
+        $rootNode = $treeBuilder->getRootNode();
 
         $contentTypeNode = $rootNode
             ->useAttributeAsKey('name')

--- a/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/MarkdownBundle/DependencyInjection/Configuration.php
@@ -27,9 +27,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin_markdown');
 
-        $rootNode = $treeBuilder->root('sculpin_markdown');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PaginationBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin_pagination');
 
-        $rootNode = $treeBuilder->root('sculpin_pagination');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/PostsBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin_posts');
 
-        $rootNode = $treeBuilder->root('sculpin_posts');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/SculpinBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ final class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin');
 
-        $rootNode = $treeBuilder->root('sculpin');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TextileBundle/DependencyInjection/Configuration.php
@@ -27,9 +27,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin_textile');
 
-        $rootNode = $treeBuilder->root('sculpin_textile');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/ThemeBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin_theme');
 
-        $rootNode = $treeBuilder->root('sculpin_theme');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Sculpin/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration implements ConfigurationInterface
     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder;
+        $treeBuilder = new TreeBuilder('sculpin_twig');
 
-        $rootNode = $treeBuilder->root('sculpin_twig');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
This PR attempts to fix deprecated `root` method in TreeBuilder.
Since Symfony 4.3, it is deprecated to use `root` method in TreeBuilder to set the rootNode.
Referencing: [New in Symfony 4\.2: Important deprecations \(Symfony Blog\)](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes)