### PR TITLE
Add PHP attributes to suppress some PHP 8.1 deprecation notices

### DIFF
--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
@@ -31,6 +31,7 @@ class ProxySourceCollection implements \ArrayAccess, \Iterator, \Countable
         $this->sorter = $sorter ?: new DefaultSorter;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -40,46 +41,55 @@ class ProxySourceCollection implements \ArrayAccess, \Iterator, \Countable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->items[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->items[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->items[$offset]) ? $this->items[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return next($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->current() !== false;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -109,6 +109,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         $this->setHasChanged();
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -127,11 +128,13 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ! method_exists($this, $offset) && null !== $this->data()->get($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (! method_exists($this, $offset)) {
@@ -142,6 +145,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (method_exists($this, $offset)) {

--- a/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
+++ b/src/Sculpin/Core/Permalink/SourcePermalinkFactory.php
@@ -107,14 +107,14 @@ class SourcePermalinkFactory implements SourcePermalinkFactoryInterface
                 $permalink = preg_replace('/:mo/', $mo, $permalink);
                 $permalink = preg_replace('/:day/', $day, $permalink);
                 $permalink = preg_replace('/:dy/', $dy, $permalink);
-                $permalink = preg_replace('/:title/', $this->normalize($title), $permalink);
-                $permalink = preg_replace('/:slug_title/', $slug ?: $this->normalize($title), $permalink);
+                $permalink = preg_replace('/:title/', $this->normalize((string)$title), $permalink);
+                $permalink = preg_replace('/:slug_title/', $slug ?: $this->normalize((string)$title), $permalink);
                 $filename = $pathname;
                 if ($isDatePath = $this->isDatePath($pathname)) {
                     $filename = $isDatePath[3];
                 }
                 $permalink = preg_replace('/:filename/', $filename, $permalink);
-                $permalink = preg_replace('/:slug_filename/', $slug ?: $this->normalize($filename), $permalink);
+                $permalink = preg_replace('/:slug_filename/', $slug ?: $this->normalize((string)$filename), $permalink);
                 if (strrpos($filename, DIRECTORY_SEPARATOR) !== false) {
                     $basename = substr($filename, strrpos($filename, DIRECTORY_SEPARATOR)+1);
                 } else {


### PR DESCRIPTION
- ArrayAccess interface has change to implement `mixed` types
  on the methods. This may create a BC break with people using
  Sculpin on PHP 7.x, which the project is not yet prepared to do.
  Therefore, it is preferable to use the attributes for now.