### PR TITLE
Improve init ux

### DIFF
--- a/craft.yml
+++ b/craft.yml
@@ -1,5 +1,5 @@
 php-version: 8.5
-extensions: "apcu,bcmath,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,intl,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,xsl,zip,zlib"
+extensions: "apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ffi,gd,gettext,iconv,intl,mbregex,mbstring,memcache,memcached,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,xsl,zip,zlib"
 sapi:
     - cli
     - micro

--- a/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 namespace Sculpin\Bundle\ContentTypesBundle\Command;
 
+use Sculpin\Bundle\ContentTypesBundle\ContentCreateService;
 use Sculpin\Bundle\SculpinBundle\Command\AbstractCommand;
 use Sculpin\Bundle\SculpinBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -19,7 +20,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\String\Inflector\EnglishInflector;
 
 /**
@@ -30,8 +30,6 @@ use Symfony\Component\String\Inflector\EnglishInflector;
  */
 final class ContentCreateCommand extends AbstractCommand
 {
-    private const string DIRECTORY_FLAG = '_directory_';
-
     /**
      * {@inheritdoc}
      */
@@ -93,19 +91,21 @@ final class ContentCreateCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $pluralType   = $input->getArgument('type');
-        $singularType = (new EnglishInflector())->singularize($pluralType)[0];
+        $singularType = new EnglishInflector()->singularize($pluralType)[0];
         $dryRun       = $input->getOption('dry-run');
         $taxonomies   = $input->getOption('taxonomy');
 
         $output->writeln('Generating new content type: <info>' . $pluralType . '</info>');
 
+        $service = new ContentCreateService($this->getProjectDir());
+
         // TODO: Prompt the user with a preview before generating content
-        $output->writeln($this->getOutputMessage($pluralType, $singularType, $taxonomies));
+        $output->writeln($this->getOutputMessage($service, $pluralType, $singularType, $taxonomies));
 
         // TODO: Write a yaml file to configure the content type (and recommend a wildcard include for types?)
 
         // grab the boilerplate manifest
-        $boilerplateManifest = $this->generateBoilerplateManifest($pluralType, $singularType, $taxonomies);
+        $boilerplateManifest = $service->generateBoilerplateManifest($pluralType, $singularType, $taxonomies);
 
         // skip creating boilerplate files if this is a dry run
         if ($dryRun) {
@@ -121,239 +121,39 @@ final class ContentCreateCommand extends AbstractCommand
         }
 
         $output->writeln('Generating boilerplate for ' . $pluralType);
-        $fs = new Filesystem();
-        foreach ($boilerplateManifest as $filename => $value) {
-            // create directory and skip the rest of the loop
-            if ($value === self::DIRECTORY_FLAG) {
-                $fs->mkdir($filename);
-                continue;
-            }
-
-            if ($fs->exists($filename)) {
-                $output->writeln('Warning: ' . $filename . ' already exists at the target location. Skipping.');
-                continue;
-            }
-
-            // create file $filename with contents $value
-            $fs->dumpFile($filename, $value);
-        }
-
+        $service->processManifest($boilerplateManifest);
         $output->writeln("\nRemember to add the content type definition (displayed above) to sculpin_kernel.yml!");
 
         return Command::SUCCESS;
     }
 
