### PR TITLE
Fix for Bug 541: twig extensions in filesource

### DIFF
--- a/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
+++ b/src/Sculpin/Bundle/SculpinBundle/Resources/config/services.xml
@@ -76,6 +76,7 @@
             <argument type="service" id="sculpin.mime.detector_ext2mime"/>
             <argument type="collection">
                 <argument key="textile">text/plain</argument>
+                <argument key="twig">text/twig</argument>
             </argument>
 
         </service>

--- a/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
+++ b/src/Sculpin/Core/Tests/Permalink/SourcePermalinkFactoryTest.php
@@ -50,6 +50,15 @@ class SourcePermalinkFactoryTest extends TestCase
                 ),
             ],
 
+            'pretty permalink page for .html.twig' => [
+                'pretty',
+                $this->makeTestSource('about.html.twig'),
+                new Permalink(
+                    'about/index.html',
+                    '/about'
+                ),
+            ],
+
             'basename with html ending' => [
                 ':basename.html',
                 static::makeTestSource('about.md'),

--- a/src/Sculpin/Tests/Functional/Fixture/source/hello_world.html.twig
+++ b/src/Sculpin/Tests/Functional/Fixture/source/hello_world.html.twig
@@ -1,0 +1,4 @@
+---
+title: Hello World
+---
+<h1>Hello World</h1>

--- a/src/Sculpin/Tests/Functional/GenerateFromHtmlDotTwigTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromHtmlDotTwigTest.php
@@ -178,8 +178,8 @@ final class GenerateFromHtmlDotTwigTest extends FunctionalTestCase
         $this->assertProjectHasGeneratedFile('/hello_world');
         $this->assertProjectHasGeneratedFile('/hello_world2');
 
-        $this->assertGeneratedFileHasContent('/hello_world', 'Title: Hello World');
-        $this->assertGeneratedFileHasContent('/hello_world2', 'Title: Hello World');
+        $this->assertGeneratedFileHasContent('/hello_world', 'title: Hello World');
+        $this->assertGeneratedFileHasContent('/hello_world2', 'title: Hello World');
     }
 
     /** @test */
@@ -215,7 +215,7 @@ final class GenerateFromHtmlDotTwigTest extends FunctionalTestCase
 
         $this->assertGeneratedFileHasContent(
             '/blog/hello_world3/index.html',
-            '<h1 id="hello-world">Hello World</h1>'
+            '<h1>Hello World</h1>'
         );
     }
 
@@ -249,7 +249,7 @@ final class GenerateFromHtmlDotTwigTest extends FunctionalTestCase
 
         $this->assertGeneratedFileHasContent(
             '/blog/hello_world3/index.html',
-            '<h1 id="hello-world">Hello World</h1>'
+            '<h1>Hello World</h1>'
         );
     }
 }

