### PR TITLE
Replace mime type detection package for PHP 8.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^7.3",
+        "php": "^8.0 || ^7.4",
         "ext-mbstring": "*",
+        "ext-fileinfo": "*",
         "dflydev/ant-path-matcher": "^1.0.3",
         "dflydev/apache-mime-types": "^1.0.1",
-        "dflydev/canal": "^1.0",
         "dflydev/dot-access-configuration": "^1.0.3",
         "doctrine/inflector": "^1.3",
+        "league/mime-type-detection": "^1.13.0",
         "michelf/php-markdown": "^1.9",
         "netcarver/textile": "^3.6",
         "react/http": "^1.0",

--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -62,17 +62,10 @@
             <argument type="service" id="sculpin.custom_mime_types_repository" />
         </service>
 
-        <service id="sculpin.canal.default_detector" class="Dflydev\Canal\Detector\ApacheMimeTypesExtensionDetector" />
-
-        <service id="sculpin.canal.detector" class="Dflydev\Canal\Detector\CompositeDetector">
-            <argument type="collection">
-                <argument type="service" id="sculpin.canal.custom_detector" />
-                <argument type="service" id="sculpin.canal.default_detector" />
-            </argument>
-        </service>
-
-        <service id="sculpin.canal.analyzer" class="Dflydev\Canal\Analyzer\Analyzer">
-            <argument type="service" id="sculpin.canal.detector" />
+        <service id="sculpin.mime.detector" class="League\MimeTypeDetection\FinfoMimeTypeDetector">
+            <argument></argument>
+            <argument>NULL</argument>
+            <argument>200</argument>
         </service>
 
         <service id="sculpin.default_filesystem_data_source" class="Sculpin\Core\Source\FilesystemDataSource">
@@ -81,7 +74,7 @@
             <argument>%sculpin.ignore%</argument>
             <argument>%sculpin.raw%</argument>
             <argument type="service" id="sculpin.matcher" />
-            <argument type="service" id="sculpin.canal.analyzer" />
+            <argument type="service" id="sculpin.mime.detector" />
             <tag name="sculpin.data_source" />
         </service>
 

--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sculpin\Core\Source;
 
-use Dflydev\Canal\Analyzer\Analyzer;
+use League\MimeTypeDetection\MimeTypeDetector;
 use Symfony\Component\Finder\Finder;
 use dflydev\util\antPathMatcher\AntPathMatcher;
 use Sculpin\Core\Util\DirectorySeparatorNormalizer;
@@ -50,9 +50,9 @@ final class FilesystemDataSource implements DataSourceInterface
     private $pathMatcher;
 
     /**
-     * @var Analyzer
+     * @var MimeTypeDetector
      */
-    private $analyzer;
+    private $detector;
 
     /**
      * @var DirectorySeparatorNormalizer
@@ -75,7 +75,7 @@ final class FilesystemDataSource implements DataSourceInterface
         array $ignorePaths,
         array $rawPaths,
         AntPathMatcher $matcher = null,
-        Analyzer $analyzer = null,
+        MimeTypeDetector $detector = null,
         DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
     ) {
         $this->sourceDir = $sourceDir;
@@ -83,7 +83,7 @@ final class FilesystemDataSource implements DataSourceInterface
         $this->ignorePaths = $ignorePaths;
         $this->rawPaths = $rawPaths;
         $this->pathMatcher = $matcher ?: new AntPathMatcher;
-        $this->analyzer = $analyzer;
+        $this->detector = $detector;
         $this->directorySeparatorNormalizer = $directorySeparatorNormalizer ?: new DirectorySeparatorNormalizer;
         $this->sinceTime = '1970-01-01T00:00:00Z';
     }
@@ -172,7 +172,7 @@ final class FilesystemDataSource implements DataSourceInterface
                 }
             }
 
-            $source = new FileSource($this->analyzer, $this, $file, $isRaw, true);
+            $source = new FileSource($this->detector, $this, $file, $isRaw, true);
             $sourceSet->mergeSource($source);
         }
 

--- a/src/Sculpin/Core/Tests/Source/FileSourceTest.php
+++ b/src/Sculpin/Core/Tests/Source/FileSourceTest.php
@@ -3,12 +3,10 @@
 declare(strict_types=1);
 namespace Sculpin\Core\Tests\Source;
 
-use Dflydev\Canal\Analyzer\Analyzer;
+use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use PHPUnit\Framework\TestCase;
 use Sculpin\Core\Source\FileSource;
 use Symfony\Component\Finder\SplFileInfo;
-use Dflydev\Canal\InternetMediaType\InternetMediaTypeInterface;
-use Dflydev\Canal\InternetMediaType\InternetMediaTypeFactory;
 use Sculpin\Core\Source\DataSourceInterface;
 
 class FileSourceTest extends TestCase
@@ -20,7 +18,7 @@ class FileSourceTest extends TestCase
     public function makeTestSource($filename, $hasChanged = true)
     {
         $source = new FileSource(
-            $this->makeTestAnalyzer(),
+            $this->makeTestDetector(),
             $this->makeTestDatasource(),
             new SplFileInfo($filename, '../Fixtures', $filename),
             false,
@@ -30,45 +28,15 @@ class FileSourceTest extends TestCase
         return $source;
     }
 
-    public function makeTestAnalyzer()
+    public function makeTestDetector()
     {
-        $analyzer = $this->createMock(Analyzer::class);
-
-        $analyzer
+        $detector = $this->createMock(FinfoMimeTypeDetector::class);
+        $detector
             ->expects($this->any())
-            ->method('getInternetMediaTypeFactory')
-            ->will($this->returnValue($this->makeTestInternetMediaFactory()));
+            ->method('detectMimeType')
+            ->will($this->returnValue('text/yml'));
 
-        $analyzer
-            ->expects($this->any())
-            ->method('detectFromFilename')
-            ->will($this->returnValue($this->makeTestInternetMediaType()));
-
-        return $analyzer;
-    }
-
-    public function makeTestInternetMediaType()
-    {
-        $type = $this->createMock(InternetMediaTypeInterface::class);
-
-        $type
-            ->expects($this->any())
-            ->method('getType')
-            ->will($this->returnValue('text'));
-
-        return $type;
-    }
-
-    public function makeTestInternetMediaFactory()
-    {
-        $factory = $this->createMock(InternetMediaTypeFactory::class);
-
-        $factory
-            ->expects($this->any())
-            ->method('createApplicationXml')
-            ->will($this->returnValue('html/yml'));
-
-        return $factory;
+        return $detector;
     }
 
     public function makeTestDatasource()


### PR DESCRIPTION
[Dflydev\Canal](https://github.com/dflydev/dflydev-canal/) is not fully compatible with PHP 8.2, which makes Sculpin also not compatible.
So first I upgraded Canal https://github.com/dflydev/dflydev-canal/pull/1, but @dflydev suggested that the package is not maintained and might be good to replace it or find a maintainer.

[thephpleague/mime-type-detection](https://github.com/thephpleague/mime-type-detection) package is simpler, but has the same purpose and seems to be good enough for Sculpin, and most importantly, actively maintained.

This, however, bumps the minimal PHP version to 7.4. But since 7 has reached end-of-life anyway, it makes sense to just leave 8.0.