### PR TITLE
Update heredoc indents

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
@@ -69,16 +69,16 @@ final class ContentCreateCommand extends AbstractCommand
         );
 
         $this->setHelp(<<<EOT
-The <info>content:create</info> command helps you create a custom content type and the associated boilerplate/templates.
+            The <info>content:create</info> command helps you create a custom content type and the associated boilerplate/templates.
 
-Example:
+            Example:
 
-      vendor/bin/sculpin content:create docs -t product -t year
+                  vendor/bin/sculpin content:create docs -t product -t year
 
-NOTE: This command does not automatically modify the <info>app/config/sculpin_kernel.yml</info> file. You will have to
-      add the suggested changes yourself.
+            NOTE: This command does not automatically modify the <info>app/config/sculpin_kernel.yml</info> file. You will have to
+                  add the suggested changes yourself.
 
-EOT
+            EOT
         );
     }
 
@@ -186,19 +186,19 @@ EOT
     {
         $outputMessage = <<<EOT
 
-YAML content type definition you will have to
-add to <info>app/config/sculpin_kernel.yml</info>:
-================START OF YAML================
+        YAML content type definition you will have to
+        add to <info>app/config/sculpin_kernel.yml</info>:
+        ================START OF YAML================
 
-sculpin_content_types:
-    {$type}:
-        type: path
-        path: _{$type}
-        singular_name: {$singularType}
-        layout: {$singularType}
-        enabled: true
-        permalink: {$type}/:title
-EOT;
+        sculpin_content_types:
+            {$type}:
+                type: path
+                path: _{$type}
+                singular_name: {$singularType}
+                layout: {$singularType}
+                enabled: true
+                permalink: {$type}/:title
+        EOT;
         if ($taxonomies) {
             $outputMessage .= "\n        taxonomies:\n";
             foreach ($taxonomies as $taxonomy) {
@@ -216,51 +216,51 @@ EOT;
         $title = ucfirst($plural);
 
         return <<<EOT
----
-layout: default
-title: $title
-generator: pagination
-pagination:
-    provider: data.$plural
-    max_per_page: 10
-use: [$plural]
----
-<ul>
-    {% for $singular in page.pagination.items %}
-        <li><a href="{{ $singular.url }}">{{ $singular.title }}</a></li>
-    {% endfor %}
-</ul>
+        ---
+        layout: default
+        title: $title
+        generator: pagination
+        pagination:
+            provider: data.$plural
+            max_per_page: 10
+        use: [$plural]
+        ---
+        <ul>
+            {% for $singular in page.pagination.items %}
+                <li><a href="{{ $singular.url }}">{{ $singular.title }}</a></li>
+            {% endfor %}
+        </ul>
 
-<nav>
-    {% if page.pagination.previous_page or page.pagination.next_page %}
-    {% if page.pagination.previous_page %}
-    <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
-    {% endif %}
-    {% if page.pagination.next_page %}
-    <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
-    {% endif %}
-    {% endif %}
-</nav>
-EOT;
+        <nav>
+            {% if page.pagination.previous_page or page.pagination.next_page %}
+            {% if page.pagination.previous_page %}
+            <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
+            {% endif %}
+            {% if page.pagination.next_page %}
+            <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
+            {% endif %}
+            {% endif %}
+        </nav>
+        EOT;
     }
 
     private function getViewTemplate(string $plural, array $taxonomies = []): string
     {
         $output = <<<EOT
-{% extends 'default' %}
+        {% extends 'default' %}
 
-{% block content_wrapper %}
-<article>
-  <header>
-    <h2>{{ page.title }}</h2>
-  {% if page.subtitle %}
-    <h3 class="subtitle">{{ page.subtitle }}</h3>
-  {% endif %}
-  </header>
-  <section class="main_body">
-    {{ page.blocks.content|raw }}
-  </section>
-EOT;
+        {% block content_wrapper %}
+        <article>
+          <header>
+            <h2>{{ page.title }}</h2>
+          {% if page.subtitle %}
+            <h3 class="subtitle">{{ page.subtitle }}</h3>
+          {% endif %}
+          </header>
+          <section class="main_body">
+            {{ page.blocks.content|raw }}
+          </section>
+        EOT;
 
         if ($taxonomies) {
             $output .= "\n" . '  <section class="taxonomies">' . "\n";
@@ -269,27 +269,27 @@ EOT;
                 $capitalTaxonomy  = ucwords($taxonomy);
                 $singularTaxonomy = Inflector::singularize($taxonomy);
                 $output .= <<<EOT
-    <div class="taxonomy">
-        <a href="{{site.url }}/{$plural}/{$taxonomy}">{$capitalTaxonomy}</a>:
-        {% for {$singularTaxonomy} in page.{$taxonomy} %}
-        <a href="{{ site.url }}/{$plural}/{$taxonomy}/{{ {$singularTaxonomy} }}">
-            {{ {$singularTaxonomy} }}
-        </a>{% if not loop.last %}, {% endif %}
-        {% endfor %}
-      </div>
-EOT;
+                    <div class="taxonomy">
+                        <a href="{{site.url }}/{$plural}/{$taxonomy}">{$capitalTaxonomy}</a>:
+                        {% for {$singularTaxonomy} in page.{$taxonomy} %}
+                        <a href="{{ site.url }}/{$plural}/{$taxonomy}/{{ {$singularTaxonomy} }}">
+                            {{ {$singularTaxonomy} }}
+                        </a>{% if not loop.last %}, {% endif %}
+                        {% endfor %}
+                      </div>
+                EOT;
             }
 
             $output .= "\n" . '  </section>' . "\n";
         }
 
         $output .= <<<EOT
-  <footer>
-    <p class="published_date">Published: {{page.date|date('F j, Y')}}</p>
-  </footer>
-</article>
-{% endblock content_wrapper %}
-EOT;
+          <footer>
+            <p class="published_date">Published: {{page.date|date('F j, Y')}}</p>
+          </footer>
+        </article>
+        {% endblock content_wrapper %}
+        EOT;
 
         return $output;
     }
@@ -302,19 +302,19 @@ EOT;
         $title = ucfirst($taxonomy);
 
         return <<<EOT
----
-layout: default
-use: [{$plural}_{$taxonomy}]
----
-<h1>{$title}</h1>
-<ul>
-    {% for {$singularTaxonomy},{$plural} in data.{$plural}_{$taxonomy} %}
-        <li>
-            <a href="/{$plural}/{$taxonomy}/{{ {$singularTaxonomy}|url_encode(true) }}">{{ {$singularTaxonomy} }}</a>
-        </li>
-    {% endfor %}
-</ul>
-EOT;
+        ---
+        layout: default
+        use: [{$plural}_{$taxonomy}]
+        ---
+        <h1>{$title}</h1>
+        <ul>
+            {% for {$singularTaxonomy},{$plural} in data.{$plural}_{$taxonomy} %}
+                <li>
+                    <a href="/{$plural}/{$taxonomy}/{{ {$singularTaxonomy}|url_encode(true) }}">{{ {$singularTaxonomy} }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+        EOT;
     }
 
     private function getTaxonomyViewTemplate(
@@ -325,30 +325,30 @@ EOT;
         $title = ucfirst($plural);
 
         return <<<EOT
----
-layout: default
-generator: [{$plural}_{$singularTaxonomy}_index, pagination]
-pagination:
-    provider: page.{$singularTaxonomy}_{$plural}
-    max_per_page: 10
----
-<h1>{{ page.{$singularTaxonomy}|capitalize }}</h1>
-<ul>
-    {% for {$singular} in page.pagination.items %}
-        <li><a href="{{ {$singular}.url }}">{{ {$singular}.title }}</a></li>
-    {% endfor %}
-</ul>
+        ---
+        layout: default
+        generator: [{$plural}_{$singularTaxonomy}_index, pagination]
+        pagination:
+            provider: page.{$singularTaxonomy}_{$plural}
+            max_per_page: 10
+        ---
+        <h1>{{ page.{$singularTaxonomy}|capitalize }}</h1>
+        <ul>
+            {% for {$singular} in page.pagination.items %}
+                <li><a href="{{ {$singular}.url }}">{{ {$singular}.title }}</a></li>
+            {% endfor %}
+        </ul>
 
-<nav>
-    {% if page.pagination.previous_page or page.pagination.next_page %}
-    {% if page.pagination.previous_page %}
-    <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
-    {% endif %}
-    {% if page.pagination.next_page %}
-    <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
-    {% endif %}
-    {% endif %}
-</nav>
-EOT;
+        <nav>
+            {% if page.pagination.previous_page or page.pagination.next_page %}
+            {% if page.pagination.previous_page %}
+            <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
+            {% endif %}
+            {% if page.pagination.next_page %}
+            <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
+            {% endif %}
+            {% endif %}
+        </nav>
+        EOT;
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ContainerDebugCommand.php
@@ -74,36 +74,36 @@ final class ContainerDebugCommand extends ContainerAwareCommand
                 )
             ])
             ->setDescription('Displays current services for an application')
