### PR TITLE
add .php-version and .phpunit.result.cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __BlankSculpinProject__/
 __SculpinTestProject__/
 output_test/
 clover.xml
+.php-version
+.phpunit.result.cache


### PR DESCRIPTION
I added `.phpunit.result.cache` and `.php-version` to gitignore.

`.php-version` is a file that is required when using `phpenv`.