-    private function generateBoilerplateManifest(string $plural, string $singular, array $taxonomies = []): array
+    private function getOutputMessage(
+        ContentCreateService $service,
+        string $type,
+        string $singularType,
+        array $taxonomies = []
+    ): string {
+        $yaml = $service->getYamlString($type, $singularType, $taxonomies);
+        $outputMessage = <<<EOT
+
+        YAML content type definition to add to your
+        <info>app/config/sculpin_kernel.yml</info> file:
+        ================START OF YAML================
+
+        sculpin_content_types:
+            {$yaml}
+        EOT;
+
+        return $outputMessage . "\n=================END OF YAML=================\n\n";
+    }
+
+    public function getProjectDir(): string
     {
         $app = $this->getApplication();
         if (!$app instanceof Application) {
             throw new \RuntimeException('Sculpin Application not found!');
         }
 
-        $rootDir  = \dirname($app->getKernel()->getProjectDir());
-        $manifest = [];
-
-        // ensure the content type storage folder exists
-        $storageFolder            = $rootDir . '/source/_' . $plural;
-        $manifest[$storageFolder] = self::DIRECTORY_FLAG;
-
-        // content type index template
-        $index            = $rootDir . '/source/' . $plural . '.html';
-        $manifest[$index] = $this->getIndexTemplate($plural, $singular);
-
-        // ensure the views folder exists
-        $storageFolder            = $rootDir . '/source/_views';
-        $manifest[$storageFolder] = self::DIRECTORY_FLAG;
-
-        // content type view template
-        $index            = $rootDir . '/source/_views/' . $singular . '.html';
-        $manifest[$index] = $this->getViewTemplate($plural, $taxonomies);
-
-        foreach ($taxonomies as $taxonomy) {
-            $singularTaxonomy = (new EnglishInflector())->singularize($taxonomy)[0];
-            // content taxonomy index template
-            $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '.html';
-            $manifest[$index] = $this->getTaxonomyIndexTemplate($plural, $taxonomy, $singularTaxonomy);
-
-            // content taxonomy directory
-            $storageFolder            = $rootDir . '/source/' . $plural . '/' . $taxonomy;
-            $manifest[$storageFolder] = self::DIRECTORY_FLAG;
-
-            // content taxonomy view template(s)
-            $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '/' . $singularTaxonomy . '.html';
-            $manifest[$index] = $this->getTaxonomyViewTemplate($plural, $singular, $singularTaxonomy);
-        }
-
-        return $manifest;
-    }
-
-    private function getOutputMessage(string $type, string $singularType, array $taxonomies = []): string
-    {
-        $outputMessage = <<<EOT
-
-        YAML content type definition you will have to
-        add to <info>app/config/sculpin_kernel.yml</info>:
-        ================START OF YAML================
-
-        sculpin_content_types:
-            {$type}:
-                type: path
-                path: _{$type}
-                singular_name: {$singularType}
-                layout: {$singularType}
-                enabled: true
-                permalink: {$type}/:title
-        EOT;
-        if ($taxonomies !== []) {
-            $outputMessage .= "\n        taxonomies:\n";
-            foreach ($taxonomies as $taxonomy) {
-                $outputMessage .= sprintf('            - %s%s', $taxonomy, PHP_EOL);
-            }
-        }
-
-        return $outputMessage . "\n=================END OF YAML=================\n\n";
-    }
-
-    private function getIndexTemplate(string $plural, string $singular): string
-    {
-        $title = ucfirst($plural);
-
-        return <<<EOT
-        ---
-        layout: default
-        title: {$title}
-        generator: pagination
-        pagination:
-            provider: data.{$plural}
-            max_per_page: 10
-        use: [{$plural}]
-        ---
-        <ul>
-            {% for {$singular} in page.pagination.items %}
-                <li><a href="{{ {$singular}.url }}">{{ {$singular}.title }}</a></li>
-            {% endfor %}
-        </ul>
-
-        <nav>
-            {% if page.pagination.previous_page or page.pagination.next_page %}
-            {% if page.pagination.previous_page %}
-            <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
-            {% endif %}
-            {% if page.pagination.next_page %}
-            <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
-            {% endif %}
-            {% endif %}
-        </nav>
-        EOT;
-    }
-
-    private function getViewTemplate(string $plural, array $taxonomies = []): string
-    {
-        $output = <<<EOT
-        {% extends 'default' %}
-
-        {% block content_wrapper %}
-        <article>
-          <header>
-            <h2>{{ page.title }}</h2>
-          {% if page.subtitle %}
-            <h3 class="subtitle">{{ page.subtitle }}</h3>
-          {% endif %}
-          </header>
-          <section class="main_body">
-            {{ page.blocks.content|raw }}
-          </section>
-        EOT;
-
-        if ($taxonomies !== []) {
-            $output .= "\n" . '  <section class="taxonomies">' . "\n";
-
-            foreach ($taxonomies as $taxonomy) {
-                $capitalTaxonomy  = ucwords((string) $taxonomy);
-                $singularTaxonomy = (new EnglishInflector())->singularize($taxonomy)[0];
-                $output .= <<<EOT
-                    <div class="taxonomy">
-                        <a href="{{site.url }}/{$plural}/{$taxonomy}">{$capitalTaxonomy}</a>:
-                        {% for {$singularTaxonomy} in page.{$taxonomy} %}
-                        <a href="{{ site.url }}/{$plural}/{$taxonomy}/{{ {$singularTaxonomy} }}">
-                            {{ {$singularTaxonomy} }}
-                        </a>{% if not loop.last %}, {% endif %}
-                        {% endfor %}
-                      </div>
-                EOT;
-            }
-
-            $output .= "\n" . '  </section>' . "\n";
-        }
-
-        return $output . <<<EOT
-          <footer>
-            <p class="published_date">Published: {{page.date|date('F j, Y')}}</p>
-          </footer>
-        </article>
-        {% endblock content_wrapper %}
-        EOT;
-    }
-
-    private function getTaxonomyIndexTemplate(
-        string $plural,
-        string $taxonomy,
-        string $singularTaxonomy
-    ): string {
-        $title = ucfirst($taxonomy);
-
-        // phpcs:disable
-        return <<<EOT
-        ---
-        layout: default
-        use: [{$plural}_{$taxonomy}]
-        ---
-        <h1>{$title}</h1>
-        <ul>
-            {% for {$singularTaxonomy},{$plural} in data.{$plural}_{$taxonomy} %}
-                <li>
-                    <a href="/{$plural}/{$taxonomy}/{{ {$singularTaxonomy}|url_encode(true) }}">
-                        {{ {$singularTaxonomy} }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-        EOT;
-        // phpcs:enable
-    }
-
-    private function getTaxonomyViewTemplate(
-        string $plural,
-        string $singular,
-        string $singularTaxonomy
-    ): string {
-        $title = ucfirst($plural);
-
-        return <<<EOT
-        ---
-        layout: default
-        generator: [{$plural}_{$singularTaxonomy}_index, pagination]
-        pagination:
-            provider: page.{$singularTaxonomy}_{$plural}
-            max_per_page: 10
-        ---
-        <h1>{{ page.{$singularTaxonomy}|capitalize }}</h1>
-        <ul>
-            {% for {$singular} in page.pagination.items %}
-                <li><a href="{{ {$singular}.url }}">{{ {$singular}.title }}</a></li>
-            {% endfor %}
-        </ul>
-
-        <nav>
-            {% if page.pagination.previous_page or page.pagination.next_page %}
-            {% if page.pagination.previous_page %}
-            <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
-            {% endif %}
-            {% if page.pagination.next_page %}
-            <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
-            {% endif %}
-            {% endif %}
-        </nav>
-        EOT;
+        return \dirname($app->getKernel()->getProjectDir());
     }
 }