-            ->setHelp(<<<EOF
-The <info>%command.name%</info> command displays all configured <comment>public</comment> services:
+            ->setHelp(<<<EOT
+            The <info>%command.name%</info> command displays all configured <comment>public</comment> services:
 
-  <info>php %command.full_name%</info>
+              <info>php %command.full_name%</info>
 
-To get specific information about a service, specify its name:
+            To get specific information about a service, specify its name:
 
-  <info>php %command.full_name% validator</info>
+              <info>php %command.full_name% validator</info>
 
-By default, private services are hidden. You can display all services by
-using the --show-private flag:
+            By default, private services are hidden. You can display all services by
+            using the --show-private flag:
 
-  <info>php %command.full_name% --show-private</info>
+              <info>php %command.full_name% --show-private</info>
 
-Use the --tags option to display tagged <comment>public</comment> services grouped by tag:
+            Use the --tags option to display tagged <comment>public</comment> services grouped by tag:
 
-  <info>php %command.full_name% --tags</info>
+              <info>php %command.full_name% --tags</info>
 
-Find all services with a specific tag by specifying the tag name with the --tag option:
+            Find all services with a specific tag by specifying the tag name with the --tag option:
 
-  <info>php %command.full_name% --tag=form.type</info>
+              <info>php %command.full_name% --tag=form.type</info>
 
-Use the --parameters option to display all parameters:
+            Use the --parameters option to display all parameters:
 
-  <info>php %command.full_name% --parameters</info>
+              <info>php %command.full_name% --parameters</info>
 
-Display a specific parameter by specifying his name with the --parameter option:
+            Display a specific parameter by specifying his name with the --parameter option:
 
-  <info>php %command.full_name% --parameter=kernel.debug</info>
-EOF
+              <info>php %command.full_name% --parameter=kernel.debug</info>
+            EOT
             )
         ;
     }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -77,9 +77,9 @@ class GenerateCommand extends AbstractCommand
                 new InputOption('source-dir', null, InputOption::VALUE_REQUIRED, 'Source Directory'),
             ])
             ->setHelp(<<<EOT
-The <info>generate</info> command generates a site.
+            The <info>generate</info> command generates a site.
 
-EOT
+            EOT
             );
     }
 

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -57,9 +57,9 @@ final class InitCommand extends AbstractCommand
                 ),
             ])
             ->setHelp(<<<EOT
-The <info>init</info> command initializes a default site configuration.
+            The <info>init</info> command initializes a default site configuration.
 
-EOT
+            EOT
             );
     }
 
