### PR TITLE
Fix `projectDir`

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpKernel/AbstractKernel.php
@@ -28,7 +28,6 @@ abstract class AbstractKernel extends Kernel
     protected $outputDir;
     protected $projectDir;
     protected $sourceDir;
-    protected string $rootDir;
 
     /**
      * {@inheritdoc}
@@ -39,10 +38,6 @@ abstract class AbstractKernel extends Kernel
         $this->outputDir  = $overrides['outputDir']  ?? null;
         $this->sourceDir  = $overrides['sourceDir']  ?? null;
 
-        if (null !== $this->projectDir) {
-            $this->rootDir = $this->projectDir . '/app';
-        }
-
         parent::__construct($environment, $debug);
     }
 
@@ -51,10 +46,6 @@ abstract class AbstractKernel extends Kernel
      */
     protected function getKernelParameters(): array
     {
-        if (null === $this->projectDir) {
-            $this->projectDir = dirname($this->rootDir);
-        }
-
         return array_merge(parent::getKernelParameters(), [
             'sculpin.project_dir'         => $this->projectDir,
             'sculpin.output_dir_override' => $this->outputDir,
@@ -99,9 +90,9 @@ abstract class AbstractKernel extends Kernel
         // Load defaults.
         $loader->load(__DIR__.'/../Resources/config/kernel.yml');
 
-        if (file_exists($file = $this->rootDir.'/config/sculpin_kernel_'.$this->getEnvironment().'.yml')) {
+        if (file_exists($file = $this->getProjectDir().'/app/config/sculpin_kernel_'.$this->getEnvironment().'.yml')) {
             $loader->load($file);
-        } elseif (file_exists($file = $this->rootDir.'/config/sculpin_kernel.yml')) {
+        } elseif (file_exists($file = $this->getProjectDir().'/app/config/sculpin_kernel.yml')) {
             $loader->load($file);
         }
     }
@@ -129,8 +120,8 @@ abstract class AbstractKernel extends Kernel
         $container->addObjectResource($this);
         $this->prepareContainer($container);
 
-        if (file_exists($this->rootDir.'/config/sculpin_services.yml')) {
-            $loader = new YamlFileLoader($container, new FileLocator($this->rootDir.'/config'));
+        if (file_exists($this->getProjectDir().'/app/config/sculpin_services.yml')) {
+            $loader = new YamlFileLoader($container, new FileLocator($this->getProjectDir().'/app/config'));
             $loader->load('sculpin_services.yml');
         }
 
@@ -165,6 +156,16 @@ abstract class AbstractKernel extends Kernel
     public function getMissingSculpinBundles(): array
     {
         return $this->missingSculpinBundles;
+    }
+
+    /**
+     * Gets the application root dir (path of the project's composer file).
+     *
+     * @return string
+     */
+    public function getProjectDir(): ?string
+    {
+        return $this->projectDir;
     }
 
     /**

--- a/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
+++ b/src/Sculpin/Core/SiteConfiguration/SiteConfigurationFactory.php
@@ -25,16 +25,16 @@ final class SiteConfigurationFactory
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var string
      */
     private $environment;
 
-    public function __construct(string $rootDir, string $environment)
+    public function __construct(string $projectDir, string $environment)
     {
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->environment = $environment;
     }
 
@@ -71,11 +71,11 @@ final class SiteConfigurationFactory
      */
     public function detectConfig(): ConfigurationInterface
     {
-        if (file_exists($file = $this->rootDir.'/config/sculpin_site_'.$this->environment.'.yml')) {
+        if (file_exists($file = $this->projectDir.'/app/config/sculpin_site_'.$this->environment.'.yml')) {
             return $this->getConfigFile($file);
         }
 
-        if (file_exists($file = $this->rootDir.'/config/sculpin_site.yml')) {
+        if (file_exists($file = $this->projectDir.'/app/config/sculpin_site.yml')) {
             return $this->getConfigFile($file);
         }
 

--- a/src/Sculpin/Tests/Functional/Fixture/config/sculpin_site.yml
+++ b/src/Sculpin/Tests/Functional/Fixture/config/sculpin_site.yml
@@ -1,0 +1,2 @@
+title: "Test Project"
+subtitle: "Test Project Subtitle"

--- a/src/Sculpin/Tests/Functional/Fixture/source/hello_world.md
+++ b/src/Sculpin/Tests/Functional/Fixture/source/hello_world.md
@@ -2,3 +2,7 @@
 layout: raw.html.twig
 ---
 # Hello World
+
+title: "{{ site.title }}"
+
+subtitle: "{{ site.subtitle }}"

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -168,10 +168,11 @@ class FunctionalTestCase extends TestCase
     /**
      * @param string $fixturePath
      * @param string $projectPath
+     * @param bool $overwriteNewerFiles
      */
-    protected function copyFixtureToProject(string $fixturePath, string $projectPath): void
+    protected function copyFixtureToProject(string $fixturePath, string $projectPath, bool $overwriteNewerFiles = false): void
     {
-        static::$fs->copy($fixturePath, static::projectDir() . $projectPath);
+        static::$fs->copy($fixturePath, static::projectDir() . $projectPath, $overwriteNewerFiles);
     }
 
     /**

--- a/src/Sculpin/Tests/Functional/GenerateCommandTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateCommandTest.php
@@ -72,6 +72,22 @@ class GenerateCommandTest extends FunctionalTestCase
         $this->assertGeneratedFileHasContent($filePath, 'Testing JS /build/js/app.43dcc737.js');
     }
 
+    /** @test */
+    public function shouldGenerateUsingSiteVariables(): void
+    {
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/config/sculpin_site.yml', '/app/config/sculpin_site.yml', true);
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.md', '/source/hello_world.md');
+
+        $this->executeSculpin(['generate']);
+
+        $filePath = '/hello_world/index.html';
+        $msg      = "Expected project to have generated file at path $filePath.";
+
+        $this->assertProjectHasFile('/output_test' . $filePath, $msg);
+        $this->assertGeneratedFileHasContent($filePath, '<p>title: "Test Project"</p>');
+        $this->assertGeneratedFileHasContent($filePath, '<p>subtitle: "Test Project Subtitle"</p>');
+    }
+
     protected function configureForWebpack(): void
     {
         $this->writeToProjectFile(


### PR DESCRIPTION
@beryllium in `alpha2` I've encountered that the config is not loading properly
(e.g. `$this->configuration->get('title')` or `{{ site.title }}` was missing),
this should help.

Added a test to proof it.