--- a/src/Sculpin/Bundle/ContentTypesBundle/ContentCreateService.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/ContentCreateService.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Sculpin\Bundle\ContentTypesBundle;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\String\Inflector\EnglishInflector;
+
+class ContentCreateService
+{
+    private const string DIRECTORY_FLAG = '_directory_';
+
+    public function __construct(public ?string $projectDir)
+    {
+        if (null === $this->projectDir || !is_writable($this->projectDir)) {
+            throw new \InvalidArgumentException('Project Dir not found or not writable');
+        }
+    }
+
+    public function generateBoilerplateManifest(string $plural, string $singular, array $taxonomies = []): array
+    {
+        $rootDir  = $this->projectDir;
+        $manifest = [];
+
+        // ensure the content type storage folder exists
+        $storageFolder            = $rootDir . '/source/_' . $plural;
+        $manifest[$storageFolder] = self::DIRECTORY_FLAG;
+
+        // content type index template
+        $index            = $rootDir . '/source/' . $plural . '.html';
+        $manifest[$index] = $this->getIndexTemplate($plural, $singular);
+
+        // ensure the views folder exists
+        $storageFolder            = $rootDir . '/source/_views';
+        $manifest[$storageFolder] = self::DIRECTORY_FLAG;
+
+        // content type view template
+        $index            = $rootDir . '/source/_views/' . $singular . '.html';
+        $manifest[$index] = $this->getViewTemplate($plural, $taxonomies);
+
+        foreach ($taxonomies as $taxonomy) {
+            $singularTaxonomy = new EnglishInflector()->singularize($taxonomy)[0];
+            // content taxonomy index template
+            $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '.html';
+            $manifest[$index] = $this->getTaxonomyIndexTemplate($plural, $taxonomy, $singularTaxonomy);
+
+            // content taxonomy directory
+            $storageFolder            = $rootDir . '/source/' . $plural . '/' . $taxonomy;
+            $manifest[$storageFolder] = self::DIRECTORY_FLAG;
+
+            // content taxonomy view template(s)
+            $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '/' . $singularTaxonomy . '.html';
+            $manifest[$index] = $this->getTaxonomyViewTemplate($plural, $singular, $singularTaxonomy);
+        }
+
+        return $manifest;
+    }
+
+    public function processManifest(array $boilerplateManifest): void
+    {
+        $fs = new Filesystem();
+        foreach ($boilerplateManifest as $filename => $value) {
+            // create directory and skip the rest of the loop
+            if ($value === self::DIRECTORY_FLAG) {
+                $fs->mkdir($filename);
+                continue;
+            }
+
+            if ($fs->exists($filename)) {
+                continue;
+            }
+
+            // create file $filename with contents $value
+            $fs->dumpFile($filename, $value);
+        }
+    }
+
+    public function getYamlString(string $type, string $singularType, array $taxonomies = []): string
+    {
+        $outputMessage = <<<EOT
+            {$type}:
+                type: path
+                path: _{$type}
+                singular_name: {$singularType}
+                layout: {$singularType}
+                enabled: true
+                permalink: {$type}/:title
+        EOT;
+
+        if ($taxonomies !== []) {
+            $outputMessage .= "\n        taxonomies:\n";
+            foreach ($taxonomies as $taxonomy) {
+                $outputMessage .= sprintf('            - %s%s', $taxonomy, PHP_EOL);
+            }
+        }
+
+        return $outputMessage . PHP_EOL;
+    }
+
+    private function getIndexTemplate(string $plural, string $singular): string
+    {
+        $title = ucfirst($plural);
+
+        return <<<EOT
+        ---
+        layout: default
+        title: {$title}
+        generator: pagination
+        pagination:
+            provider: data.{$plural}
+            max_per_page: 10
+        use: [{$plural}]
+        ---
+        <ul>
+            {% for {$singular} in page.pagination.items %}
+                <li><a href="{{ {$singular}.url }}">{{ {$singular}.title }}</a></li>
+            {% endfor %}
+        </ul>
+
+        <nav>
+            {% if page.pagination.previous_page or page.pagination.next_page %}
+            {% if page.pagination.previous_page %}
+            <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
+            {% endif %}
+            {% if page.pagination.next_page %}
+            <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
+            {% endif %}
+            {% endif %}
+        </nav>
+        EOT;
+    }
+
+    private function getViewTemplate(string $plural, array $taxonomies = []): string
+    {
+        $output = <<<EOT
+        {% extends 'default' %}
+
+        {% block content_wrapper %}
+        <article>
+          <header>
+            <h2>{{ page.title }}</h2>
+          {% if page.subtitle %}
+            <h3 class="subtitle">{{ page.subtitle }}</h3>
+          {% endif %}
+          </header>
+          <section class="main_body">
+            {{ page.blocks.content|raw }}
+          </section>
+        EOT;
+
+        if ($taxonomies !== []) {
+            $output .= "\n" . '  <section class="taxonomies">' . "\n";
+
+            foreach ($taxonomies as $taxonomy) {
+                $capitalTaxonomy  = ucwords((string) $taxonomy);
+                $singularTaxonomy = new EnglishInflector()->singularize($taxonomy)[0];
+                $output .= <<<EOT
+                    <div class="taxonomy">
+                        <a href="{{site.url }}/{$plural}/{$taxonomy}">{$capitalTaxonomy}</a>:
+                        {% for {$singularTaxonomy} in page.{$taxonomy} %}
+                        <a href="{{ site.url }}/{$plural}/{$taxonomy}/{{ {$singularTaxonomy} }}">
+                            {{ {$singularTaxonomy} }}
+                        </a>{% if not loop.last %}, {% endif %}
+                        {% endfor %}
+                      </div>
+                EOT;
+            }
+
+            $output .= "\n" . '  </section>' . "\n";
+        }
+
+        return $output . <<<EOT
+          <footer>
+            <p class="published_date">Published: {{page.date|date('F j, Y')}}</p>
+          </footer>
+        </article>
+        {% endblock content_wrapper %}
+        EOT;
+    }
+
+    private function getTaxonomyIndexTemplate(
+        string $plural,
+        string $taxonomy,
+        string $singularTaxonomy
+    ): string {
+        $title = ucfirst($taxonomy);
+
+        // phpcs:disable
+        return <<<EOT
+        ---
+        layout: default
+        use: [{$plural}_{$taxonomy}]
+        ---
+        <h1>{$title}</h1>
+        <ul>
+            {% for {$singularTaxonomy},{$plural} in data.{$plural}_{$taxonomy} %}
+                <li>
+                    <a href="/{$plural}/{$taxonomy}/{{ {$singularTaxonomy}|url_encode(true) }}">
+                        {{ {$singularTaxonomy} }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+        EOT;
+        // phpcs:enable
+    }
+
+    private function getTaxonomyViewTemplate(
+        string $plural,
+        string $singular,
+        string $singularTaxonomy
+    ): string {
+        $title = ucfirst($plural);
+
+        return <<<EOT
+        ---
+        layout: default
+        generator: [{$plural}_{$singularTaxonomy}_index, pagination]
+        pagination:
+            provider: page.{$singularTaxonomy}_{$plural}
+            max_per_page: 10
+        ---
+        <h1>{{ page.{$singularTaxonomy}|capitalize }}</h1>
+        <ul>
+            {% for {$singular} in page.pagination.items %}
+                <li><a href="{{ {$singular}.url }}">{{ {$singular}.title }}</a></li>
+            {% endfor %}
+        </ul>
+
+        <nav>
+            {% if page.pagination.previous_page or page.pagination.next_page %}
+            {% if page.pagination.previous_page %}
+            <a href="{{ site.url }}{{ page.pagination.previous_page.url }}">Newer {$title}</a>
+            {% endif %}
+            {% if page.pagination.next_page %}
+            <a href="{{ site.url }}{{ page.pagination.next_page.url }}">Older {$title}</a>
+            {% endif %}
+            {% endif %}
+        </nav>
+        EOT;
+    }
+}

--- a/src/Sculpin/Bundle/ContentTypesBundle/ContentCreateService.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/ContentCreateService.php
@@ -52,6 +52,10 @@ class ContentCreateService
             $manifest[$index] = $this->getTaxonomyViewTemplate($plural, $singular, $singularTaxonomy);
         }
 