@@ -128,20 +128,20 @@ EOT
 
     private function createDefaultKernel(string $projectDir, OutputInterface $output): bool
     {
-        $contents = <<<EOF
-<?php
+        $contents = <<<EOT
+        <?php
 
-class SculpinKernel extends \Sculpin\Bundle\SculpinBundle\HttpKernel\AbstractKernel
-{
-    protected function getAdditionalSculpinBundles(): array
-    {
-        return [
-//            'App\\Bundle\\ExampleBundle\\AppExampleBundle'
-        ];
-    }
-}
+        class SculpinKernel extends \Sculpin\Bundle\SculpinBundle\HttpKernel\AbstractKernel
+        {
+            protected function getAdditionalSculpinBundles(): array
+            {
+                return [
+        //            'App\\Bundle\\ExampleBundle\\AppExampleBundle'
+                ];
+            }
+        }
 
-EOF;
+        EOT;
         $this->createFile($projectDir . '/app/SculpinKernel.php', $contents);
 
         return true;
@@ -149,12 +149,12 @@ EOF;
 
     private function createSiteKernelFile(string $projectDir, OutputInterface $output): bool
     {
-        $contents = <<<EOF
-sculpin_content_types:
-    posts:
-      enabled: false
+        $contents = <<<EOT
+        sculpin_content_types:
+            posts:
+              enabled: false
 
-EOF;
+        EOT;
         $this->createFile($projectDir . '/app/config/sculpin_kernel.yml', $contents);
 
         return true;
@@ -166,13 +166,13 @@ EOF;
         string $subTitle,
         OutputInterface $output
     ): bool {
-        $contents = <<<EOF
-title: "$title"
-subtitle: "$subTitle"
-google_analytics_tracking_id: ''
-url: ''
+        $contents = <<<EOT
+        title: "$title"
+        subtitle: "$subTitle"
+        google_analytics_tracking_id: ''
+        url: ''
 
-EOF;
+        EOT;
         $this->createFile($projectDir . '/app/config/sculpin_site.yml', $contents);
 
         return true;
@@ -184,27 +184,27 @@ EOF;
 
         $fs->dumpFile(
             $projectDir . '/source/index.md',
-            <<<EOF
----
-layout: default
----
+            <<<EOT
+            ---
+            layout: default
+            ---
 
-<h1>Welcome to {{site.title}}</h1>
+            <h1>Welcome to {{site.title}}</h1>
 
-EOF
+            EOT
         );
 
         $fs->dumpFile(
             $projectDir . '/source/_views/default.html',
-            <<<EOF
-<html>
-<head><title>{{site.title}}</title></head>
-<body>
-{% block content_wrapper %}{% block content '' %}{% endblock content_wrapper %}
-</body>
-</html>
+            <<<EOT
+            <html>
+            <head><title>{{site.title}}</title></head>
+            <body>
+            {% block content_wrapper %}{% block content '' %}{% endblock content_wrapper %}
+            </body>
+            </html>
 
-EOF
+            EOT
         );
 
         return true;

--- a/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/ServeCommand.php
@@ -37,9 +37,9 @@ class ServeCommand extends AbstractCommand
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Port'),
             ])
             ->setHelp(<<<EOT
-The <info>serve</info> command serves a site.
+            The <info>serve</info> command serves a site.
 
-EOT
+            EOT
             )->setAliases(['server']);
     }
 

