### PR TITLE
[PHP 8.4] Updates to avoid implicit nulable parameter deprecation

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Console/Application.php
@@ -87,7 +87,7 @@ final class Application extends BaseApplication
     /**
      * {@inheritDoc}
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         if (null === $output) {
             $styles = [

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollection.php
@@ -25,7 +25,7 @@ class ProxySourceCollection implements \ArrayAccess, \Iterator, \Countable
     protected $items = [];
     protected $sorter;
 
-    public function __construct(array $items = [], SorterInterface $sorter = null)
+    public function __construct(array $items = [], ?SorterInterface $sorter = null)
     {
         $this->items = $items;
         $this->sorter = $sorter ?: new DefaultSorter;

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -40,10 +40,10 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         FormatterManager $formatterManager,
         $dataProviderName,
         $dataSingularName = null,
-        ProxySourceCollection $collection = null,
-        FilterInterface $filter = null,
-        MapInterface $map = null,
-        ProxySourceItemFactoryInterface $factory = null
+        ?ProxySourceCollection $collection = null,
+        ?FilterInterface $filter = null,
+        ?MapInterface $map = null,
+        ?ProxySourceItemFactoryInterface $factory = null
     ) {
         $this->formatterManager = $formatterManager;
         $this->dataProviderName = $dataProviderName;

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceItem.php
@@ -53,7 +53,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         return $this->data()->get('blocks');
     }
 
-    public function setBlocks(array $blocks = null)
+    public function setBlocks(?array $blocks = null)
     {
         $this->data()->set('blocks', $blocks ?: []);
     }
@@ -63,7 +63,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         return $this->previousItem;
     }
 
-    public function setPreviousItem(ProxySourceItem $item = null)
+    public function setPreviousItem(?ProxySourceItem $item = null)
     {
         $lastPreviousItem = $this->previousItem;
         $this->previousItem = $item;
@@ -86,7 +86,7 @@ class ProxySourceItem extends ProxySource implements \ArrayAccess
         return $this->nextItem;
     }
 
-    public function setNextItem(ProxySourceItem $item = null)
+    public function setNextItem(?ProxySourceItem $item = null)
     {
         $lastNextItem = $this->nextItem;
         $this->nextItem = $item;

--- a/src/Sculpin/Core/Console/Command/ContainerAwareCommand.php
+++ b/src/Sculpin/Core/Console/Command/ContainerAwareCommand.php
@@ -55,7 +55,7 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
      *
      * @see ContainerAwareInterface::setContainer()
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(?ContainerInterface $container = null)
     {
         $this->container = $container;
     }

--- a/src/Sculpin/Core/Formatter/FormatterManager.php
+++ b/src/Sculpin/Core/Formatter/FormatterManager.php
@@ -53,7 +53,7 @@ class FormatterManager
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         Configuration $siteConfiguration,
-        DataProviderManager $dataProviderManager = null
+        ?DataProviderManager $dataProviderManager = null
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->siteConfiguration = $siteConfiguration;
@@ -175,7 +175,7 @@ class FormatterManager
      *
      * @param DataProviderManager $dataProviderManager Data Provider Manager
      */
-    public function setDataProviderManager(DataProviderManager $dataProviderManager = null): void
+    public function setDataProviderManager(?DataProviderManager $dataProviderManager = null): void
     {
         $this->dataProviderManager = $dataProviderManager;
     }

--- a/src/Sculpin/Core/Generator/GeneratorManager.php
+++ b/src/Sculpin/Core/Generator/GeneratorManager.php
@@ -47,7 +47,7 @@ class GeneratorManager
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         Configuration $siteConfiguration,
-        DataProviderManager $dataProviderManager = null
+        ?DataProviderManager $dataProviderManager = null
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->siteConfiguration = $siteConfiguration;
@@ -117,7 +117,7 @@ class GeneratorManager
      * Manager via constructor injection as some data providers might also rely
      * on formatter. Hurray for circular dependencies. :(
      */
-    public function setDataProviderManager(DataProviderManager $dataProviderManager = null): void
+    public function setDataProviderManager(?DataProviderManager $dataProviderManager = null): void
     {
         $this->dataProviderManager = $dataProviderManager;
     }

--- a/src/Sculpin/Core/Sculpin.php
+++ b/src/Sculpin/Core/Sculpin.php
@@ -99,7 +99,7 @@ final class Sculpin
         $this->converterManager = $converterManager;
     }
 
-    public function run(DataSourceInterface $dataSource, SourceSet $sourceSet, IoInterface $io = null)
+    public function run(DataSourceInterface $dataSource, SourceSet $sourceSet, ?IoInterface $io = null)
     {
         if (null === $io) {
             $io = new NullIo();

--- a/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/ConfigFilesystemDataSource.php
@@ -53,7 +53,7 @@ final class ConfigFilesystemDataSource implements DataSourceInterface
         string $sourceDir,
         ConfigurationInterface $siteConfiguration,
         SiteConfigurationFactory $siteConfigurationFactory,
-        AntPathMatcher $pathMatcher = null
+        ?AntPathMatcher $pathMatcher = null
     ) {
         $this->sourceDir = $sourceDir;
         $this->siteConfiguration = $siteConfiguration;

--- a/src/Sculpin/Core/Source/FilesystemDataSource.php
+++ b/src/Sculpin/Core/Source/FilesystemDataSource.php
@@ -74,9 +74,9 @@ final class FilesystemDataSource implements DataSourceInterface
         array $excludePaths,
         array $ignorePaths,
         array $rawPaths,
-        AntPathMatcher $matcher = null,
-        MimeTypeDetector $detector = null,
-        DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
+        ?AntPathMatcher $matcher = null,
+        ?MimeTypeDetector $detector = null,
+        ?DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
     ) {
         $this->sourceDir = $sourceDir;
         $this->excludePaths = $excludePaths;

--- a/src/Sculpin/Core/Source/Filter/AntPathFilter.php
+++ b/src/Sculpin/Core/Source/Filter/AntPathFilter.php
@@ -28,8 +28,8 @@ class AntPathFilter implements FilterInterface
 
     public function __construct(
         array $paths,
-        AntPathMatcher $antPathMatcher = null,
-        DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
+        ?AntPathMatcher $antPathMatcher = null,
+        ?DirectorySeparatorNormalizer $directorySeparatorNormalizer = null
     ) {
         if (null === $antPathMatcher) {
             $antPathMatcher = new AntPathMatcher;


### PR DESCRIPTION
Fixes implicit nullable parameter deprecation messages on PHP 8.4.

 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

Nullable parameters are a PHP 7.1 feature, but our minimum PHP version requirement is PHP 7.1, so this is a safe change.