+        // create the first content item in the storage folder
+        $firstPost            = $rootDir . '/source/_' . $plural . '/first_' . $singular . '.md';
+        $manifest[$firstPost] = $this->getFirstItem($singular, $taxonomies);
+
         return $manifest;
     }
 
@@ -236,6 +240,25 @@ class ContentCreateService
             {% endif %}
             {% endif %}
         </nav>
+        EOT;
+    }
+
+    private function getFirstItem(string $singular, array $taxonomies): string
+    {
+        $title = ucfirst($singular);
+
+        $taxonomyFrontMatter = implode("\n", array_map(fn ($taxonomy) => "$taxonomy:\n  - example", $taxonomies));
+
+        return <<<EOT
+        ---
+        layout: default
+        title: My First {$title}
+        $taxonomyFrontMatter
+        ---
+        # Welcome to My First {$singular}
+
+        Welcome! This the first {$singular} for {{ site.title }}!
+
         EOT;
     }
 }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -118,7 +118,7 @@ final class InitCommand extends AbstractCommand
                 'y' => true,
                 default => false,
             };
-        } else if ($enablePosts) {
+        } elseif ($enablePosts) {
             $posts = true;
         }
 
@@ -337,10 +337,14 @@ final class InitCommand extends AbstractCommand
                 <div class="pagination">
                     {% if page.pagination.previous_page or page.pagination.next_page %}
                         {% if page.pagination.previous_page %}