--- a/src/Sculpin/Tests/Functional/GenerateFromHtmlDotTwigTest.php
+++ b/src/Sculpin/Tests/Functional/GenerateFromHtmlDotTwigTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Functional;
+
+use Sculpin\Tests\Functional\FunctionalTestCase;
+
+final class GenerateFromHtmlDotTwigTest extends FunctionalTestCase
+{
+    /** @test */
+    public function shouldGenerateAnHtmlFileFromHtmlDotTwig(): void
+    {
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/hello_world.html.twig');
+
+        $this->executeSculpin(['generate']);
+
+        $this->assertProjectHasGeneratedFile('/hello_world/index.html');
+    }
+
+    /** @test */
+    public function shouldGenerateHtmlContentFromMarkdown(): void
+    {
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/hello_world.html.twig');
+
+        $this->executeSculpin(['generate']);
+
+        $crawler = $this->crawlGeneratedProjectFile('/hello_world/index.html');
+
+        $this->assertStringContainsString('Hello World', $crawler->filter('h1')->text());
+    }
+
+    /** @test */
+    public function shouldGenerateIntoNestedDirectories(): void
+    {
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/hello/world.html.twig');
+
+        $this->executeSculpin(['generate']);
+
+        $this->assertProjectHasGeneratedFile('/hello/world/index.html');
+    }
+
+    /** @test */
+    public function shouldGenerateHtmlUsingALayout(): void
+    {
+        $this->addProjectFile('/source/_layouts/my_layout.html.twig', <<<EOT
+        <body>
+            <div class="page-content">{% block content %}{% endblock content %}</div>
+        </body>
+        EOT
+        );
+
+        $this->addProjectFile('/source/my_page_with_layout.html.twig', <<<EOT
+        ---
+        layout: my_layout.html.twig
+        ---
+        Hello World
+        EOT
+        );
+
+        $this->executeSculpin(['generate']);
+
+        $crawler = $this->crawlGeneratedProjectFile('/my_page_with_layout/index.html');
+
+        $pageContentEl = $crawler->filter('.page-content');
+        $this->assertEquals(
+            1,
+            $pageContentEl->count(),
+            "Expected generated file to have a single .page-content element."
+        );
+        $this->assertStringContainsString('Hello World', $pageContentEl->text());
+    }
+
+    /** @test */
+    public function shouldRefreshGeneratedHtmlAfterFilesystemChange(): void
+    {
+        $layoutFile    = '/source/_layouts/my_layout.html.twig';
+        $pageFile      = '/source/my_page_with_layout.html.twig';
+        $pageGenerated = '/my_page_with_layout/index.html';
+
+        $expectedHeader  = 'ORIGINAL_HEADER';
+        $expectedContent = 'Hello World';
+
+        $layoutContent = <<<EOT
+        <body>
+            <h1 class="header">{$expectedHeader}</h1>
+            <div class="page-content">{% block content %}{% endblock content %}</div>
+        </body>
+        EOT;
+
+        $pageContent = <<<EOT
+        ---
+        layout: my_layout.html.twig
+        ---
+        {$expectedContent}
+        EOT;
+
+        $this->addProjectFile($layoutFile, $layoutContent);
+        $this->addProjectFile($pageFile, $pageContent);
+
+        // start our async sculpin watcher/server
+        $process = $this->executeSculpinAsync(['generate', '--watch']);
+
+        sleep(1); // wait until our file exists
+        $crawler = $this->crawlGeneratedProjectFile($pageGenerated);
+
+        $pageContentEl = $crawler->filter('.page-content');
+        $this->assertEquals(
+            1,
+            $pageContentEl->count(),
+            "Expected generated file to have a single .page-content element."
+        );
+
+        $pageHeaderEl = $crawler->filter('.header');
+        $this->assertEquals(
+            1,
+            $pageHeaderEl->count(),
+            "Expected generated file to have a single .header element."
+        );
+
+        $this->assertStringContainsString($expectedHeader, $pageHeaderEl->text());
+        $this->assertStringContainsString($expectedContent, $pageContentEl->text());
+
+        // update the content
+        $originalHeader  = $expectedHeader;
+        $originalContent = $expectedContent;
+
+        $expectedHeader  = 'FRESH HEADER';
+        $expectedContent = 'HELLO WORLD!';
+
+        $layoutContent = str_replace($originalHeader, $expectedHeader, $layoutContent);
+        $pageContent   = str_replace($originalContent, $expectedContent, $pageContent);
+
+        // test that page content refreshes properly
+        $this->addProjectFile($pageFile, $pageContent);
+
+        sleep(2);
+        $crawler = $this->crawlGeneratedProjectFile($pageGenerated);
+
+        $pageContentEl = $crawler->filter('.page-content');
+        $this->assertEquals(
+            1,
+            $pageContentEl->count(),
+            "Expected generated file to have a single .page-content element."
+        );
+
+        $this->assertStringContainsString($expectedContent, $pageContentEl->text());
+
+        // test that layouts/views refresh properly
+        $this->addProjectFile($layoutFile, $layoutContent);
+
+        sleep(2);
+        $crawler = $this->crawlGeneratedProjectFile($pageGenerated);
+
+        $pageHeaderEl = $crawler->filter('.header');
+        $this->assertEquals(
+            1,
+            $pageHeaderEl->count(),
+            "Expected generated file to have a single .header element."
+        );
+
+        $this->assertStringContainsString(
+            $expectedHeader,
+            $pageHeaderEl->text()
+        );
+
+        $process->stop(0);
+    }
+
+    /** @test */
+    public function shouldPassThruFilesWithNoExtension(): void
+    {
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/hello_world');
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/hello_world2');
+
+        $this->executeSculpin(['generate']);
+
+        $this->assertProjectHasGeneratedFile('/hello_world');
+        $this->assertProjectHasGeneratedFile('/hello_world2');
+
+        $this->assertGeneratedFileHasContent('/hello_world', 'Title: Hello World');
+        $this->assertGeneratedFileHasContent('/hello_world2', 'Title: Hello World');
+    }
+
+    /** @test */
+    public function shouldSkipContentTypeFilesWithNoExtension(): void
+    {
+        $this->addProjectDirectory('/source/_posts');
+        $this->writeToProjectFile(
+            '/app/config/sculpin_kernel.yml',
+            <<<EOT
+            sculpin_content_types:
+              posts:
+                permalink: blog/:basename
+            EOT
+        );
+
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/_posts/hello_world');
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/_posts/hello_world2');
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/_posts/hello_world3.html.twig');
+
+        $this->executeSculpin(['generate']);
+
+        $actualOutput = $this->executeOutput;
+        $this->assertStringContainsString(
+            'Skipping empty or unknown file: _posts/hello_world' . PHP_EOL,
+            $actualOutput
+        );
+        $this->assertStringContainsString('Skipping empty or unknown file: _posts/hello_world2', $actualOutput);
+        $this->assertStringNotContainsString('Skipping empty or unknown file: _posts/hello_world3.md', $actualOutput);
+
+        $this->assertProjectLacksFile('/output_test/_posts/hello_world');
+        $this->assertProjectLacksFile('/output_test/_posts/hello_world2');
+        $this->assertProjectHasGeneratedFile('/blog/hello_world3/index.html');
+
+        $this->assertGeneratedFileHasContent(
+            '/blog/hello_world3/index.html',
+            '<h1 id="hello-world">Hello World</h1>'
+        );
+    }
+
+    /** @test */
+    public function shouldSkipHiddenFilesSilently(): void
+    {
+        $this->addProjectDirectory('/source/_posts');
+        $this->writeToProjectFile(
+            '/app/config/sculpin_kernel.yml',
+            <<<EOT
+            sculpin_content_types:
+              posts:
+                permalink: blog/:basename
+            EOT
+        );
+
+        $this->addProjectFile('/source/_posts/.DS_Store');
+        $this->addProjectFile('/source/_posts/.hello_world2.swp');
+        $this->copyFixtureToProject(__DIR__ . '/Fixture/source/hello_world.html.twig', '/source/_posts/hello_world3.html.twig');
+
+        $this->executeSculpin(['generate']);
+
+        $actualOutput = $this->executeOutput;
+        $this->assertStringNotContainsString('.DS_Store', $actualOutput);
+        $this->assertStringNotContainsString('.hello_world2.swp', $actualOutput);
+        $this->assertStringNotContainsString('Skipping empty or unknown file:', $actualOutput);
+
+        $this->assertProjectLacksFile('/output_test/_posts/.DS_Store');
+        $this->assertProjectLacksFile('/output_test/_posts/.hello_world2.swp');
+        $this->assertProjectHasGeneratedFile('/blog/hello_world3/index.html');
+
+        $this->assertGeneratedFileHasContent(
+            '/blog/hello_world3/index.html',
+            '<h1 id="hello-world">Hello World</h1>'
+        );
+    }
+}


### PR DESCRIPTION
Twig files were accidentally being excluded from the mime type detection logic. Added a services.xml entry to correct the issue, and created some tests.

This was a result of the move from Dfly Canal Analyzer to League MimeDetector; apparently when I implemented that change, I didn't understand the nuances of the Analyzer-Detector configurations.

There may still be related issues, but at least the big one has been solved.

Fixes Bug #541 