### PR TITLE
Add Nix flake for local development

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766651565,
+        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          php
+          phpPackages.composer
+        ];
+      };
+    };
+}


### PR DESCRIPTION
This PR adds a Nix flake to use [Nix and nixpkgs][0] to create a reproducible development environment for Sculpin, and not rely on specifically installed versions by individual contributors or within CI pipelines.

With these files in place, running `nix develop` will create a development shell with the packages defined in flake.nix - locked to the versions defined in flake.lock.

The currently included packages are:

* PHP 8.4.15
* Composer 2.9.2

There are [multiple versions of PHP][1] available in nixpkgs, if another version would be better - but the PHPUnit tests and PHPStan checks all pass within this shell.

[0]: https://nixos.org
[1]: https://search.nixos.org/packages?channel=unstable&query=php