--- a/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
+++ b/src/Sculpin/Bundle/StandaloneBundle/Command/CacheClearCommand.php
@@ -36,14 +36,14 @@ class CacheClearCommand extends ContainerAwareCommand
         $this
             ->setName('cache:clear')
             ->setDescription('Clears the cache')
-            ->setHelp(<<<EOF
-The <info>%command.name%</info> command clears the application cache for a given environment
-and debug mode:
+            ->setHelp(<<<EOT
+            The <info>%command.name%</info> command clears the application cache for a given environment
+            and debug mode:
 
-<info>php %command.full_name% --env=dev</info>
-<info>php %command.full_name% --env=prod --no-debug</info>
+            <info>php %command.full_name% --env=dev</info>
+            <info>php %command.full_name% --env=prod --no-debug</info>
 
-EOF
+            EOT
             )
         ;
     }

--- a/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
+++ b/src/Sculpin/Bundle/ThemeBundle/Command/ListCommand.php
@@ -31,9 +31,9 @@ class ListCommand extends ContainerAwareCommand
             ->setName('theme:list')
             ->setDescription('List currently installed themes.')
             ->setHelp(<<<EOT
-The <info>theme:list</info> command lists currently installed themes.
+            The <info>theme:list</info> command lists currently installed themes.
 
-EOT
+            EOT
             );
     }
 

