### PR TITLE
Fix for #540, content type pluralization/singularization

### DIFF
--- a/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/Command/ContentCreateCommand.php
@@ -91,7 +91,7 @@ final class ContentCreateCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $pluralType   = $input->getArgument('type');
-        $singularType = new EnglishInflector()->singularize($pluralType)[0];
+        $singularType = array_last(new EnglishInflector()->singularize($pluralType));
         $dryRun       = $input->getOption('dry-run');
         $taxonomies   = $input->getOption('taxonomy');
 

--- a/src/Sculpin/Bundle/ContentTypesBundle/ContentCreateService.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/ContentCreateService.php
@@ -38,7 +38,8 @@ class ContentCreateService
         $manifest[$index] = $this->getViewTemplate($plural, $taxonomies);
 
         foreach ($taxonomies as $taxonomy) {
-            $singularTaxonomy = new EnglishInflector()->singularize($taxonomy)[0];
+            $singularTaxonomy = array_last(new EnglishInflector()->singularize($taxonomy));
+
             // content taxonomy index template
             $index            = $rootDir . '/source/' . $plural . '/' . $taxonomy . '.html';
             $manifest[$index] = $this->getTaxonomyIndexTemplate($plural, $taxonomy, $singularTaxonomy);
@@ -156,7 +157,7 @@ class ContentCreateService
 
             foreach ($taxonomies as $taxonomy) {
                 $capitalTaxonomy  = ucwords((string) $taxonomy);
-                $singularTaxonomy = new EnglishInflector()->singularize($taxonomy)[0];
+                $singularTaxonomy = array_last(new EnglishInflector()->singularize($taxonomy));
                 $output .= <<<EOT
                     <div class="taxonomy">
                         <a href="{{site.url }}/{$plural}/{$taxonomy}">{$capitalTaxonomy}</a>:

--- a/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
+++ b/src/Sculpin/Bundle/ContentTypesBundle/DependencyInjection/SculpinContentTypesExtension.php
@@ -64,7 +64,7 @@ class SculpinContentTypesExtension extends Extension
             }
 
             // What should be used for the singular name?
-            $singularName = $setup['singular_name'] ?? (new EnglishInflector())->singularize($type)[0];
+            $singularName = $setup['singular_name'] ?? array_last(new EnglishInflector()->singularize($type));
 
             // How is the type detected?
             $detectionTypes = is_array($setup['type']) ? $setup['type'] : [$setup['type']];
@@ -256,7 +256,7 @@ class SculpinContentTypesExtension extends Extension
                 $permalinkStrategies->addArgument($taxonomy);
                 $container->setDefinition($permalinkStrategyId, $permalinkStrategies);
 
-                $taxon = (new EnglishInflector())->singularize($taxonomyName)[0];
+                $taxon = array_last(new EnglishInflector()->singularize($taxonomyName));
 
                 $taxonomyDataProviderName = $type.'_'.$taxonomyName;
                 $taxonomyIndexGeneratorName = $type.'_'.$taxon.'_index';

--- a/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
+++ b/src/Sculpin/Bundle/EditorBundle/InBrowserEditorContentFetcher.php
@@ -61,8 +61,14 @@ class InBrowserEditorContentFetcher implements ContentFetcher
                     ['Content-Type' => 'application/json'],
                     json_encode(['error' => 'Not Found-ish'])
                 ),
-            strstr($path, '/_SCULPIN_/metadata') && $requestMethod === 'GET' => $this->getMetadataResponse($url, $source),
-            str_ends_with($path, '_SCULPIN_/update') && $requestMethod === 'PUT' => $this->applyUpdate($request, $output),
+            strstr($path, '/_SCULPIN_/metadata') && $requestMethod === 'GET' => $this->getMetadataResponse(
+                $url,
+                $source
+            ),
+            str_ends_with($path, '_SCULPIN_/update') && $requestMethod === 'PUT' => $this->applyUpdate(
+                $request,
+                $output
+            ),
             default => null,
         };
     }

