### PR TITLE
Make path to bin/sculpin.php absolute

### DIFF
--- a/bin/sculpin
+++ b/bin/sculpin
@@ -19,4 +19,4 @@ if (
     exit(1);
 }
 
-include 'sculpin.php';
+include __DIR__ . '/sculpin.php';


### PR DESCRIPTION
Composer on WSL/Windows creates proxies in vendor/bin. This leads to
weird include behaviour, so by making the path to bin/sculpin.php
absolute, we force the include of the right file.