--- a/src/Sculpin/Tests/Functional/GenerateFromMarkdownTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromMarkdownTest.php
@@ -42,18 +42,18 @@ class GenerateFromMarkdownTest extends FunctionalTestCase
     public function shouldGenerateHtmlUsingALayout()
     {
         $this->addProjectFile('/source/_layouts/my_layout.html.twig', <<<EOT
-<body>
-	<div class="page-content">{% block content %}{% endblock content %}</div>
-</body>
-EOT
+        <body>
+            <div class="page-content">{% block content %}{% endblock content %}</div>
+        </body>
+        EOT
         );
 
         $this->addProjectFile('/source/my_page_with_layout.md', <<<EOT
----
-layout: my_layout.html.twig
----
-Hello World
-EOT
+        ---
+        layout: my_layout.html.twig
+        ---
+        Hello World
+        EOT
         );
 
         $this->executeSculpin('generate');
@@ -80,18 +80,18 @@ EOT
         $expectedContent = 'Hello World';
 
         $layoutContent = <<<EOT
-<body>
-    <h1 class="header">{$expectedHeader}</h1>
-	<div class="page-content">{% block content %}{% endblock content %}</div>
-</body>
-EOT;
+        <body>
+            <h1 class="header">{$expectedHeader}</h1>
+            <div class="page-content">{% block content %}{% endblock content %}</div>
+        </body>
+        EOT;
 
         $pageContent = <<<EOT
----
-layout: my_layout.html.twig
----
-{$expectedContent}
-EOT;
+        ---
+        layout: my_layout.html.twig
+        ---
+        {$expectedContent}
+        EOT;
 
         $this->addProjectFile($layoutFile, $layoutContent);
         $this->addProjectFile($pageFile, $pageContent);
@@ -186,11 +186,11 @@ EOT;
         $this->addProjectDirectory(__DIR__ . '/Fixture/source/_posts');
         $this->writeToProjectFile(
             '/app/config/sculpin_kernel.yml',
-            <<<EOF
-sculpin_content_types:
-  posts:
-    permalink: blog/:basename
-EOF
+            <<<EOT
+            sculpin_content_types:
+              posts:
+                permalink: blog/:basename
+            EOT
         );
 
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.md', '/source/_posts/hello_world');
@@ -223,11 +223,11 @@ EOF
         $this->addProjectDirectory(__DIR__ . '/Fixture/source/_posts');
         $this->writeToProjectFile(
             '/app/config/sculpin_kernel.yml',
-            <<<EOF
-sculpin_content_types:
-  posts:
-    permalink: blog/:basename
-EOF
+            <<<EOT
+            sculpin_content_types:
+              posts:
+                permalink: blog/:basename
+            EOT
         );
 
         $this->addProjectFile('/source/_posts/.DS_Store');


### PR DESCRIPTION
Since PHP7.3, we've been able to use heredoc indentation to clean up these sorts of inline references.

### Changes:

- HEREDOCs are reindented so as not to be at col(0) position
- HEREDOC label is standardized to `EOT` (End Of Text)