### PR TITLE
Add sculpin `run` command to make starting local sculpin easier

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Command/RunCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/RunCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is a part of Sculpin.
+ *
+ * (c) Dragonfly Development Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sculpin\Bundle\SculpinBundle\Command;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Run sculpin: Generate, Serve, and Edit the site.
+ *
+ * @author Kevin Boyd <kevin@whateverthing.com>
+ */
+class RunCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('run')
+            ->setDescription('Run sculpin: generate, serve, and edit your unpublished site.')
+            ->setDefinition([
+                new InputOption(
+                    'clean',
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Cleans the output directory prior to generation.'
+                ),
+                new InputOption('url', null, InputOption::VALUE_REQUIRED, 'Override URL.'),
+                new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Port'),
+                new InputOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output Directory'),
+                new InputOption('source-dir', null, InputOption::VALUE_REQUIRED, 'Source Directory'),
+            ])
+            ->setHelp(<<<EOT
+            The <info>run</info> command is a helper alias for launching Sculpin.
+
+            It is the same as running <info>sculpin generate --watch --server --editor</info>
+
+            It will watch your <info>--source-dir</info> for changes, automatically
+            regenerate the content into <info>--output-dir</info>, and provide an in-browser
+            editor interface for ease of use.
+
+            If your site has not yet been initialized, please
+            run <warning> sculpin init </warning> before <info>sculpin run</info>.
+            EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $inputData = [
+            'command' => 'generate',
+            '--watch' => true,
+            '--editor' => true,
+            '--server' => true,
+        ];
+
+        foreach ($input->getOptions() as $key => $value) {
+            $inputData['--' . $key] = $value;
+        }
+
+        $inputData = $inputData + $input->getArguments();
+        $inputData = array_filter($inputData);
+
+        $commandInput = new ArrayInput($inputData);
+
+        return $this->getApplication()->doRun($commandInput, $output);
+    }
+}

--- a/src/Sculpin/Bundle/SculpinBundle/Command/RunCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/RunCommand.php
@@ -42,6 +42,7 @@ class RunCommand extends AbstractCommand
                 ),
                 new InputOption('url', null, InputOption::VALUE_REQUIRED, 'Override URL.'),
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Port'),
+                new InputOption('no-editor', null, InputOption::VALUE_NONE, 'Turn off the in-browser editor.'),
                 new InputOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output Directory'),
                 new InputOption('source-dir', null, InputOption::VALUE_REQUIRED, 'Source Directory'),
             ])
@@ -74,6 +75,11 @@ class RunCommand extends AbstractCommand
 
         foreach ($input->getOptions() as $key => $value) {
             $inputData['--' . $key] = $value;
+        }
+
+        if (true === $inputData['--no-editor']) {
+            unset($inputData['--editor']);
+            unset($inputData['--no-editor']);
         }
 
         $inputData = $inputData + $input->getArguments();

--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -104,6 +104,11 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Sculpin\Bundle\SculpinBundle\Command\RunCommand"
+                 class="Sculpin\Bundle\SculpinBundle\Command\RunCommand">
+            <tag name="console.command"/>
+        </service>
+
         <service id="Sculpin\Bundle\SculpinBundle\Command\ServeCommand"
                  class="Sculpin\Bundle\SculpinBundle\Command\ServeCommand">
             <tag name="console.command"/>

--- a/src/Sculpin/Tests/Functional/ComplexProviderLifecycleTest.php
+++ b/src/Sculpin/Tests/Functional/ComplexProviderLifecycleTest.php
@@ -85,6 +85,58 @@ class ComplexProviderLifecycleTest extends FunctionalTestCase
         );
     }
 
+    /** @test */
+    public function testComplexLifecycleBuildsProperly_WhileUsingRun(): void
+    {
+        $sourcePage = __DIR__ . self::PROJECT_DIR . '/source/_clades/1-jacksons.html';
+        $generatedPage = __DIR__ . self::PROJECT_DIR . '/' . 'output_test/index.html';
+        $expectedFileContents = '<strong>hypothetical</strong>';
+        $matchString = "{% include 'jackson.html' %}";
+
+        // ensure consistent test state
+        $rawPage = file_get_contents($sourcePage);
+        $this->modifySourcePage(
+            filePath: $sourcePage,
+            regex: '# *' . $matchString . ' *#',
+            replacement: $matchString,
+            body: $rawPage
+        );
+
+        // start our async sculpin watcher/server
+        // this may result in TCP port conflicts on some system configurations
+        $process = $this->executeSculpinAsync(['run']);
+
+        sleep(1); // wait until our file exists
+        $pageContent = file_get_contents($generatedPage);
+
+        // check for the word being tested
+        $this->assertStringContainsString($expectedFileContents, $pageContent);
+
+        // update the files under test by adding whitespace
+        $this->modifySourcePage(
+            filePath: $sourcePage,
+            regex: '#' . $matchString . '#',
+            replacement: '  ' . $matchString . ' ',
+            body: $rawPage
+        );
+
+        sleep(2);
+        $pageContent = file_get_contents($generatedPage);
+
+        // check for the word being tested
+        $this->assertStringContainsString($expectedFileContents, $pageContent);
+
+        $process->stop(0);
+
+        // reset the source page
+        $this->modifySourcePage(
+            filePath: $sourcePage,
+            regex: '# *' . $matchString . ' *#',
+            replacement: $matchString,
+            body: $rawPage
+        );
+    }
+
     protected function modifySourcePage(string $filePath, string $regex, string $replacement, string $body): void
     {
         file_put_contents($filePath, preg_replace($regex, $replacement, $body));


### PR DESCRIPTION
`sculpin run` is an alias to `sculpin generate --watch --editor --server`, and the goal is to make it easier to get up and running with a sculpin site.