### PR TITLE
Create a new "Add File" interface

### DIFF
--- a/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
+++ b/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
@@ -13,11 +13,21 @@ use Sculpin\Core\Source\SourceSet;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
+/**
+ * Provides the routes, logic, and resources for the In-browser Editor interface
+ */
 class InBrowserEditorContentFetcher implements ContentFetcher
 {
+    /** @var array A list of rendered output URLs, pointing to their Source file's full path */
     protected array $pathMap;
+
+    /** @var array A list of all source files and their info */
     protected array $sourceMap;
+
+    /** @var string Location of the rendered output files */
     protected string $docroot;
+
+    /** @var string Location of the user's website source files */
     protected string $sourceDir;
 
     public function __construct(
@@ -33,6 +43,18 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         $this->buildSourceMap();
     }
 
+    /**
+     * Checks incoming HTTP Requests for specific URL prefixes to activate the Editor logic
+     *
+     * Enables loading JS and CSS for the editor, fetching hash info and metadata for files,
+     * and updating/creating files in the Source Dir.
+     *
+     * @param string $path
+     * @param ServerRequestInterface $request
+     * @param OutputInterface $output
+     * @return Response|null
+     * @throws \Exception
+     */
     public function handleRequest(
         string $path,
         ServerRequestInterface $request,
@@ -67,6 +89,16 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         };
     }
 
+    /**
+     * Builds the data structure that maps generated files (URLs) to their
+     * corresponding file in the Source Directory.
+     *
+     * For generated files, such as Tags or Categories or Pagination, multiple
+     * paths may map to the same Source file - the template for that type of page.
+     *
+     * @param SourceSet $set
+     * @return void
+     */
     public function buildPathMap(SourceSet $set): void
     {
         $pathMap = [];
@@ -103,6 +135,13 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         }
     }
 
+    /**
+     * Performs the ContentFetcher "fetchData" operation, returning the
+     * HTML for the content being rendered.
+     *
+     * @param string $path
+     * @return string|null
+     */
     public function fetchData(string $path): ?string
     {
         $body = file_get_contents($path);
@@ -111,6 +150,16 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         return $body ? $this->process($relativePath, $body) : null;
     }
 
+    /**
+     * Intercepts the content being rendered in order to update its HTML
+     * to display the In-Browser Editor.
+     *
+     * Skips unrecognized paths, non-HTML files, etc.
+     *
+     * @param string $path
+     * @param string $body
+     * @return string
+     */
     protected function process(string $path, string $body): string
     {
         // if we don't know the disk location for edits, exit early
@@ -158,11 +207,23 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         );
     }
 
+    /**
+     * Fetch the raw editor JS
+     *
+     * @return string
+     */
     public function editorJs(): string
     {
         return file_get_contents(__DIR__ . '/Resources/js/editor.js') ?: '';
     }
 
