### PR TITLE
Fix permalink generation on PHP 8 when //TRANSLIT isn't supported

### DIFF
--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -215,7 +215,12 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
     {
         $param = trim($param);
         if (function_exists('iconv')) {
-            $param = @iconv('utf-8', 'us-ascii//TRANSLIT', $param);
+            // Try to transliterate accented characters
+            $converted = @iconv('utf-8', 'us-ascii//TRANSLIT', $param);
+            // Only overwrite $param if conversion was successful
+            if ($converted !== false) {
+                $param = $converted;
+            }
         }
         $param = preg_replace('/[^a-zA-Z0-9 -]/', '', $param);
         $param = strtolower($param);


### PR DESCRIPTION
Alpine Linux (and possibly other environments?) don't support the use of `//TRANSLIT` and `//IGNORE` in `iconv()` calls. When those modifiers are used in an unsupported environment, `iconv()` emits a warning and returns `FALSE`.

Reference: https://github.com/docker-library/php/issues/240#issuecomment-250213168

During permalink generation in Sculpin, that behavior causes `FALSE` to be passed to the subsequent call to `preg_replace()` — which throws a fatal error in PHP 8 when strict type-checking is enabled.

This patch ensures that if `iconv()`conversion fails, the original `$param` value is used instead.