-                            <a href="{{ site_url }}{{ page.pagination.previous_page.url }}" title="{{ previous }}"><span>{{ previous|raw }}</span></a>
+                            <a href="{{ site_url }}{{ page.pagination.previous_page.url }}" title="{{ previous }}">
+                                <span>{{ previous|raw }}</span>
+                            </a>
                         {% endif %}
                         {% if page.pagination.next_page %}
-                            <a href="{{ site_url }}{{ page.pagination.next_page.url }}" title="{{ next }}"><span>{{ next|raw}}</span></a>
+                            <a href="{{ site_url }}{{ page.pagination.next_page.url }}" title="{{ next }}">
+                                <span>{{ next|raw}}</span>
+                            </a>
                         {% endif %}
                     {% endif %}
                 </div>

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -48,7 +48,6 @@ final class InitCommand extends AbstractCommand
                     't',
                     InputOption::VALUE_REQUIRED,
                     'Title for your new website',
-                    self::DEFAULT_TITLE
                 ),
                 new InputOption(
                     'subtitle',

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -143,7 +143,7 @@ final class InitCommand extends AbstractCommand
         $this->createSiteKernelFile($projectDir, $posts);
         $this->createSiteConfigFile($projectDir, $title, $subTitle);
 
-        // 4. Create source folder (with or without posts) and the very first basic entry in the source folder
+        // 4. Create source folder (with or without posts)
         $this->createSourceFolder($projectDir, $posts);
 
         $output->writeln('<info>Success!</info>');
@@ -241,17 +241,81 @@ final class InitCommand extends AbstractCommand
     {
         $fs = new Filesystem();
 
-        $fs->dumpFile(
-            $projectDir . '/source/index.md',
-            <<<EOT
-            ---
-            layout: default
-            ---
+        if (!$posts) {
+            // Sites without posts get a bare-bones Index
+            $fs->dumpFile(
+                $projectDir . '/source/index.md',
+                <<<EOT
+                ---
+                layout: default
+                ---
 
-            <h1>Welcome to {{site.title}}</h1>
+                <h1>Welcome to {{site.title}}</h1>
 
-            EOT
-        );
+                EOT
+            );
+        } else {
+            $fs->dumpFile(
+                $projectDir . '/source/index.md',
+                <<<EOT
+                ---
+                layout: default
+                generator: pagination
+                pagination:
+                    max_per_page: 6
+                use:
+                    - posts
+                ---
+
+                <h1>Welcome to {{site.title}}</h1>
+
+                <h2>Recent Posts</h2>
+                {% for post in page.pagination.items %}
+                    <article>
+                        <header>
+                            <div><h2><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></h2></div>
+                            <div>{{post.date|date("F j, Y")}}</div>
+                        </header>
+                        <div>
+                                {# Split the post into an array using explode().
+                                   Because we provide a length of 2, the "rest"
+                                   of the post will be stored in the second array
+                                   element, even if there are multiple breakpoints. #}
+                                {% set break_array =
+                                    post.blocks.content|split('<!-- break -->', 2) %}
+
+                                {# Output the first element of the array in raw mode #}
+                                {{ break_array[0]|raw }}
+
+                                {# Detect if there is more to the post. If the post
+                                   was only one array element with no breakpoints,
+                                   it would all have shown up. This Read More link should
+                                   only show up if there is overflow to the post. #}
+                                {% if break_array|length > 1 %}
+                                    <div><a href="{{ site.url }}{{ post.url }}">
+                                        Read more of this post »
+                                    </a></div>
+                                {% endif %}
+                        </div>
+                        {% if post.meta.tags %}
+                        <div>
+                            <small>Tags: {% for tag in post.meta.tags %}
+                            <a href="{{ site.url }}/posts/tags/{{ tag }}">{{ tag }}</a>
+                            {% endfor %}
+                            </small>
+                        </div>
+                        {% endif %}
+                    </article>
+                {% else %}
+                <p>There no recent posts.</p>
+                {% endfor %}
+
+                {% import 'macros.twig' as util %}
+                {{ util.pagination(page, site.url, '« Newer Posts', 'Older Posts »') }}
+
+                EOT
+            );
+        }
 
         $fs->dumpFile(
             $projectDir . '/source/_views/default.html',
@@ -262,6 +326,34 @@ final class InitCommand extends AbstractCommand
             {% block content_wrapper %}{% block content '' %}{% endblock content_wrapper %}
             </body>
             </html>
+
+            EOT
+        );
+
+        $fs->dumpFile(
+            $projectDir . '/source/_includes/macros.twig',
+            <<<EOT
+            {% macro pagination(page, site_url, previous = 'Older', next = 'Newer') %}
+                <div class="pagination">
+                    {% if page.pagination.previous_page or page.pagination.next_page %}
+                        {% if page.pagination.previous_page %}
+                            <a href="{{ site_url }}{{ page.pagination.previous_page.url }}" title="{{ previous }}"><span>{{ previous|raw }}</span></a>
+                        {% endif %}
+                        {% if page.pagination.next_page %}
+                            <a href="{{ site_url }}{{ page.pagination.next_page.url }}" title="{{ next }}"><span>{{ next|raw}}</span></a>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            {% endmacro %}
+
+            {% macro breadcrumb(items) %}
+                <div class="breadcrumb">
+                    {% for url, label in items %}
+                        {% if not loop.first %}<span>&raquo;</span>{% endif %}
+                    <a href="{{site.url}}{{url}}">{{ label }}</a>
+                    {% endfor %}
+                </div>
+            {% endmacro %}
 
             EOT
         );

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -107,8 +108,16 @@ final class InitCommand extends AbstractCommand
 
         $posts = false;
         if (!$enablePosts && !$disablePosts) {
-            $question = new Question('Will your website have blog posts?', false);
-            $posts = $questionHelper->ask($input, $output, $question);
+            $question = new ChoiceQuestion(
+                'Will your website have blog posts?',
+                ['y' => 'yes', 'n' => 'no (default)'],
+                'n'
+            );
+
+            $posts = match ($questionHelper->ask($input, $output, $question)) {
+                'y' => true,
+                default => false,
+            };
         } else if ($enablePosts) {
             $posts = true;
         }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/InitCommand.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Sculpin\Bundle\SculpinBundle\Command;
 
+use Sculpin\Bundle\ContentTypesBundle\ContentCreateService;
 use Sculpin\Bundle\SculpinBundle\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -24,12 +27,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class InitCommand extends AbstractCommand
 {
-    public const int COMMAND_SUCCESS          = 0;
-
     public const int PROJECT_FOLDER_NOT_EMPTY = 101;
-
     public const string DEFAULT_SUBTITLE = 'A Static Site Powered By Sculpin';
-
     public const string DEFAULT_TITLE    = 'My Sculpin Site';
 
     /**
@@ -40,27 +39,43 @@ final class InitCommand extends AbstractCommand
         $prefix = $this->isStandaloneSculpin() ? '' : 'sculpin:';
 
         $this
-            ->setName($prefix.'init')
+            ->setName($prefix . 'init')
             ->setDescription('Initialize a default site configuration.')
             ->setDefinition([
                 new InputOption(
                     'title',
                     't',
                     InputOption::VALUE_REQUIRED,
-                    'Specify a title for your Sculpin site.',
+                    'Title for your new website',
                     self::DEFAULT_TITLE
                 ),
                 new InputOption(
                     'subtitle',
                     's',
                     InputOption::VALUE_REQUIRED,
-                    'Specify a sub-title for your Sculpin site.',
+                    'Sub-title for your new website',
                     self::DEFAULT_SUBTITLE
+                ),
+                new InputOption(
+                    'posts',
+                    'p',
+                    InputOption::VALUE_NONE,
+                    'Configure the website as a blog'
+                ),
+                new InputOption(
+                    'no-posts',
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Disable blog posts (default)'
                 ),
             ])
             ->setHelp(<<<EOT
             The <info>init</info> command initializes a default site configuration.
 
+            If title/subtitle are not provided, the command will ask the user for input.
+
+            Once the site has been created, the `content:create` command can be used
+            to create custom Content Types, such as Blog Posts.
             EOT
             );
     }
@@ -79,6 +94,24 @@ final class InitCommand extends AbstractCommand
 
         $title    = $input->getOption('title');
         $subTitle = $input->getOption('subtitle');
+        $enablePosts = $input->getOption('posts');
+        $disablePosts = $input->getOption('no-posts');
+
+        $questionHelper = new QuestionHelper();
+
+        $question = new Question('Title for your website:', self::DEFAULT_TITLE);
+        $title ??= $questionHelper->ask($input, $output, $question);
+
+        $question = new Question('Sub-heading for your website:', self::DEFAULT_SUBTITLE);
+        $subTitle ??= $questionHelper->ask($input, $output, $question);
+
+        $posts = false;
+        if (!$enablePosts && !$disablePosts) {
+            $question = new Question('Will your website have blog posts?', false);
+            $posts = $questionHelper->ask($input, $output, $question);
+        } else if ($enablePosts) {
+            $posts = true;
+        }
 
         $projectDir = $this->getContainer()->getParameter('sculpin.project_dir');
         $output->writeln('Project Directory: <info>' . $projectDir . '</info>');
@@ -98,16 +131,23 @@ final class InitCommand extends AbstractCommand
         $this->createDefaultKernel($projectDir);
 
         // 3. Create default Site config files
-        $this->createSiteKernelFile($projectDir);
+        $this->createSiteKernelFile($projectDir, $posts);
         $this->createSiteConfigFile($projectDir, $title, $subTitle);
 
         // 4. Create source folder (with or without posts) and the very first basic entry in the source folder
-        $this->createSourceFolder($projectDir);
+        $this->createSourceFolder($projectDir, $posts);
 
         $output->writeln('<info>Success!</info>');
-        $output->writeln('Run "sculpin generate --watch --server" to see your static site in action.');
+        $output->writeln('Run "sculpin generate --watch --server --editor" to see your static site in action.');
+        $output->writeln('');
 
-        return self::COMMAND_SUCCESS;
+        if (!$posts) {
+            $output->writeln(
+                'Or, use the `sculpin content:create` command to create a custom Content Type, such as Blog Posts.'
+            );
+        }
+
+        return self::SUCCESS;
     }
 
     private function ensureCleanSlate(string $projectDir, OutputInterface $output): bool
@@ -138,7 +178,7 @@ final class InitCommand extends AbstractCommand
             protected function getAdditionalSculpinBundles(): array
             {
                 return [
-        //            'App\\Bundle\\ExampleBundle\\AppExampleBundle'
+        //            App\Bundle\ExampleBundle\AppExampleBundle:class,
                 ];
             }
         }
@@ -147,14 +187,27 @@ final class InitCommand extends AbstractCommand
         $this->createFile($projectDir . '/app/SculpinKernel.php', $contents);
     }
 
-    private function createSiteKernelFile(string $projectDir): void
+    private function createSiteKernelFile(string $projectDir, bool $posts = false): void
     {
-        $contents = <<<EOT
-        sculpin_content_types:
-            posts:
-              enabled: false
+        if ($posts) {
+            $contents = <<<EOT
+            sculpin_content_types:
+                posts:
+                    type: path
+                    path: _posts
+                    permalink: pretty
+                    taxonomies:
+                        - tags
+                        - categories
+            EOT;
+        } else {
+            $contents = <<<EOT
+            sculpin_content_types:
+                posts:
+                  enabled: false
+            EOT;
+        }
 
-        EOT;
         $this->createFile($projectDir . '/app/config/sculpin_kernel.yml', $contents);
     }
 
@@ -164,6 +217,8 @@ final class InitCommand extends AbstractCommand
         string $subTitle
     ): void {
         $contents = <<<EOT
+        # These values will be available in your markdown and HTML twig templates, in the `site` object.
+        # Example: `{{ site.title }}`
         title: "{$title}"
         subtitle: "{$subTitle}"
         google_analytics_tracking_id: ''
@@ -173,7 +228,7 @@ final class InitCommand extends AbstractCommand
         $this->createFile($projectDir . '/app/config/sculpin_site.yml', $contents);
     }
 
-    private function createSourceFolder(string $projectDir): void
+    private function createSourceFolder(string $projectDir, bool $posts = false): void
     {
         $fs = new Filesystem();
 
@@ -201,6 +256,18 @@ final class InitCommand extends AbstractCommand
 
             EOT
         );
+
+        if ($posts) {
+            $contentService = new ContentCreateService($projectDir);
+
+            $manifest = $contentService->generateBoilerplateManifest(
+                'posts',
+                'post',
+                ['tags', 'categories'],
+            );
+
+            $contentService->processManifest($manifest);
+        }
     }
 
     private function createFile(string $path, string $contents): void

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -28,7 +28,7 @@ final class InitCommandTest extends FunctionalTestCase
         $projectDir = self::projectDir();
         $this->assertProjectEmpty($projectDir);
 
-        $this->executeSculpin(['init', '--no-posts']);
+        $this->executeSculpin(['init', '--no-posts', '-t', InitCommand::DEFAULT_TITLE]);
 
         $this->assertProjectInitialized($projectDir);
 

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -28,7 +28,7 @@ final class InitCommandTest extends FunctionalTestCase
         $projectDir = self::projectDir();
         $this->assertProjectEmpty($projectDir);
 
-        $this->executeSculpin(['init']);
+        $this->executeSculpin(['init', '--no-posts']);
 
         $this->assertProjectInitialized($projectDir);
 
@@ -54,7 +54,7 @@ final class InitCommandTest extends FunctionalTestCase
         $projectDir = self::projectDir();
         $this->assertProjectEmpty($projectDir);
 
-        $this->executeSculpin(['init', '-t', 'My Custom Title', '-s', 'Custom Subtitle']);
+        $this->executeSculpin(['init', '-t', 'My Custom Title', '-s', 'Custom Subtitle', '--no-posts']);
 
         $this->assertProjectInitialized($projectDir);
 

--- a/src/Sculpin/Tests/Functional/InitCommandTest.php
+++ b/src/Sculpin/Tests/Functional/InitCommandTest.php
@@ -49,7 +49,36 @@ final class InitCommandTest extends FunctionalTestCase
     }
 
     /** @test */
-    public function shouldInitWithSpecifiedParameters(): void
+    public function shouldFailWhenAppOrSourceFoldersExist(): void
+    {
+        $projectDir = self::projectDir();
+        $this->assertProjectEmpty($projectDir);
+
+        // The check currently only looks for "/app" and "/source",
+        // so the folder could contain other content (e.g., if someone has
+        // an existing site structure they want to augment with Sculpin)
+        file_put_contents($projectDir . '/source', 'fail this test');
+
+        $this->assertProjectNotEmpty($projectDir);
+
+        $process = $this->executeSculpinAsync(
+            ['init', '-t', 'My Custom Title', '-s', 'Custom Subtitle', '--no-posts'],
+            start: false,
+        );
+        $result = $process->run();
+
+        $this->executeOutput = $process->getOutput();
+        $this->errorOutput = $process->getErrorOutput();
+
+        self::assertSame(101, $result);
+        self::assertStringContainsString(
+            "/source folder exists.\nThis command can only be run in an uninitialized folder.",
+            $this->executeOutput
+        );
+    }
+
+    /** @test */
+    public function shouldInitWithSpecifiedParameters_NoPosts(): void
     {
         $projectDir = self::projectDir();
         $this->assertProjectEmpty($projectDir);
@@ -74,6 +103,59 @@ final class InitCommandTest extends FunctionalTestCase
         );
     }
 
+    /** @test */
+    public function shouldInitWithSpecifiedParameters_PostsEnabled(): void
+    {
+        $projectDir = self::projectDir();
+        $this->assertProjectEmpty($projectDir);
+
+        $this->executeSculpin(['init', '-t', 'My Custom Title', '-s', 'Custom Subtitle', '-p']);
+
+        $this->assertProjectInitialized(
+            $projectDir,
+            [
+                '/source/_posts',
+                '/source/_posts/first_post.md',
+                '/source/_views/post.html',
+                '/source/posts',
+                '/source/posts.html',
+                '/source/posts/categories',
+                '/source/posts/categories.html',
+                '/source/posts/categories/category.html',
+                '/source/posts/tags',
+                '/source/posts/tags.html',
+                '/source/posts/tags/tag.html',
+            ]
+        );
+
+        $this->assertYamlFileEqualsArray(
+            [
+                'sculpin_content_types' => [
+                    'posts' => [
+                        'type' => 'path',
+                        'path' => '_posts',
+                        'permalink' => 'pretty',
+                        'taxonomies' => [
+                            'tags',
+                            'categories',
+                        ]
+                    ]
+                ]
+            ],
+            $projectDir . '/app/config/sculpin_kernel.yml'
+        );
+
+        $this->assertYamlFileEqualsArray(
+            [
+                'title'                        => 'My Custom Title',
+                'subtitle'                     => 'Custom Subtitle',
+                'google_analytics_tracking_id' => '',
+                'url'                          => '',
+            ],
+            $projectDir . '/app/config/sculpin_site.yml'
+        );
+    }
+
     private function assertProjectEmpty(string $projectDir): void
     {
         $files = $this->finder->in($projectDir);
@@ -84,21 +166,33 @@ final class InitCommandTest extends FunctionalTestCase
         );
     }
 
-    private function assertProjectInitialized(string $projectDir): void
+    private function assertProjectNotEmpty(string $projectDir): void
+    {
+        $files = $this->finder->in($projectDir);
+        $this->assertGreaterThan(
+            0,
+            count(array_keys(iterator_to_array($files))),
+            'Expected project dir to be empty'
+        );
+    }
+
+    private function assertProjectInitialized(string $projectDir, array $extraExpected = []): void
     {
         $files = $this->finder->in($projectDir);
 
-        $expected = [
+        $expected = array_merge([
             $projectDir . '/app',
             $projectDir . '/app/config',
             $projectDir . '/app/config/sculpin_site.yml',
             $projectDir . '/app/config/sculpin_kernel.yml',
             $projectDir . '/app/SculpinKernel.php',
             $projectDir . '/source',
+            $projectDir . '/source/_includes',
+            $projectDir . '/source/_includes/macros.twig',
             $projectDir . '/source/_views',
             $projectDir . '/source/_views/default.html',
             $projectDir . '/source/index.md',
-        ];
+        ], array_map(fn ($file) => $projectDir . $file, $extraExpected));
 
         $actual = array_keys(iterator_to_array($files));
 


### PR DESCRIPTION
The init command can now create a `posts` supporting structure, including tags and categories, by default.

The output is still horrifically un-styled, but the operational requirements are in place.

Todos:

- [x] Make the flow properly prompt for title and subtitle options, if they were not provided on the command line. (Currently they are set as a `default` in the InputOption configuration, which is confounding things.)