+    /**
+     * Check if the provided path exists in the PathMap - and, if it does,
+     * check if its corresponding Source file exists on disk.
+     *
+     * @param string $path
+     * @return bool
+     */
     public function diskPathExists(string $path): bool
     {
         if (!isset($this->pathMap[$path])) {
@@ -172,6 +233,14 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         return file_exists($this->pathMap[$path]);
     }
 
+    /**
+     * Check if the provided Source path exists in the Source Map,
+     * and if it does, check if the corresponding rendered output
+     * file exists under the docroot.
+     *
+     * @param string $sourcePath
+     * @return bool
+     */
     public function sourceExists(string $sourcePath): bool
     {
         if (!isset($this->sourceMap[$sourcePath])) {
@@ -183,6 +252,13 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         return file_exists($fullPath);
     }
 
+    /**
+     * Write provided bytes to a file in the Source dir.
+     *
+     * @param string $sourcePath
+     * @param string $content
+     * @return void
+     */
     public function save(string $sourcePath, string $content): void
     {
         if (!$this->sourceExists($sourcePath)) {
@@ -192,6 +268,12 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         file_put_contents($this->sourceDir . $this->sourceMap[$sourcePath]['pathname'], $content);
     }
 
+    /**
+     * Retrieve an MD5Hash of the requested rendered output file.
+     *
+     * @param string $path
+     * @return string|null
+     */
     public function hash(string $path): ?string
     {
         if (!$this->diskPathExists($path)) {
@@ -201,11 +283,33 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         return md5_file($this->docroot . $path) ?: null;
     }
 
+    /**
+     * Fetch the raw editor CSS
+     *
+     * @return string
+     */
     public function editorCss(): string
     {
         return file_get_contents(__DIR__ . '/Resources/css/editor.css') ?: '';
     }
 
+    /**
+     * Fetch metadata for the provided Path or Source value.
+     *
+     * Metadata includes: url, pathMap key, sourceMap key.
+     *
+     * If the full disk path exists, then the metadata will
+     * also include: diskPath, content, contentHashSource,
+     *               contentHashGenerated.
+     *
+     * Content Hash Generated may be "unknown" if the file
+     * does not exist; but really, the whole request should
+     * have skipped past that in such a scenario.
+     *
+     * @param string $path
+     * @param string $source
+     * @return array
+     */
     public function getMetadata(string $path = '', string $source = ''): array
     {
         $url = $path ? $this->pathMap[$path] ?? $source : $source;
@@ -247,6 +351,8 @@ class InBrowserEditorContentFetcher implements ContentFetcher
     }
 
     /**
+     * Returns a Response containing requested Metadata.
+     *
      * @param string $url
      * @param string $source
      * @return Response
@@ -269,6 +375,8 @@ class InBrowserEditorContentFetcher implements ContentFetcher
     }
 
     /**
+     * Writes incoming changes to an existing file.
+     *
      * @param ServerRequestInterface $request
      * @param OutputInterface $output
      * @return Response

--- a/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
+++ b/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
@@ -85,6 +85,7 @@ class InBrowserEditorContentFetcher implements ContentFetcher
                 ),
             strstr($path, '/_SCULPIN_/metadata') && $requestMethod === 'GET' => $this->getMetadataResponse($url, $source),
             str_ends_with($path, '_SCULPIN_/update') && $requestMethod === 'PUT' => $this->applyUpdate($request, $output),
+            str_ends_with($path, '_SCULPIN_/create') && $requestMethod === 'PUT' => $this->createFile($request, $output),
             default => null,
         };
     }
@@ -428,5 +429,98 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         $output->writeln(sprintf('Updated: %s', $edit['diskPath']));
 
         return new Response(307, ['Location' => $edit['path']]);
+    }
+
+    /**
+     * Creates the requested file if criteria are met, such as the file not
+     * already existing.
+     *
+     * @param ServerRequestInterface $request
+     * @param OutputInterface $output
+     * @return Response
+     */
+    public function createFile(ServerRequestInterface $request, OutputInterface $output): Response
+    {
+        $edit = json_decode($request->getBody()->getContents(), true);
+
+        $newFileName = ltrim(trim($edit['fileName'] ?? ''), '/\\');
+        $newFilePath = $this->sourceDir . $newFileName;
+
+        if (file_exists($newFilePath)) {
+            // error
+            throw new \Exception('file path exists!');
+        }
+
+        $touchResult = touch($newFilePath);
+        if (!$touchResult) {
+            throw new \Exception('bad touch!');
+        }
+
+        $newFilePath = realpath($newFilePath);
+
+        $output->writeln(
+            sprintf(
+                "Received NewFilePath of %s (new file name: %s, sourcedir: %s, realpath input was: %s",
+                $newFilePath === false ? 'FALSE!!!' : $newFilePath,
+                $newFileName,
+                $this->sourceDir,
+                $this->sourceDir . $newFileName,
+            )
+        );
+
+        if (empty($newFileName) || !str_starts_with($newFilePath, $this->sourceDir)) {
+            HttpServer::logRequest($output, 400, $request);
+            $output->writeln(
+                sprintf(
+                    "Rejected NewFilePath of %s (new file name: %s, sourcedir: %s",
+                    $newFilePath,
+                    $newFileName,
+                    $this->sourceDir
+                )
+            );
+
+            $forbiddenMessage = '<h1>400</h1><h2>Bad Request</h2>'
+                . '<p>'
+                . 'The embedded <a href="https://sculpin.io">Sculpin</a> web server '
+                . 'could not create the requested resource.'
+                . '</p>';
+
+            return new Response(403, ['Content-Type' => 'text/html'], $forbiddenMessage);
+            // throw new \Exception("Detected a bad filename! " . $newFileName);
+        }
+
+        if ($this->sourceExists($newFileName) || filesize($newFilePath) > 0) {
+            HttpServer::logRequest($output, 403, $request);
+
+            $forbiddenMessage = '<h1>403</h1><h2>Forbidden</h2>'
+                . '<p>'
+                . 'The embedded <a href="https://sculpin.io">Sculpin</a> web server '
+                . 'could not update the requested resource.'
+                . '</p>';
+
+            return new Response(403, ['Content-Type' => 'text/html'], $forbiddenMessage);
+        }
+
+        $defaultContent = <<<EOT
+        ---
+        layout: default
+        ---
+        ## My New Page
+
+        Hello and welcome to a new page on my website!
+        EOT;
+
+        file_put_contents($newFilePath, $defaultContent);
+
+        HttpServer::logRequest($output, 307, $request);
+        $output->writeln(sprintf('Created: %s', $newFileName));
+
+        // This is a least-effort guess that does not factor in Content Types/Generators/Pagination
+        $redirectLocation = explode('.', $newFileName)[0];
+        if (str_starts_with($redirectLocation, '_')) {
+            return new Response(307, ['Location' => '/']);
+        }
+
+        return new Response(307, ['Location' => $redirectLocation]);
     }
 }

--- a/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
+++ b/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
@@ -133,6 +133,31 @@ class InBrowserEditorContentFetcher implements ContentFetcher
                 'ext' => mb_strtolower($file->getExtension()),
             ];
         }
+
+        // Sort the list of source files by a specific algorithm:
+        // - Leading-Underscores (_posts, _partials, _includes, etc) go last
+        // - Deeper paths go second-to-last (subfolders)
+        // - Otherwise, regular string comparison rules apply
+        uksort($this->sourceMap, function (string $a, string $b) {
+            $aStartsWithUnderscore = str_starts_with($a, '_');
+            $aDepth = substr_count($a, DIRECTORY_SEPARATOR);
+            $bStartsWithUnderscore = str_starts_with($b, '_');
+            $bDepth = substr_count($b, DIRECTORY_SEPARATOR);
+
+            if ($aStartsWithUnderscore && $bStartsWithUnderscore) {
+                return $b <=> $a;
+            } else if ($aStartsWithUnderscore) {
+                return 1;
+            } else if ($bStartsWithUnderscore) {
+                return -1;
+            }
+
+            if (0 === ($return = $aDepth <=> $bDepth)) {
+                return $return;
+            }
+
+            return $a <=> $b;
+        });
     }
 
     /**

--- a/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
+++ b/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
@@ -36,8 +36,8 @@ class InBrowserEditorContentFetcher implements ContentFetcher
         string $sourceDir,
         protected readonly MimeTypeDetector $detector,
     ) {
-        $this->docroot   = rtrim($docroot, '/') . '/';
-        $this->sourceDir = rtrim($sourceDir, '/') . '/';
+        $this->docroot   = realpath($docroot) . DIRECTORY_SEPARATOR;
+        $this->sourceDir = realpath($sourceDir) . DIRECTORY_SEPARATOR;
 
         $this->buildPathMap($set);
         $this->buildSourceMap();

--- a/src/Sculpin/Bundle/EditorBundle/Resources/css/editor.css
+++ b/src/Sculpin/Bundle/EditorBundle/Resources/css/editor.css
@@ -150,4 +150,29 @@
         background-color: #9f1770;
         margin-right: 12px;
     }
+
+    a,
+    a:visited,
+    > div > button {
+        color: #ffffff;
+        border: 0;
+        font-weight: bolder;
+        text-decoration: underline;
+        display: inline-block;
+        padding: 12px 8px;
+        margin-right: 5px;
+    }
+
+    a:hover,
+    > div > button:hover {
+        background-color: #B1C4CB;
+        text-decoration: none;
+    }
+
+    a > svg {
+        color: white;
+        fill: white;
+        margin-right: 5px;
+        vertical-align: bottom;
+    }
 }

--- a/src/Sculpin/Bundle/EditorBundle/Resources/js/editor.js
+++ b/src/Sculpin/Bundle/EditorBundle/Resources/js/editor.js
@@ -78,6 +78,33 @@ var SculpinEditor = {
         this.registerEditorListeners();
     },
 
+    renderAddModal: function () {
+        console.log('Drawing Add File Modal');
+
+        // Check if modal has already been drawn
+        let addModal = document.getElementById('SCULPIN_ADD_MODAL');
+        if (addModal) {
+            this.registerAddModalListeners();
+            return;
+        }
+
+        // load editor box with content
+        let body = document.getElementsByTagName('body')[0];
+        body.innerHTML += '<div id="SCULPIN_ADD_MODAL">' +
+            '<dialog id="add-file-modal">\n' +
+            '  <p>Create a file in your Sculpin <strong>"source/"</strong> folder.</p>\n' +
+            '<form>' +
+            '  <input type="text" name="filename" placeholder="_posts/second-post.md"/>' +
+            '  <div>' +
+            '  </div>' +
+            '</form>' +
+            '    <button commandfor="add-file-modal" command="close" name="create">Add</button>\n' +
+            '</dialog>' +
+            '</div>';
+
+        this.registerAddModalListeners();
+    },
+
     registerListeners: function () {
         console.log('Registering Edit Bar Listeners');
         let editButton = document.getElementById("SCULPIN_EDIT_BUTTON");
@@ -123,6 +150,22 @@ var SculpinEditor = {
 
             SculpinEditor.renderBar();
         });
+    },
+
+    registerAddModalListeners: function () {
+        console.log('Registering Add-Modal Listeners');
+        let createButton = document.querySelector("#SCULPIN_ADD_MODAL button[name=create]");
+
+        // Add Button
+        // @todo should also work with pressing enter key!
+        createButton && createButton.addEventListener('click', function (e) {
+            e.preventDefault();
+            console.log('Clicked Create');
+            SculpinEditor.addFile();
+        });
+
+        // Cancel Button
+        // Other dismissal behaviours (i.e., clicking outside the modal or pressing escape)
     },
 
     saveChanges: function () {

--- a/src/Sculpin/Bundle/EditorBundle/Resources/js/editor.js
+++ b/src/Sculpin/Bundle/EditorBundle/Resources/js/editor.js
@@ -25,6 +25,12 @@ var SculpinEditor = {
             '<path d="M11.0055 2C9.61949 1.99999 8.51721 1.99999 7.62839 2.0738C6.71811 2.14939 5.94253 2.30755 5.23415 2.67552C4.1383 3.24478 3.24477 4.1383 2.67552 5.23416C2.30755 5.94253 2.14939 6.71811 2.0738 7.6284C1.99999 8.51721 1.99999 9.61949 2 11.0055V12.9945C1.99999 14.3805 1.99999 15.4828 2.0738 16.3716C2.14939 17.2819 2.30755 18.0575 2.67552 18.7659C3.24477 19.8617 4.1383 20.7552 5.23415 21.3245C5.94253 21.6925 6.71811 21.8506 7.62839 21.9262C8.5172 22 9.61946 22 11.0054 22H13.0438C14.4068 22 15.4909 22 16.3654 21.9286C17.261 21.8554 18.0247 21.7023 18.7239 21.346C19.8529 20.7708 20.7708 19.8529 21.346 18.7239C21.7023 18.0247 21.8554 17.261 21.9286 16.3654C22 15.4909 22 14.4069 22 13.0439V13C22 12.4477 21.5523 12 21 12C20.4477 12 20 12.4477 20 13C20 14.4166 19.9992 15.419 19.9352 16.2026C19.8721 16.9745 19.7527 17.4457 19.564 17.816C19.1805 18.5686 18.5686 19.1805 17.816 19.564C17.4457 19.7527 16.9745 19.8721 16.2026 19.9352C15.419 19.9992 14.4166 20 13 20H11.05C9.60949 20 8.59025 19.9992 7.79391 19.9331C7.00955 19.8679 6.53142 19.7446 6.1561 19.5497C5.42553 19.1702 4.82985 18.5745 4.45035 17.8439C4.25538 17.4686 4.13208 16.9905 4.06694 16.2061C4.0008 15.4097 4 14.3905 4 12.95V11.05C4 9.60949 4.0008 8.59026 4.06694 7.79392C4.13208 7.00955 4.25538 6.53142 4.45035 6.15611C4.82985 5.42553 5.42553 4.82985 6.1561 4.45035C6.53142 4.25539 7.00955 4.13208 7.79391 4.06694C8.59025 4.00081 9.60949 4 11.05 4H12C12.5523 4 13 3.55229 13 3C13 2.44772 12.5523 2 12 2L11.0055 2Z" fill="currentColor"/>\n' +
             '</svg>' +
             'Edit This Page</a>' +
+            '<a href="#add" id="SCULPIN_ADD_BUTTON">' +
+            '<svg width="25px" height="25px" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">\n' +
+            '<path d="M13 8C13 7.44772 12.5523 7 12 7C11.4477 7 11 7.44772 11 8V11H8C7.44772 11 7 11.4477 7 12C7 12.5523 7.44772 13 8 13H11V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V13H16C16.5523 13 17 12.5523 17 12C17 11.4477 16.5523 11 16 11H13V8Z" fill="currentColor"/>\n' +
+            '<path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12Z" fill="currentColor"/>\n' +
+            '</svg>' +
+            'Add File ...</a>' +
             '<a href="https://sculpin.io/documentation/sources">' +
             '<svg width="25px" height="25px" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">\n' +
             '<path d="M13 17C13 17.5523 12.5523 18 12 18C11.4477 18 11 17.5523 11 17C11 16.4477 11.4477 16 12 16C12.5523 16 13 16.4477 13 17Z" fill="currentColor"/>\n' +
@@ -63,6 +69,12 @@ var SculpinEditor = {
                 (item, i) => '<option value="' + item[0] + '"' + (item[0] === SCULPIN_EDITOR_METADATA.diskPath ? ' SELECTED' : '') + '>' + item[0] + '</option>'
             ).join('') +
             '</select></form>' +
+            '<a href="#add" id="SCULPIN_EDIT_ADD_BUTTON">' +
+            '<svg width="25px" height="25px" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">\n' +
+            '<path d="M13 8C13 7.44772 12.5523 7 12 7C11.4477 7 11 7.44772 11 8V11H8C7.44772 11 7 11.4477 7 12C7 12.5523 7.44772 13 8 13H11V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V13H16C16.5523 13 17 12.5523 17 12C17 11.4477 16.5523 11 16 11H13V8Z" fill="currentColor"/>\n' +
+            '<path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12Z" fill="currentColor"/>\n' +
+            '</svg>' +
+            'Add File ...</a>' +
             '</div>' +
             '<div class="gap"></div>' +
             '<div class="right"><strong>Sculpin</strong> <em>In-Browser Editor</em></div> ' +
@@ -108,6 +120,7 @@ var SculpinEditor = {
     registerListeners: function () {
         console.log('Registering Edit Bar Listeners');
         let editButton = document.getElementById("SCULPIN_EDIT_BUTTON");
+        let addButton = document.getElementById("SCULPIN_ADD_BUTTON");
 
         editButton && editButton.addEventListener('click', function () {
             console.log('Clicked Edit');
@@ -122,6 +135,14 @@ var SculpinEditor = {
                 editor.style.visibility = 'visible';
             }
         });
+
+        addButton && addButton.addEventListener('click', function () {
+            console.log('Clicked Add');
+            SculpinEditor.renderAddModal();
+
+            let addModal = document.getElementById('add-file-modal')
+            addModal.showModal();
+        });
     },
 
     registerEditorListeners: function () {
@@ -129,6 +150,7 @@ var SculpinEditor = {
         let saveButton = document.getElementById("SCULPIN_SAVE_CHANGES");
         let cancelButton = document.getElementById("SCULPIN_CANCEL_CHANGES");
         let fileSelectorForm = document.getElementById('SCULPIN_FILE_SELECTOR');
+        let addButton = document.getElementById("SCULPIN_EDIT_ADD_BUTTON");
 
         saveButton && saveButton.addEventListener('click', function () {
             console.log('Clicked Save');
@@ -140,7 +162,14 @@ var SculpinEditor = {
             SculpinEditor.switchFile(e);
         });
 
-        // @todo Cancel button re-registration is not working
+        addButton && addButton.addEventListener('click', function () {
+            console.log('Clicked Add on the Edit Panel');
+            SculpinEditor.renderAddModal();
+
+            let addModal = document.getElementById('add-file-modal')
+            addModal.showModal();
+        });
+
         cancelButton && cancelButton.addEventListener('click', function () {
             console.log('Clicked Cancel');
 
@@ -374,6 +403,7 @@ var SculpinEditor = {
             })
             .catch(err => console.log('Exception while updating metadata', err));
     },
+
     refreshEditor: () => {
         console.log('Refreshing the Editor Contents & Metadata');
         let editBox = document.getElementById('SCULPIN_EDIT_TEXTAREA');

--- a/src/Sculpin/Bundle/EditorBundle/Resources/js/editor.js
+++ b/src/Sculpin/Bundle/EditorBundle/Resources/js/editor.js
@@ -210,6 +210,50 @@ var SculpinEditor = {
         });
     },
 
+    addFile: function () {
+        var fileName = document.querySelector('#SCULPIN_ADD_MODAL > #add-file-modal > form > input[name=filename]').value;
+
+        // Get the filename
+        console.log('creating file ...', fileName, SCULPIN_EDITOR_METADATA.diskPath, SCULPIN_EDITOR_METADATA.url);
+        // Ensure that the filename doesn't already exist
+        var existingFile = SCULPIN_EDITOR_METADATA.sourceMap[fileName];
+        console.log('existing file check', existingFile);
+
+        if (undefined !== existingFile) {
+            alert("File " + fileName + " already exists in your site's source/ folder!");
+            // @todo come up with a nicer failure-handler than this ...
+            document.location.reload();
+            return;
+        }
+
+        // PUT content to the appropriate spot
+        // this logic is temporary. Would be nice to use local storage to make sure that nothing gets lost if
+        // user navs away.
+        // var requestBody = ;
+        fetch('/_SCULPIN_/create', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                'fileName': fileName
+            })
+        }).then(response => {
+            if (response.ok) {
+                SculpinEditor.watchForNewFile(fileName);
+
+                return;
+            }
+
+            throw Error(response.statusText);
+        }).catch(err => {
+            console.log('Update failed: ' + err.message);
+
+            // @todo come up with a nicer failure-handler than this ...
+            document.location.reload();
+        });
+    },
+
     // Watches the hash every 500ms for 10 attempts, then gives up and reloads
     watchForChanges: function (url, oldHash) {
         let hashwatcherId;
@@ -248,6 +292,49 @@ var SculpinEditor = {
                 // check that hash has changed from oldHash
                 // if so, reload the current page
                 if (data.hash !== oldHash) {
+                    document.location.reload();
+                }
+            })
+        }, 500);
+    },
+
+    // Watches the file every 500ms for 10 attempts, then gives up and reloads
+    watchForNewFile: function (file) {
+        let filewatcherId;
+        let filewatcherCounter = 0;
+
+        filewatcherId = setInterval(() => {
+            if (file.length === 0) {
+                // The edited content does not correspond to a specific URL
+                // Wait a few seconds and then trigger a regular reload
+                clearInterval(filewatcherId);
+                setTimeout(() => document.location.reload(), 3000);
+                return;
+            }
+
+            // @todo maybe update the document.location if the `file` is not blank & doesn't
+            //       match (or isn't contained in) document.location
+            if (filewatcherCounter++ > 10) {
+                console.log('Giving up on checking the hash; reloading current location');
+                clearInterval(filewatcherId);
+                document.location.reload();
+            }
+
+            fetch('/_SCULPIN_/hash?file=' + file + '&exists=true', {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }).then(response => {
+                if (response.ok) {
+                    // fetch that body
+                    return response.json();
+                }
+            }).then(data => {
+                console.log('Expected File to Exist: ' + file, data);
+
+                // check if the response confirms the file exists
+                if (data.exists === true) {
                     document.location.reload();
                 }
             })


### PR DESCRIPTION
In addition to editing files, the in-browser editor will need to have the ability to add new files. This simple "Add File" modal will fill that need for the short term, by allowing users to create text files (markdown, HTML) from the browser.

In the future, it will be expanded to enable adding directories & "uploading" images and other files.