### PR TITLE
Fix handling of default port in generate+server mode

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
+++ b/src/Sculpin/Bundle/SculpinBundle/HttpServer/HttpServer.php
@@ -37,6 +37,10 @@ final class HttpServer
         private bool $debug,
         private int $port = self::DEFAULT_PORT
     ) {
+        if ($this->port === 0) {
+            $this->port = self::DEFAULT_PORT;
+        }
+
         $socketServer = $this->startSocketServer();
         $httpServer = $this->getHttpServer($docroot, $output);
 


### PR DESCRIPTION
PHP 8.5 updates broke the handling of "default port" in Generate Command, allowing a default port of 0 due to an (int) cast in the Command class.