### PR TITLE
Fix PHPCS errors

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
@@ -69,14 +69,15 @@ final class ContentCreateCommand extends AbstractCommand
         );
 
         $this->setHelp(<<<EOT
-            The <info>content:create</info> command helps you create a custom content type and the associated boilerplate/templates.
+            The <info>content:create</info> command helps you create a custom content type and the associated
+                  boilerplate/templates.
 
             Example:
 
                   vendor/bin/sculpin content:create docs -t product -t year
 
-            NOTE: This command does not automatically modify the <info>app/config/sculpin_kernel.yml</info> file. You will have to
-                  add the suggested changes yourself.
+            NOTE: This command does not automatically modify the <info>app/config/sculpin_kernel.yml</info> file. You
+                  will have to add the suggested changes yourself.
 
             EOT
         );
@@ -310,7 +311,9 @@ final class ContentCreateCommand extends AbstractCommand
         <ul>
             {% for {$singularTaxonomy},{$plural} in data.{$plural}_{$taxonomy} %}
                 <li>
-                    <a href="/{$plural}/{$taxonomy}/{{ {$singularTaxonomy}|url_encode(true) }}">{{ {$singularTaxonomy} }}</a>
+                    <a href="/{$plural}/{$taxonomy}/{{ {$singularTaxonomy}|url_encode(true) }}">
+                        {{ {$singularTaxonomy} }}
+                    </a>
                 </li>
             {% endfor %}
         </ul>

--- a/src/Sculpin/Tests/Functional/FunctionalTestCase.php
+++ b/src/Sculpin/Tests/Functional/FunctionalTestCase.php
@@ -170,8 +170,11 @@ class FunctionalTestCase extends TestCase
      * @param string $projectPath
      * @param bool $overwriteNewerFiles
      */
-    protected function copyFixtureToProject(string $fixturePath, string $projectPath, bool $overwriteNewerFiles = false): void
-    {
+    protected function copyFixtureToProject(
+        string $fixturePath,
+        string $projectPath,
+        bool $overwriteNewerFiles = false,
+    ): void {
         static::$fs->copy($fixturePath, static::projectDir() . $projectPath, $overwriteNewerFiles);
     }
 


### PR DESCRIPTION
This PR fixes errors reported by PHPCS when ran with `composer run cs-check`:

```shell
$ composer run cs-check
.W..........................................................  60 / 157 (38%)
....W....................................................... 120 / 157 (76%)
.....................................                        157 / 157 (100%)

FILE: /home/opdavies/Repos/github.com/opdavies/sculpin/src/Sculpin/Tests/Functional/FunctionalTestCase.php
--------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------
 173 | WARNING | Line exceeds 120 characters; contains 126 characters
--------------------------------------------------------------------------------------------------------------

FILE: /home/opdavies/Repos/github.com/opdavies/sculpin/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
---------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
---------------------------------------------------------------------------------------------------------------------------------
  72 | WARNING | Line exceeds 120 characters; contains 132 characters
  78 | WARNING | Line exceeds 120 characters; contains 130 characters
 313 | WARNING | Line exceeds 120 characters; contains 125 characters
---------------------------------------------------------------------------------------------------------------------------------
```

After making the changes:

```
$ composer run cs-check
> phpcs
............................................................  60 / 157 (38%)
............................................................ 120 / 157 (76%)
.....................................                        157 / 157 (100%)
```