--- a/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
+++ b/src/Sculpin/Bundle/SculpinBundle/Command/GenerateCommand.php
@@ -152,11 +152,13 @@ class GenerateCommand extends AbstractCommand
             );
 
             if ($watch) {
-                Loop::addPeriodicTimer(1, function () use ($sculpin, $dataSource, $sourceSet, $fetcher, $consoleIo): void {
-                    clearstatcache();
-                    $sourceSet->reset();
-                    $fetcher->buildPathMap($sourceSet);
-                    $this->runSculpin($sculpin, $dataSource, $sourceSet, $consoleIo);
+                Loop::addPeriodicTimer(
+                    1,
+                    function () use ($sculpin, $dataSource, $sourceSet, $fetcher, $consoleIo): void {
+                        clearstatcache();
+                        $sourceSet->reset();
+                        $fetcher->buildPathMap($sourceSet);
+                        $this->runSculpin($sculpin, $dataSource, $sourceSet, $consoleIo);
                     }
                 );
             }

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -36,7 +36,9 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         private ?MapInterface $map = null,
         private ?ProxySourceItemFactoryInterface $factory = null
     ) {
-        $this->dataSingularName = $dataSingularName ?: array_last(new EnglishInflector()->singularize($dataProviderName));
+        $this->dataSingularName = $dataSingularName ?: array_last(
+            new EnglishInflector()->singularize($dataProviderName)
+        );
         $this->collection = $collection ?: new ProxySourceCollection;
         $this->filter = $filter ?: new NullFilter;
         $this->map = $map ?: new NullMap;

--- a/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
+++ b/src/Sculpin/Contrib/ProxySourceCollection/ProxySourceCollectionDataProvider.php
@@ -36,7 +36,7 @@ class ProxySourceCollectionDataProvider implements DataProviderInterface, EventS
         private ?MapInterface $map = null,
         private ?ProxySourceItemFactoryInterface $factory = null
     ) {
-        $this->dataSingularName = $dataSingularName ?: (new EnglishInflector())->singularize($dataProviderName)[0];
+        $this->dataSingularName = $dataSingularName ?: array_last(new EnglishInflector()->singularize($dataProviderName));
         $this->collection = $collection ?: new ProxySourceCollection;
         $this->filter = $filter ?: new NullFilter;
         $this->map = $map ?: new NullMap;

--- a/src/Sculpin/Tests/Functional/GenerateFromTextileTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromTextileTest.php
@@ -43,14 +43,18 @@ class GenerateFromTextileTest extends FunctionalTestCase
     /** @test */
     public function shouldGenerateHtmlUsingALayout()
     {
-        $this->addProjectFile('/source/_layouts/my_layout.html.twig', <<<EOT
+        $this->addProjectFile(
+            '/source/_layouts/my_layout.html.twig',
+            <<<EOT
         <body>
             <div class="page-content">{% block content %}{% endblock content %}</div>
         </body>
         EOT
         );
 
-        $this->addProjectFile('/source/my_page_with_layout.textile', <<<EOT
+        $this->addProjectFile(
+            '/source/my_page_with_layout.textile',
+            <<<EOT
         ---
         layout: my_layout.html.twig
         ---
@@ -74,11 +78,11 @@ class GenerateFromTextileTest extends FunctionalTestCase
     /** @test */
     public function shouldRefreshGeneratedHtmlAfterFilesystemChange(): void
     {
-        $layoutFile    = '/source/_layouts/my_layout.html.twig';
-        $pageFile      = '/source/my_page_with_layout.textile';
+        $layoutFile = '/source/_layouts/my_layout.html.twig';
+        $pageFile = '/source/my_page_with_layout.textile';
         $pageGenerated = '/my_page_with_layout/index.html';
 
-        $expectedHeader  = 'ORIGINAL_HEADER';
+        $expectedHeader = 'ORIGINAL_HEADER';
         $expectedContent = 'Hello World';
 
         $layoutContent = <<<EOT
@@ -122,14 +126,14 @@ class GenerateFromTextileTest extends FunctionalTestCase
         $this->assertStringContainsString($expectedContent, $pageContentEl->text());
 
         // update the content
-        $originalHeader  = $expectedHeader;
+        $originalHeader = $expectedHeader;
         $originalContent = $expectedContent;
 
-        $expectedHeader  = 'FRESH HEADER';
+        $expectedHeader = 'FRESH HEADER';
         $expectedContent = 'HELLO WORLD!';
 
         $layoutContent = str_replace($originalHeader, $expectedHeader, $layoutContent);
-        $pageContent   = str_replace($originalContent, $expectedContent, $pageContent);
+        $pageContent = str_replace($originalContent, $expectedContent, $pageContent);
 
         // test that page content refreshes properly
         $this->addProjectFile($pageFile, $pageContent);
@@ -197,7 +201,10 @@ class GenerateFromTextileTest extends FunctionalTestCase
 
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.textile', '/source/_posts/hello_world');
         $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.textile', '/source/_posts/hello_world2');
-        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.textile', '/source/_posts/hello_world3.textile');
+        $this->copyFixtureToProject(
+            __DIR__ . '/Fixture/source/hello_world.textile',
+            '/source/_posts/hello_world3.textile'
+        );
 
         $this->executeSculpin(['generate']);
 
@@ -207,7 +214,10 @@ class GenerateFromTextileTest extends FunctionalTestCase
             $actualOutput
         );
         $this->assertStringContainsString('Skipping empty or unknown file: _posts/hello_world2', $actualOutput);
-        $this->assertStringNotContainsString('Skipping empty or unknown file: _posts/hello_world3.textile', $actualOutput);
+        $this->assertStringNotContainsString(
+            'Skipping empty or unknown file: _posts/hello_world3.textile',
+            $actualOutput
+        );
 
         $this->assertProjectLacksFile('/output_test/_posts/hello_world');
         $this->assertProjectLacksFile('/output_test/_posts/hello_world2');
@@ -234,7 +244,10 @@ class GenerateFromTextileTest extends FunctionalTestCase
 
         $this->addProjectFile('/source/_posts/.DS_Store');
         $this->addProjectFile('/source/_posts/.hello_world2.swp');
-        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.textile', '/source/_posts/hello_world3.textile');
+        $this->copyFixtureToProject(
+            __DIR__ . '/Fixture/source/hello_world.textile',
+            '/source/_posts/hello_world3.textile'
+        );
 
         $this->executeSculpin(['generate']);
 


### PR DESCRIPTION
Heard joke once. `EnglishInflector` returned array of results. Sculpin picked first one.

Content Type asked for singular of 'pages'. `EnglishInflector` said it heard of new entertainer in town, the great clown Pagliacci.

Content Type burst into tears, says _"but `EnglishInflector`, I am ***Page***-liacci!"_

Good joke. Everybody laugh. Roll on snare drums. Curtains.

---

In the case of `pages` being singularized, EnglishInflector returns an array of `['pag', 'page']`, with sculpin always picking `pag`. This PR attempts to fix resulting problems by picking the last array element ... this may not be 100% solved, but it addresses the specific case.